### PR TITLE
Single Arg Constructors: Explicit

### DIFF
--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -11,7 +11,7 @@ struct FieldComps{
 class Fields
 {
 public:
-    Fields (int max_level) : m_F(max_level+1) {}
+    explicit Fields (int max_level) : m_F(max_level+1) {}
 
     void AllocData (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm);
 

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -18,7 +18,7 @@ class BeamParticleContainer
     : public amrex::ParticleContainer<0, 0, BeamIdx::nattribs>
 {
 public:    
-    BeamParticleContainer (amrex::AmrCore* amr_core) :
+    explicit BeamParticleContainer (amrex::AmrCore* amr_core) :
         amrex::ParticleContainer<0,0,BeamIdx::nattribs>(amr_core->GetParGDB())
     {}
 

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -118,7 +118,7 @@ InitParticles(const IntVect& a_num_particles_per_cell,
 
         int procID = ParallelDescriptor::MyProc();
         int pid = ParticleType::NextID();
-        ParticleType::NextID(pid + num_to_add);;
+        ParticleType::NextID(pid + num_to_add);
         
         amrex::ParallelFor(tile_box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -134,7 +134,7 @@ InitParticles(const IntVect& a_num_particles_per_cell,
             unsigned int uiz = amrex::min(nz-1,amrex::max(0,iz));
             unsigned int cellid = (uix * ny + uiy) * nz + uiz;
 
-            int pidx = poffset[cellid] - poffset[0];
+            int pidx = int(poffset[cellid] - poffset[0]);
 
             for (int i_part=0; i_part<num_ppc;i_part++)
             {

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -24,7 +24,7 @@ class PlasmaParticleContainer
     : public amrex::ParticleContainer<0, 0, PlasmaIdx::nattribs>
 {
 public:
-    PlasmaParticleContainer (amrex::AmrCore* amr_core);
+    explicit PlasmaParticleContainer (amrex::AmrCore* amr_core);
 
     void InitData (const amrex::Geometry& geom);
 

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -118,7 +118,7 @@ InitParticles(const IntVect& a_num_particles_per_cell,
 
         int procID = ParallelDescriptor::MyProc();
         int pid = ParticleType::NextID();
-        ParticleType::NextID(pid + num_to_add);;
+        ParticleType::NextID(pid + num_to_add);
         
         amrex::ParallelFor(tile_box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -134,7 +134,7 @@ InitParticles(const IntVect& a_num_particles_per_cell,
             unsigned int uiz = amrex::min(nz-1,amrex::max(0,iz));
             unsigned int cellid = (uix * ny + uiy) * nz + uiz;
 
-            int pidx = poffset[cellid] - poffset[0];
+            int pidx = int(poffset[cellid] - poffset[0]);
 
             for (int i_part=0; i_part<num_ppc;i_part++)
             {


### PR DESCRIPTION
Caught with CLion's clang-tidy integration:
  https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html