### PR TITLE
Fix Warnings: ;s and Init

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -16,24 +16,30 @@ public:
     void MakeNewLevelFromScratch (
         int lev, amrex::Real time, const amrex::BoxArray& ba,
         const amrex::DistributionMapping& dm) override;
+
     void ErrorEst (
-                   int /*lev*/, amrex::TagBoxArray& /*tags*/, amrex::Real /*time*/, int /*ngrow*/) override {};
+                   int /*lev*/, amrex::TagBoxArray& /*tags*/, amrex::Real /*time*/, int /*ngrow*/) override {}
+
     void MakeNewLevelFromCoarse (
                                  int /*lev*/, amrex::Real /*time*/, const amrex::BoxArray& /*ba*/,
-                                 const amrex::DistributionMapping& /*dm*/) override {};
+                                 const amrex::DistributionMapping& /*dm*/) override {}
+
     void RemakeLevel (
                       int /*lev*/, amrex::Real /*time*/, const amrex::BoxArray& /*ba*/,
-                      const amrex::DistributionMapping& /*dm*/) override {};
-    void ClearLevel (int /*lev*/) override {};
+                      const amrex::DistributionMapping& /*dm*/) override {}
+
+    void ClearLevel (int /*lev*/) override {}
     
     void InitData ();
+
     void Evolve ();
+
     void WriteDiagnostics (int step);
 
     Fields m_fields;
     MultiBeamParticleContainer m_beam_containers;
     MultiPlasmaParticleContainer m_plasma_containers;
-    int m_max_step;
+    int m_max_step = 0;
 };
 
 #endif

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -11,10 +11,13 @@ struct FieldComps{
 class Fields
 {
 public:
-    Fields (int max_level) : m_F(max_level+1) {};
+    Fields (int max_level) : m_F(max_level+1) {}
+
     void AllocData (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm);
-    amrex::Vector<amrex::MultiFab>& getF () { return m_F; };
-    amrex::MultiFab& getF (int lev) { return m_F[lev]; };
+
+    amrex::Vector<amrex::MultiFab>& getF () { return m_F; }
+
+    amrex::MultiFab& getF (int lev) { return m_F[lev]; }
 private:
     amrex::Vector<amrex::MultiFab> m_F;
     amrex::IntVect m_nguards {2, 2, 2};

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -20,8 +20,10 @@ class BeamParticleContainer
 public:    
     BeamParticleContainer (amrex::AmrCore* amr_core) :
         amrex::ParticleContainer<0,0,BeamIdx::nattribs>(amr_core->GetParGDB())
-    {};
+    {}
+
     void InitData (const amrex::Geometry& geom);
+
     void InitParticles(
         const amrex::IntVect& a_num_particles_per_cell,
         const amrex::Real     a_thermal_momentum_std,


### PR DESCRIPTION
Remove unnecessary `;`s and init a member variable before passing it (write-only but still) to an external function.