### PR TITLE
Space between function name and bracket for declaration and definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,5 @@ The last line would work on MacOS. On another platform, open the html file with 
 - Classes use CamelCase
 - Objects use snake_case
 - Lines should not have >100 characters
+- The declaration and definition of a function should have a space between the function name and the first bracket (`my_function (...)`), function calls should not (`my_function(...)`).
+  This is a convention introduce in AMReX so `git grep "my_function ("` returns only the declaration and definition, not the many function calls.

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -17,8 +17,10 @@ public:
      * and initialize longitudinal and transverse MPI communicators */
     Hipace ();
 
+    /** Destructor */
     ~Hipace ();
 
+    /** Get singleton instance */
     static Hipace& GetInstance ();
 
     /** Virtual functions need to be defined for pure virtual class AmrCore */
@@ -26,19 +28,32 @@ public:
         int lev, amrex::Real time, const amrex::BoxArray& ba,
         const amrex::DistributionMapping& dm) override;
 
+    /** Tag cells for refinement */
     void ErrorEst (
-                   int /*lev*/, amrex::TagBoxArray& /*tags*/, amrex::Real /*time*/, int /*ngrow*/) override {}
+                   int /*lev*/, amrex::TagBoxArray& /*tags*/,
+                   amrex::Real /*time*/, int /*ngrow*/) override {}
 
+    /** Make a new level using provided BoxArray and DistributionMapping and
+     * fill with interpolated coarse level data */
     void MakeNewLevelFromCoarse (
                                  int /*lev*/, amrex::Real /*time*/, const amrex::BoxArray& /*ba*/,
                                  const amrex::DistributionMapping& /*dm*/) override {}
 
+    /** Remake an existing level using provided BoxArray and DistributionMapping and fill
+     * with existing fine and coarse data */
     void RemakeLevel (
                       int /*lev*/, amrex::Real /*time*/, const amrex::BoxArray& /*ba*/,
                       const amrex::DistributionMapping& /*dm*/) override {}
 
+    /** Delete level data */
     void ClearLevel (int /*lev*/) override {}
 
+    /**\brief Apply some user-defined changes the to base grids.
+     *
+     * This function is only called by MakeNewGrids after computing a box array for
+     * the coarsest level and before calling MakeNewLevelFromScratch.
+     * For example, use this function if you want to remove covered grids on
+     * the coarsest refinement level. */
     void PostProcessBaseGrids (amrex::BoxArray& ba0) const override;
 
     /** Init AmrCore and allocate beam and plasma containers */

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -32,6 +32,7 @@ private:
     static constexpr int m_nslices = 4;
 
 public:
+    /** Constructor */
     explicit Fields (Hipace const* a_hipace);
 
     /** Allocate MultiFabs for the 3D array and the 2D slices

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -36,7 +36,7 @@ public:
      * \param[in] dm DistributionMapping for the BoxArray.
      * \param[in] gm Geometry, contains the box dimensions.
      */
-    void define  (amrex::BoxArray const& realspace_ba,
+    void define ( amrex::BoxArray const& realspace_ba,
                   amrex::DistributionMapping const& dm,
                   amrex::Geometry const& gm);
 
@@ -48,7 +48,7 @@ public:
     void SolvePoissonEquation (amrex::MultiFab& lhs_mf);
 
     /** Get reference to the taging area */
-    amrex::MultiFab& StagingArea() {return m_stagingArea;}
+    amrex::MultiFab& StagingArea () {return m_stagingArea;}
 private:
     /** BoxArray for the spectral fields */
     amrex::BoxArray m_spectralspace_ba;

--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -73,18 +73,18 @@ namespace AnyFFT
      * \param[out] complex_array Complex array to/from where R2C/C2R FFT is performed
      * \param[in] dir direction, either R2C or C2R
      */
-    FFTplan CreatePlan(const amrex::IntVect& real_size, amrex::Real * const real_array,
-                       Complex * const complex_array, const direction dir);
+    FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
+                        Complex * const complex_array, const direction dir);
 
     /** \brief Destroy library FFT plan.
      * \param[out] fft_plan plan to destroy
      */
