### PR TITLE
[WIP] Avoid random errors in parallel runs with plasma particles

### DIFF
--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -22,11 +22,9 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
     for ( amrex::MFIter mfi(S); mfi.isValid(); ++mfi )
     {
         // Extract properties associated with the extent of the current box
-        // amrex::Box tilebox = pti.tilebox().grow(2); // Grow to capture the extent of the particle shape
         // Grow to capture the extent of the particle shape
-        //amrex::Box tilebox = mfi.tilebox().grow(
-        //    {Hipace::m_depos_order_xy, Hipace::m_depos_order_xy, 0});
-        amrex::Box tilebox = mfi.tilebox().grow(2);
+        amrex::Box tilebox = mfi.tilebox().grow(
+            {Hipace::m_depos_order_xy, Hipace::m_depos_order_xy, 0});
 
         amrex::RealBox const grid_box{tilebox, gm.CellSize(), gm.ProbLo()};
         amrex::Real const * AMREX_RESTRICT xyzmin = grid_box.lo();

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -16,41 +16,46 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
 
     PhysConst phys_const = get_phys_const();
 
+    amrex::MultiFab& S = fields.getSlices(lev, 1);
+
     // Loop over particle boxes
-    for (PlasmaParticleIterator pti(plasma, lev); pti.isValid(); ++pti)
+    for ( amrex::MFIter mfi(S); mfi.isValid(); ++mfi )
     {
         // Extract properties associated with the extent of the current box
-        amrex::Box tilebox = pti.tilebox().grow(2); // Grow to capture the extent of the particle shape
+        // amrex::Box tilebox = pti.tilebox().grow(2); // Grow to capture the extent of the particle shape
+        // Grow to capture the extent of the particle shape
+        //amrex::Box tilebox = mfi.tilebox().grow(
+        //    {Hipace::m_depos_order_xy, Hipace::m_depos_order_xy, 0});
+        amrex::Box tilebox = mfi.tilebox().grow(2);
 
         amrex::RealBox const grid_box{tilebox, gm.CellSize(), gm.ProbLo()};
         amrex::Real const * AMREX_RESTRICT xyzmin = grid_box.lo();
         amrex::Dim3 const lo = amrex::lbound(tilebox);
 
         // Extract the fields currents
-        amrex::MultiFab& S = fields.getSlices(lev, 1);
         amrex::MultiFab jx(S, amrex::make_alias, FieldComps::jx, 1);
         amrex::MultiFab jy(S, amrex::make_alias, FieldComps::jy, 1);
         amrex::MultiFab jz(S, amrex::make_alias, FieldComps::jz, 1);
         // Extract FabArray for this box
-        amrex::FArrayBox& jx_fab = jx[pti];
-        amrex::FArrayBox& jy_fab = jy[pti];
-        amrex::FArrayBox& jz_fab = jz[pti];
+        amrex::FArrayBox& jx_fab = jx[mfi];
+        amrex::FArrayBox& jy_fab = jy[mfi];
+        amrex::FArrayBox& jz_fab = jz[mfi];
 
         // For now: fix the value of the charge
         amrex::Real q = - phys_const.q_e;
 
         // Call deposition function in each box
         if        (Hipace::m_depos_order_xy == 0){
-                doDepositionShapeN<0, 0>( pti, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
+            doDepositionShapeN<0, 0>( plasma, mfi, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
                                           CurrentDepoType::DepositThisSlice );
         } else if (Hipace::m_depos_order_xy == 1){
-                doDepositionShapeN<1, 0>( pti, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
+                doDepositionShapeN<1, 0>( plasma, mfi, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
                                           CurrentDepoType::DepositThisSlice );
         } else if (Hipace::m_depos_order_xy == 2){
-                doDepositionShapeN<2, 0>( pti, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
+                doDepositionShapeN<2, 0>( plasma, mfi, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
                                           CurrentDepoType::DepositThisSlice );
         } else if (Hipace::m_depos_order_xy == 3){
-                doDepositionShapeN<3, 0>( pti, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
+                doDepositionShapeN<3, 0>( plasma, mfi, jx_fab, jy_fab, jz_fab, dx, xyzmin, lo, q,
                                           CurrentDepoType::DepositThisSlice );
         } else {
             amrex::Abort("unknow deposition order");

--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -43,17 +43,8 @@ void doDepositionShapeN (PlasmaParticleContainer& plasma,
     auto& particle_tile = particles[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
     // Extract particle properties
     auto& soa = particle_tile.GetStructOfArrays();
-    // auto& aos = particle_tile.GetArrayOfStructs(); // For positions
     PlasmaParticleContainer::ParticleType* pstruct = particle_tile.GetArrayOfStructs()().data();
 
-    // auto& pos_structs = aos.begin();
-    // const auto& soa = pti.GetStructOfArrays(); // For momenta and weights
-
-
-
-
-
-    
     const amrex::Real * const wp = (current_depo_type == CurrentDepoType::DepositThisSlice) ?
         soa.GetRealData(PlasmaIdx::w).data() : soa.GetRealData(PlasmaIdx::w_temp).data();
     const amrex::Real * const uxp = (current_depo_type == CurrentDepoType::DepositThisSlice) ?

--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -24,7 +24,8 @@
  * \param[in] current_depo_type type of deposition: DepositThisSlice or DepositNextSlice
  */
 template <int depos_order_xy, int depos_order_z>
-void doDepositionShapeN (const PlasmaParticleIterator& pti,
+void doDepositionShapeN (PlasmaParticleContainer& plasma,
+                         const amrex::MFIter& mfi,
                          amrex::FArrayBox& jx_fab,
                          amrex::FArrayBox& jy_fab,
                          amrex::FArrayBox& jz_fab,
@@ -37,12 +38,22 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
     using namespace amrex::literals;
 
     const PhysConst phys_const = get_phys_const();
-
+    constexpr int lev = 0;
+    auto& particles = plasma.GetParticles(lev);
+    auto& particle_tile = particles[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
     // Extract particle properties
-    const auto& aos = pti.GetArrayOfStructs(); // For positions
-    const auto& pos_structs = aos.begin();
-    const auto& soa = pti.GetStructOfArrays(); // For momenta and weights
+    auto& soa = particle_tile.GetStructOfArrays();
+    // auto& aos = particle_tile.GetArrayOfStructs(); // For positions
+    PlasmaParticleContainer::ParticleType* pstruct = particle_tile.GetArrayOfStructs()().data();
 
+    // auto& pos_structs = aos.begin();
+    // const auto& soa = pti.GetStructOfArrays(); // For momenta and weights
+
+
+
+
+
+    
     const amrex::Real * const wp = (current_depo_type == CurrentDepoType::DepositThisSlice) ?
         soa.GetRealData(PlasmaIdx::w).data() : soa.GetRealData(PlasmaIdx::w_temp).data();
     const amrex::Real * const uxp = (current_depo_type == CurrentDepoType::DepositThisSlice) ?
@@ -81,7 +92,7 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
 
     // Loop over particles and deposit into jx_fab, jy_fab and jz_fab
     amrex::ParallelFor(
-        pti.numParticles(),
+        particle_tile.GetArrayOfStructs().size(),
         [=] AMREX_GPU_DEVICE (long ip) {
 
            // calculate 1/gamma for plasma particles
@@ -103,17 +114,18 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
            const amrex::Real wqy = wq*invvol*vy;
            const amrex::Real wqz = wq*invvol*vz;
 
+           PlasmaParticleContainer::ParticleType& p = pstruct[ip];
             // --- Compute shape factors
             // x direction
             // j_cell leftmost cell in x that the particle touches. sx_cell shape factor along x
             const amrex::Real xmid = (current_depo_type == CurrentDepoType::DepositThisSlice) ?
-                (pos_structs[ip].pos(0) - xmin)*dxi : (x_temp[ip] - xmin)*dxi;
+                (p.pos(0) - xmin)*dxi : (x_temp[ip] - xmin)*dxi;
             amrex::Real sx_cell[depos_order_xy + 1];
             const int j_cell = compute_shape_factor<depos_order_xy>(sx_cell, xmid - 0.5_rt);
 
             // y direction
             const amrex::Real ymid = (current_depo_type == CurrentDepoType::DepositThisSlice) ?
-                (pos_structs[ip].pos(1) - ymin)*dyi : (y_temp[ip] - ymin)*dyi;
+                (p.pos(1) - ymin)*dyi : (y_temp[ip] - ymin)*dyi;
             amrex::Real sy_cell[depos_order_xy + 1];
             const int k_cell = compute_shape_factor<depos_order_xy>(sy_cell, ymid - 0.5_rt);
 

--- a/src/particles/pusher/PlasmaParticlePusher.cpp
+++ b/src/particles/pusher/PlasmaParticlePusher.cpp
@@ -20,7 +20,7 @@ UpdateForcePushParticles (PlasmaParticleContainer& plasma, Fields & fields,
     const PhysConst phys_const = get_phys_const();
 
     const amrex::MultiFab& S = fields.getSlices(lev, 1);
-    
+
     for ( amrex::MFIter mfi(S); mfi.isValid(); ++mfi )
     {
         // Extract properties associated with the extent of the current box
@@ -76,7 +76,7 @@ UpdateForcePushParticles (PlasmaParticleContainer& plasma, Fields & fields,
         const amrex::Real zmin = xyzmin[2];
 
         PlasmaParticleContainer::ParticleType* pstruct = particle_tile.GetArrayOfStructs()().data();
-        
+
         amrex::ParallelFor(particle_tile.GetArrayOfStructs().size(),
             [=] AMREX_GPU_DEVICE (long ip) {
                 PlasmaParticleContainer::ParticleType& p = pstruct[ip];


### PR DESCRIPTION
This PR addresses issue https://github.com/Hi-PACE/hipace/issues/115. I am not sure it is the best solution, maybe @atmyers can comment, but at least it removes the runtime error in Debug mode in `UpdateForcePushParticles`. Still have to check that it makes particle gather and deposition right in parallel, at least in the upstream rank. If this makes sense, we could also for the plasma current deposition in a similar way.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Doxygen compiles without warning**, and produced the desired output
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
