### PR TITLE
CMake: CCache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,20 @@ if(CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif()
 
 
+# CCache Support ##############################################################
+#
+# this is an optional tool that stores compiled object files; allows fast
+# re-builds even with "make clean" in between. Mainly used to store AMReX
+# objects
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    if(ENABLE_CUDA)
+        set(CMAKE_CUDA_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    endif()
+endif()
+
+
 # Output Directories ##########################################################
 #
 # temporary build directories

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Highly efficient Plasma Accelerator Emulation, quasistatic particle-in-cell code
 macOS/Linux:
 ```bash
 brew update
+brew install ccache
 brew install cmake
 brew install libomp
 brew install open-mpi
@@ -21,6 +22,7 @@ or macOS/Linux:
 ```bash
 spack env create hipace-dev
 spack env activate hipace-dev
+spack add ccache
 spack add cmake
 spack add mpi
 spack install


### PR DESCRIPTION
Speed up repeated builds by using CCache. This mainly caches AMReX objects. Developers have to do nothing but install `ccache`. It will not be used if not found.

https://ccache.dev

This usually caches object files in `~/.ccache`. As this can get large, do not hesitate to prune the cache from time to time: `ccache --clear` . CCache will also clean this automatically, see the default maximum size via `ccache -s` (e.g. 5 Gbyte on my system). A HiPACE/AMReX build caches about 0.5 Gbyte.

- [x] Linux GCC test
- [x] macOS Clang (XCode) test