-    void DestroyPlan(FFTplan& fft_plan);
+    void DestroyPlan (FFTplan& fft_plan);
 
     /** \brief Perform FFT with backend library.
      * \param[out] fft_plan plan for which the FFT is performed
      */
-    void Execute(FFTplan& fft_plan);
+    void Execute (FFTplan& fft_plan);
 }
 
 #endif // ANYFFT_H_

--- a/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
@@ -13,8 +13,8 @@ namespace AnyFFT
 
     std::string cufftErrorToString (const cufftResult& err);
 
-    FFTplan CreatePlan(const amrex::IntVect& real_size, amrex::Real * const real_array,
-                       Complex * const complex_array, const direction dir)
+    FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
+                        Complex * const complex_array, const direction dir)
     {
         FFTplan fft_plan;
 
@@ -41,12 +41,12 @@ namespace AnyFFT
         return fft_plan;
     }
 
-    void DestroyPlan(FFTplan& fft_plan)
+    void DestroyPlan (FFTplan& fft_plan)
     {
         cufftDestroy( fft_plan.m_plan );
     }
 
-    void Execute(FFTplan& fft_plan){
+    void Execute (FFTplan& fft_plan){
         BL_PROFILE("Execute_FFTplan()");
         // make sure that this is done on the same GPU stream as the above copy
         cudaStream_t stream = amrex::Gpu::Device::cudaStream();

--- a/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
@@ -14,8 +14,8 @@ namespace AnyFFT
     const auto VendorCreatePlanC2R2D = fftw_plan_dft_c2r_2d;
 #endif
 
-    FFTplan CreatePlan(const amrex::IntVect& real_size, amrex::Real * const real_array,
-                       Complex * const complex_array, const direction dir)
+    FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
+                        Complex * const complex_array, const direction dir)
     {
         FFTplan fft_plan;
 
@@ -37,7 +37,7 @@ namespace AnyFFT
         return fft_plan;
     }
 
-    void DestroyPlan(FFTplan& fft_plan)
+    void DestroyPlan (FFTplan& fft_plan)
     {
 #  ifdef AMREX_USE_FLOAT
         fftwf_destroy_plan( fft_plan.m_plan );
@@ -46,7 +46,7 @@ namespace AnyFFT
 #  endif
     }
 
-    void Execute(FFTplan& fft_plan){
+    void Execute (FFTplan& fft_plan){
         BL_PROFILE("Execute_FFTplan()");
 #  ifdef AMREX_USE_FLOAT
         fftwf_execute( fft_plan.m_plan );

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -20,6 +20,7 @@ class BeamParticleContainer
     : public amrex::ParticleContainer<0, 0, BeamIdx::nattribs>
 {
 public:
+    /** Constructor */
     explicit BeamParticleContainer (amrex::AmrCore* amr_core) :
         amrex::ParticleContainer<0,0,BeamIdx::nattribs>(amr_core->GetParGDB())
     {
@@ -59,6 +60,7 @@ class BeamParticleIterator : public amrex::ParIter<0,0,BeamIdx::nattribs>
 {
 public:
     using amrex::ParIter<0,0,BeamIdx::nattribs>::ParIter;
+    /** Constructor */
     BeamParticleIterator (ContainerType& pc, int level): ParIter(pc, level) {}
 };
 

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -30,6 +30,7 @@ class PlasmaParticleContainer
     : public amrex::ParticleContainer<0, 0, PlasmaIdx::nattribs>
 {
 public:
+    /** Constructor */
     explicit PlasmaParticleContainer (amrex::AmrCore* amr_core);
 
     /** Allocate data for the beam particles and initialize particles with requested beam profile
@@ -56,6 +57,7 @@ class PlasmaParticleIterator : public amrex::ParIter<0,0,PlasmaIdx::nattribs>
 {
 public:
     using amrex::ParIter<0,0,PlasmaIdx::nattribs>::ParIter;
+    /** Constructor */
     PlasmaParticleIterator (ContainerType& pc, int level): ParIter(pc, level) {}
 };
 


### PR DESCRIPTION
Adopt @WeiqunZhang's  convention of putting a space between the function name and bracket in declaration and definition, to ease the use of `git grep`.

Also documents remaining undocumented functions.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Doxygen compiles without warning**, and produced the desired output
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
