### PR TITLE
Default Build Type: RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,8 @@ set_default_install_dirs()
 #
 option(HiPACE_amrex_internal "Download & build AMReX" ON)
 
-# change the default build type to Release instead of Debug
-set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release"
-        CACHE STRING
-        "Choose the build type, e.g. Release, Debug, or RelWithDebInfo." FORCE)
-endif()
+# change the default build type to RelWithDebInfo (or Release) instead of Debug
+set_default_build_type("RelWithDebInfo")
 
 
 # Dependencies ################################################################

--- a/cmake/HiPACEFunctions.cmake
+++ b/cmake/HiPACEFunctions.cmake
@@ -36,6 +36,19 @@ macro(set_default_install_dirs)
     endif()
 endmacro()
 
+
+# change the default CMAKE_BUILD_TYPE
+# the default in CMake is Debug for historic reasons
+#
+macro(set_default_build_type default_build_type)
+    set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
+    if(NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE ${default_build_type}
+                CACHE STRING
+                "Choose the build type, e.g. Release, Debug, or RelWithDebInfo." FORCE)
+    endif()
+endmacro()
+
 # Set CXX
 # Note: this is a bit legacy and one should use CMake TOOLCHAINS instead.
 #


### PR DESCRIPTION
Build optimized code with debug info by default. Since this should have no performance penalty, it should be a nice default. Only side effect: slight larger binaries (but more readable crashes).

https://stackoverflow.com/questions/48754619/what-are-cmake-build-type-debug-release-relwithdebinfo-and-minsizerel/48755129