### PR TITLE
use amrex::Math::floor instead of floor for DPC++

### DIFF
--- a/src/particles/ShapeFactors.H
+++ b/src/particles/ShapeFactors.H
@@ -7,6 +7,8 @@
 #ifndef SHAPEFACTORS_H_
 #define SHAPEFACTORS_H_
 
+#include <AMReX_Math.H>
+
 /**
  *  Compute shape factor and return index of leftmost cell where
  *  particle writes.
@@ -30,7 +32,7 @@ int compute_shape_factor <0> (amrex::Real* const sx, amrex::Real xmid){
 
     using namespace amrex;
 
-    const auto j = static_cast<int>(floor(xmid+0.5_rt));
+    const auto j = static_cast<int>(amrex::Math::floor(xmid+0.5_rt));
     sx[0] = 1.0_rt;
     return j;
 }
@@ -46,7 +48,7 @@ int compute_shape_factor <1> (amrex::Real* const sx, amrex::Real xmid){
 
     using namespace amrex;
 
-    const auto j = static_cast<int>(floor(xmid));
+    const auto j = static_cast<int>(amrex::Math::floor(xmid));
     const amrex::Real xint = xmid-j;
     sx[0] = 1.0_rt - xint;
     sx[1] = xint;
@@ -64,7 +66,7 @@ int compute_shape_factor <2> (amrex::Real* const sx, amrex::Real xmid){
 
     using namespace amrex;
 
-    const auto j = static_cast<int>(floor(xmid+0.5_rt));
+    const auto j = static_cast<int>(amrex::Math::floor(xmid+0.5_rt));
     const amrex::Real xint = xmid-j;
     sx[0] = 0.5_rt*(0.5_rt-xint)*(0.5_rt-xint);
     sx[1] = 0.75_rt-xint*xint;
@@ -84,7 +86,7 @@ int compute_shape_factor <3> (amrex::Real* const sx, amrex::Real xmid){
 
     using namespace amrex;
 
-    const auto j = static_cast<int>(floor(xmid));
+    const auto j = static_cast<int>(amrex::Math::floor(xmid));
     const amrex::Real xint = xmid-j;
     sx[0] = 1.0_rt/6.0_rt*(1.0_rt-xint)*(1.0_rt-xint)*(1.0_rt-xint);
     sx[1] = 2.0_rt/3.0_rt-xint*xint*(1.0_rt-xint/2.0_rt);
@@ -118,7 +120,7 @@ int compute_shifted_shape_factor <1> (amrex::Real* const sx,
 
     using namespace amrex;
 
-    const auto i = static_cast<int>(floor(x_old));
+    const auto i = static_cast<int>(amrex::Math::floor(x_old));
     const int i_shift = i - i_new;
     const amrex::Real xint = x_old - i;
     sx[1+i_shift] = 1.0_rt - xint;
@@ -139,7 +141,7 @@ int compute_shifted_shape_factor <2> (amrex::Real* const sx,
 
     using namespace amrex;
 
-    const auto i = static_cast<int>(floor(x_old+0.5_rt));
+    const auto i = static_cast<int>(amrex::Math::floor(x_old+0.5_rt));
     const int i_shift = i - (i_new + 1);
     const amrex::Real xint = x_old - i;
     sx[1+i_shift] = 0.5_rt*(0.5_rt-xint)*(0.5_rt-xint);
@@ -162,7 +164,7 @@ int compute_shifted_shape_factor <3> (amrex::Real* const sx,
 
     using namespace amrex;
 
-    const auto i = static_cast<int>(floor(x_old));
+    const auto i = static_cast<int>(amrex::Math::floor(x_old));
     const int i_shift = i - (i_new + 1);
     const amrex::Real xint = x_old - static_cast<amrex::Real>(i);
     sx[1+i_shift] = 1.0_rt/6.0_rt*(1.0_rt-xint)*(1.0_rt-xint)*(1.0_rt-xint);


### PR DESCRIPTION
With this and #50, it compiles and runs with DPC++.
