### PR TITLE
gitignore: typical IDE dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,14 @@
 # Temporaries from editors 
 *~
 
-# CMake
+# IDEs
+/*.cbp
+/*.layout
+.idea/
+.kdev?/
+*.kdev?
+/nbproject/
+.vimrc
+cmake-build-*/
+spack-build*
 build/


### PR DESCRIPTION
exclude temporary build directories, etc.