### PR TITLE
add WarpX Copyright header for file taken from WarpX

### DIFF
--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef ANYFFT_H_
 #define ANYFFT_H_
 

--- a/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "AnyFFT.H"
 
 namespace AnyFFT

--- a/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2019-2020
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "AnyFFT.H"
 
 namespace AnyFFT

--- a/src/particles/ShapeFactors.H
+++ b/src/particles/ShapeFactors.H
@@ -4,6 +4,8 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+
+
 #ifndef SHAPEFACTORS_H_
 #define SHAPEFACTORS_H_
 

--- a/src/particles/deposition/BeamDepositCurrentInner.H
+++ b/src/particles/deposition/BeamDepositCurrentInner.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
+ * Remi Lehe, Weiqun Zhang, Michael Rowan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_BEAMDEPOSITCURRENTINNER_H_
 #define HIPACE_BEAMDEPOSITCURRENTINNER_H_
 

--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -1,3 +1,10 @@
+/* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
+ * Remi Lehe, Weiqun Zhang, Michael Rowan
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_PLASMADEPOSITCURRENTINNER_H_
 #define HIPACE_PLASMADEPOSITCURRENTINNER_H_
 

--- a/tests/checksum/benchmark.py
+++ b/tests/checksum/benchmark.py
@@ -1,3 +1,10 @@
+"""
+Copyright 2020
+
+This file is part of WarpX.
+
+License: BSD-3-Clause-LBNL
+"""
 import config
 import json
 import os

--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -1,3 +1,10 @@
+"""
+Copyright 2020
+
+This file is part of WarpX.
+
+License: BSD-3-Clause-LBNL
+"""
 from benchmark import Benchmark
 import yt
 yt.funcs.mylog.setLevel(50)

--- a/tests/checksum/checksumAPI.py
+++ b/tests/checksum/checksumAPI.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python3
 
+"""
+Copyright 2020
+
+This file is part of WarpX.
+
+License: BSD-3-Clause-LBNL
+"""
+
 from checksum import Checksum
 from benchmark import Benchmark
 import argparse

--- a/tests/checksum/config.py
+++ b/tests/checksum/config.py
@@ -1,3 +1,10 @@
+"""
+Copyright 2020
+
+This file is part of WarpX.
+
+License: BSD-3-Clause-LBNL
+"""
 import os
 
 benchmark_location = os.path.split(__file__)[0] + '/benchmarks_json'


### PR DESCRIPTION
When we go open-source, we'll need to keep these copyright headers (and add Hipace ones).

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Doxygen compiles without warning**, and produced the desired output
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
