### PR TITLE
Fix sign error in Poisson solver

### DIFF
--- a/examples/beam_in_vacuum/analysis.py
+++ b/examples/beam_in_vacuum/analysis.py
@@ -45,7 +45,7 @@ else:
     # Density of the can beam
     dens = 2.8239587008591567e23 # at this density, 1/kp = 10um, allowing for an easy comparison with normalized units
     # Define array for transverse coordinate and theory for By and Bx
-    jz0 = scc.e * scc.c * dens
+    jz0 = - scc.e * scc.c * dens
     mu_0 = scc.mu_0
     # Radius of the can beam
     R = 10.e-6
@@ -58,7 +58,7 @@ y = np.linspace(ds.domain_left_edge[1].v, ds.domain_right_edge[1].v, ds.domain_d
 Bx_th = -mu_0 * jz0 * y / 2.
 Bx_th[abs(y)>=R] = -mu_0 * jz0 * R**2/(2*y[abs(y)>R])
 
-jz_th = - np.ones_like(x) * jz0
+jz_th = np.ones_like(x) * jz0
 jz_th[abs(x)>=R] = 0.
 
 # Load Hipace data for By in SI units

--- a/examples/can_beam/analysis.py
+++ b/examples/can_beam/analysis.py
@@ -41,7 +41,7 @@ if plot_plt:
         plt.subplot(nx,ny,count+1)
         plt.title(field[1])
         F = all_data_level_0[field].v.squeeze()[:,ds.domain_dimensions[1]//2,:]
-        plt.imshow(F, extent=extent, aspect='auto')
+        plt.imshow(F, extent=extent, aspect='auto', origin='lower')
         plt.colorbar()
         plt.xlabel('z')
         plt.ylabel('x')

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
@@ -119,7 +119,7 @@ FFTPoissonSolver::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
         amrex::Array4<amrex::Real> inv_k2_arr = m_inv_k2.array(mfi);
         amrex::ParallelFor( m_spectralspace_ba[mfi],
             [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                tmp_cmplx_arr(i,j,k) *= inv_k2_arr(i,j,k);
+                tmp_cmplx_arr(i,j,k) *= -inv_k2_arr(i,j,k);
             });
 
         // Perform Fourier transform from `tmpSpectralField` to the staging area


### PR DESCRIPTION
It seems that the Poisson solver has a sign error:
In real space, we want to solve
```
Delta f = s # As defined in the doc strings
```
In spectral space this should be
```
- k^2 * FT(f) = FT(s) 
```
but we're currently solving
```
k^2 * FT(f) = FT(s) 
```

This PR proposes a fix, and updates the automated tests accordingly.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
