### PR TITLE
Fix indexing error in particle initialization

### DIFF
--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -68,9 +68,9 @@ InitParticles (const IntVect&  a_num_particles_per_cell,
             }
         });
 
-        Gpu::inclusive_scan(counts.begin(), counts.end(), offsets.begin());
+        Gpu::exclusive_scan(counts.begin(), counts.end(), offsets.begin());
 
-        int num_to_add = offsets[tile_box.numPts()-1];
+        int num_to_add = offsets[tile_box.numPts()-1] + counts[tile_box.numPts()-1];
 
         auto& particles = GetParticles(lev);
         auto& particle_tile = particles[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
@@ -138,4 +138,6 @@ InitParticles (const IntVect&  a_num_particles_per_cell,
             }
         });
     }
+
+    AMREX_ASSERT(OK());
 }

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -68,9 +68,9 @@ InitParticles (const IntVect&  a_num_particles_per_cell,
             }
         });
 
-        Gpu::inclusive_scan(counts.begin(), counts.end(), offsets.begin());
+        Gpu::exclusive_scan(counts.begin(), counts.end(), offsets.begin());
 
-        int num_to_add = offsets[tile_box.numPts()-1];
+        int num_to_add = offsets[tile_box.numPts()-1] + counts[tile_box.numPts()-1];
 
         auto& particles = GetParticles(lev);
         auto& particle_tile = particles[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
@@ -163,4 +163,6 @@ InitParticles (const IntVect&  a_num_particles_per_cell,
             }
         });
     }
+
+    AMREX_ASSERT(OK());
 }


### PR DESCRIPTION
This fixes the OK() assertion error. I've also added a few more asserts to catch issues like this earlier.