### PR TITLE
Missing CMake 3.17 CUDA Feature Guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 if(ENABLE_CUDA)
     setup_target_for_cuda_compilation(HiPACE)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-        target_compile_features(HiPACE PUBLIC cxx_std_14)
+        target_compile_features(HiPACE PUBLIC cuda_std_14)
         set_target_properties(HiPACE PROPERTIES
             CUDA_EXTENSIONS OFF
             CUDA_STANDARD_REQUIRED ON


### PR DESCRIPTION
Summit (CUDA 10.1.243):
```
CMake Error at CMakeLists.txt:104 (target_compile_features):
  target_compile_features specified unknown feature "cuda_std_14" for target
  "HiPACE".
```