### PR TITLE
Do NGP deposition

### DIFF
--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -37,7 +37,7 @@ DepositCurrent (BeamParticleContainer& beam, Fields & fields,
         amrex::Real q = - PhysConst::q_e;
 
         // Call deposition function in each box
-        doDepositionShapeN<2>( pti, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q );
+        doDepositionShapeN<0>( pti, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q );
     }
 
 }


### PR DESCRIPTION
With 2nd order deposition, when running parallel, particles deposit in the guard cells, but the guard cells are never added to the neighboring box, which results in wrong currents. Actually, this is an artificial problem, because we only parallelize in the Z direction for now, but in the final version we will do NGP in the z direction. As an easy fix, this PR proposes to do NGP in all directions.