### PR TITLE
FFTW: Only Needed in non-CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,11 @@ include(${HiPACE_SOURCE_DIR}/cmake/dependencies/AMReX.cmake)
 #   suppress warnings in AMReX headers (use -isystem instead of -I)
 make_third_party_includes_system(AMReX::amrex AMReX)
 
-# FFTW (non-GPU) and cuFFT (GPU) - or both wrapped via AMReX?
-# external library: FFTW (optional)
-find_package(PkgConfig REQUIRED QUIET)
-pkg_check_modules(fftw3 REQUIRED IMPORTED_TARGET fftw3)
+# FFTW (non-GPU) and cuFFT (GPU)
+if(NOT ENABLE_CUDA)
+    find_package(PkgConfig REQUIRED QUIET)
+    pkg_check_modules(fftw3 REQUIRED IMPORTED_TARGET fftw3)
+endif()
 
 # openPMD-api
 
@@ -93,7 +94,9 @@ set_target_properties(HiPACE PROPERTIES
 
 # link dependencies
 target_link_libraries(HiPACE PUBLIC HiPACE::thirdparty::AMReX)
-target_link_libraries(HiPACE PUBLIC PkgConfig::fftw3)
+if(NOT ENABLE_CUDA)
+    target_link_libraries(HiPACE PUBLIC PkgConfig::fftw3)
+endif()
 
 # AMReX helper function: propagate CUDA specific target & source properties
 if(ENABLE_CUDA)

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ Please see installation instructions below in the *Developers* section.
 
 - a mature [C++14](https://en.wikipedia.org/wiki/C%2B%2B14) compiler: e.g. GCC 5, Clang 3.6 or newer
 - [CMake 3.14.0+](https://cmake.org/)
-- [FFTW3](http://www.fftw.org/) (only used serially)
+- [AMReX *development*](https://amrex-codes.github.io): we automatically download and compile a copy of AMReX
+- [FFTW3](http://www.fftw.org/) (only used serially; *only required* if not using CUDA)
 
 Optional dependencies include:
 - [MPI 3.0+](https://www.mpi-forum.org/docs/): for multi-node and/or multi-GPU execution
-- [CUDA 9.0+](https://developer.nvidia.com/cuda-downloads): for Nvidia GPU support (see [matching host-compilers](https://gist.github.com/ax3l/9489132))
+- [CUDA Toolkit 9.0+](https://developer.nvidia.com/cuda-downloads): for Nvidia GPU support (see [matching host-compilers](https://gist.github.com/ax3l/9489132))
 - [OpenMP 3.1+](https://www.openmp.org): for threaded CPU execution (currently not fully accelerated)
 - [CCache](https://ccache.dev): to speed up rebuilds (needs 3.7.9+ for CUDA)
 
@@ -54,6 +55,8 @@ spack add ccache
 spack add cmake
 spack add fftw
 spack add mpi
+# optional:
+# spack add cuda
 spack install
 ```
 (in new terminals, re-activate the environment with `spack env activate hipace-dev` again)


### PR DESCRIPTION
Make FFTW required if we are *not* compiling for the CUDA platform.