### PR TITLE
Cleaning in the FFT solver

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -181,23 +181,25 @@ Hipace::Evolve ()
                 j_slice.FillBoundary(Geom(lev).periodicity());
                 amrex::ParallelContext::pop();
 
-                /* ---------- Solve Poisson equation with RHS ---------- */
+                /* ---------- Solve Poisson equation ---------- */
                 // Left-Hand Side for Poisson equation is By in the slice MF
                 amrex::MultiFab lhs(m_fields.getSlices(lev, 1), amrex::make_alias,
                                     FieldComps::By, 1);
-                // Left-Hand Side for Poisson equation: allocate a tmp MultiFab
-                amrex::MultiFab rhs = amrex::MultiFab(m_fields.getSlices(lev, 1).boxArray(),
-                                                      m_fields.getSlices(lev, 1).distributionMap,
-                                                      1, 0);
-                // Left-Hand Side for Poisson equation: compute d_x(jz) from the slice MF,
-                // and store in tmp MultiFab rhs
-                m_fields.TransverseDerivative(m_fields.getSlices(lev, 1), rhs, Direction::x,
-                                              geom[0].CellSize(Direction::x), FieldComps::jz);
-                rhs.mult(PhysConst::mu0);
-                // Solve Poisson equation, the result (lhs) is in the slice MultiFab m_slices
-                m_poisson_solver.SolvePoissonEquation(rhs, lhs);
+                // Right-Hand Side for Poisson equation: compute mu_0*d_x(jz) from the slice MF,
+                // and store in the staging area of m_poisson_solver
+                m_fields.TransverseDerivative(
+                    m_fields.getSlices(lev, 1),
+                    m_poisson_solver.StagingArea(),
+                    Direction::x,
+                    geom[0].CellSize(Direction::x),
+                    FieldComps::jz);
+                m_poisson_solver.StagingArea().mult(PhysConst::mu0);
+                // Solve Poisson equation.
+                // The RHS is in the staging area of m_poisson_solver.
+                // The LHS will be returned as lhs.
+                m_poisson_solver.SolvePoissonEquation(lhs);
 
-                /* xxxxxxxxxx Transverse FillBoundary By xxxxxxxxxx */
+                /* ---------- Transverse FillBoundary By ---------- */
                 amrex::ParallelContext::push(m_comm_xy);
                 lhs.FillBoundary(Geom(lev).periodicity());
                 amrex::ParallelContext::pop();
@@ -210,6 +212,7 @@ Hipace::Evolve ()
             }
         }
         /* xxxxxxxxxx Gather and push beam particles xxxxxxxxxx */
+
         // Slices have already been shifted, so send
         // slices {2,3} from upstream to {2,3} in downstream.
         Notify();

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -8,6 +8,15 @@
 // Declare type for fields in spectral fields
 using SpectralField = amrex::FabArray< amrex::BaseFab <amrex::GpuComplex<amrex::Real>> >;
 
+/**
+ * \brief This class handles functions and data to perform transverse Fourier-based Poisson solves.
+ *
+ * For a given source S, it solves equation \Delta F = S and returns F.
+ * Once an instance is created, a typical use consists in:
+ * 1. Compute S in FFTPoissonSolver::m_stagingArea
+ * 2. Call FFTPoissonSolver::SolvePoissonEquation(mf), which will solve Poisson equation with RHS
+ *    in the staging area and return the LHS in mf.
+ */
 class FFTPoissonSolver
 {
 public:
@@ -17,12 +26,13 @@ public:
 
     FFTPoissonSolver () = default;
 
-    void SolvePoissonEquation ( amrex::MultiFab const& rhs_mf,
-                                amrex::MultiFab& lhs_mf );
+    void SolvePoissonEquation (amrex::MultiFab& lhs_mf);
+
+    amrex::MultiFab& StagingArea() {return m_stagingArea;};
 private:
     amrex::BoxArray m_spectralspace_ba;
     SpectralField m_tmpSpectralField; // contains (complex) field in Fourier space
-    amrex::MultiFab m_tmpRealField;   // contains (real) field in real space
+    amrex::MultiFab m_stagingArea;    // contains (real) field in real space
     amrex::MultiFab m_inv_k2;         // 1/(kx^2 + ky^2)
 
     AnyFFT::FFTplans m_forward_plan, m_backward_plan;


### PR DESCRIPTION
This PR contains 2 changes:

# Initialize Poisson solver in 1 slice

As the Poisson solver is supposed to operate on a single 2D slice at a time, m_poisson_solver is now initialized from the slice BoxArray and DistributionMapping, while it was initialized on the 3D domain before. In practice, for a single-box 32x32x32 domain, it means the FFT plans created are 32x32x1 instead of 32x32x32 previously.

# Introduce a staging area for the Poisson solver

A call to the FFT solver to solve [Delta LHS = RHS] looked like:
 - allocate RHS and fill it with what is required
 - call `m_poisson_solver.SolvePoissonEquation(RHS, LHS);`. This will copy RHS to a tmp array `m_tmpRealField`, solve the poisson equation, and copy the result to LHS.

  The copy of RHS to tmp may cost performance, but it also makes it necessary to provide (probably allocate) a new multifab, which complicates the code a bit. Instead, this PR proposes to rename `m_tmpRealField` to `m_stagingArea`, and expose it so that a call to the FFT solver now reads
 - Compute RHS directly into `m_poisson_solver.m_stagingArea`
 - call `m_poisson_solver.SolvePoissonEquation(LHS);` (no copy needed).
