### PR TITLE
Only run CI on PR, not on push

### DIFF
--- a/.github/workflows/disabled/macos.yml
+++ b/.github/workflows/disabled/macos.yml
@@ -1,6 +1,6 @@
 name: macos
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   macos_appleclang_cxx14_ompi:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,6 @@
 name: linux
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
 # enable again when we open-source (free core-hours for GH Actions)


### PR DESCRIPTION
To spare some CI time, let us try to run the costly tests (e.g., not the style checks) on PRs only.