### PR TITLE
Fix units and typo in current deposition

### DIFF
--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -36,7 +36,7 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
 {
     using namespace amrex::literals;
 
-    PhysConst phys_const = get_phys_const();
+    const PhysConst phys_const = get_phys_const();
 
     // Extract particle properties
     const auto& aos = pti.GetArrayOfStructs(); // For positions
@@ -91,9 +91,9 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
                                                          + psip[ip]*psip[ip]);
 
            // calculate plasma particle velocities
-           const amrex::Real vx = uxp[ip]*gaminv/phys_const.c;
-           const amrex::Real vy = uyp[ip]*gaminv/phys_const.c;
-           const amrex::Real vz = (1-psip[ip])*gaminv;
+           const amrex::Real vx = uxp[ip]*gaminv;
+           const amrex::Real vy = uyp[ip]*gaminv;
+           const amrex::Real vz = (1._rt - psip[ip]*gaminv) * phys_const.c;
 
            // calculate charge of the plasma particles
            const amrex::Real wq = q*wp[ip]/(gaminv * psip[ip]);


### PR DESCRIPTION
This PR makes minor modifications in the plasma current deposition:
- fixes a bug in how vz is calculate from psi
- use `_rt` to avoid type conversion
- make (though I didn't test it) CD correct in SI units

