### PR TITLE
CMake: RelWithDebInfo -O3

### DIFF
--- a/cmake/HiPACEFunctions.cmake
+++ b/cmake/HiPACEFunctions.cmake
@@ -40,16 +40,18 @@ endmacro()
 # Unix-ish and portable.
 #
 macro(set_default_install_dirs)
-    include(GNUInstallDirs)
-    if(NOT CMAKE_INSTALL_CMAKEDIR)
-        set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/HiPACE"
-                CACHE PATH "CMake config package location for installed targets")
-        if(WIN32)
-            set(CMAKE_INSTALL_LIBDIR Lib
-                    CACHE PATH "Object code libraries")
-            set_property(CACHE CMAKE_INSTALL_CMAKEDIR PROPERTY VALUE "cmake")
+    if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+        include(GNUInstallDirs)
+        if(NOT CMAKE_INSTALL_CMAKEDIR)
+            set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/HiPACE"
+                    CACHE PATH "CMake config package location for installed targets")
+            if(WIN32)
+                set(CMAKE_INSTALL_LIBDIR Lib
+                        CACHE PATH "Object code libraries")
+                set_property(CACHE CMAKE_INSTALL_CMAKEDIR PROPERTY VALUE "cmake")
+            endif()
+            mark_as_advanced(CMAKE_INSTALL_CMAKEDIR)
         endif()
-        mark_as_advanced(CMAKE_INSTALL_CMAKEDIR)
     endif()
 endmacro()
 
@@ -58,13 +60,22 @@ endmacro()
 # the default in CMake is Debug for historic reasons
 #
 macro(set_default_build_type default_build_type)
-    set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
-    if(NOT CMAKE_BUILD_TYPE)
-        set(CMAKE_BUILD_TYPE ${default_build_type}
-            CACHE STRING
-            "Choose the build type, e.g. Release, Debug, or RelWithDebInfo." FORCE)
-        set_property(CACHE CMAKE_BUILD_TYPE
-            PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES})
+    if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+        set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
+        if(NOT CMAKE_BUILD_TYPE)
+            set(CMAKE_BUILD_TYPE ${default_build_type}
+                    CACHE STRING
+                    "Choose the build type, e.g. Release, Debug, or RelWithDebInfo." FORCE)
+            set_property(CACHE CMAKE_BUILD_TYPE
+                    PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES})
+        endif()
+
+        # RelWithDebInfo uses -O2 which is sub-ideal for how it is intended to be used
+        #   https://gitlab.kitware.com/cmake/cmake/-/merge_requests/591
+        list(TRANSFORM CMAKE_C_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
+        list(TRANSFORM CMAKE_CXX_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
+        # FIXME: due to the "AMReX inits CUDA first" logic we will first see this with -O2 in output
+        list(TRANSFORM CMAKE_CUDA_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
     endif()
 endmacro()
 


### PR DESCRIPTION
Replace the historic default in `RelWithDebInfo` build types of `-O2` (if present) with `-O3`.

The performance difference with quick measurements should be about +12%.

Fix #69