### PR TITLE
add some _rt and remove parallel test from script to reset benchmarks

### DIFF
--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
@@ -16,6 +16,8 @@ FFTPoissonSolver::define ( amrex::BoxArray const& realspace_ba,
                            amrex::DistributionMapping const& dm,
                            amrex::Geometry const& gm )
 {
+    using namespace amrex::literals;
+
     BL_PROFILE("FFTPoissonSolver::define()");
     // If we are going to support parallel FFT, the constructor needs to take a communicator.
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(realspace_ba.size() == 1, "Parallel FFT not supported yet");
@@ -71,10 +73,10 @@ FFTPoissonSolver::define ( amrex::BoxArray const& realspace_ba,
             // The first half of ky is positive ; the other is negative
             amrex::Real ky = (j<mid_point_y) ? dky*j : dky*(j-Ny);
             if ((i!=0) && (j!=0)) {
-                inv_k2_arr(i,j,0) = 1./(kx*kx + ky*ky);
+                inv_k2_arr(i,j,0) = 1._rt/(kx*kx + ky*ky);
             } else {
                 // Avoid division by 0
-                inv_k2_arr(i,j,0) = 0;
+                inv_k2_arr(i,j,0) = 0._rt;
             }
         });
     }

--- a/tests/checksum/reset_all_benchmarks.sh
+++ b/tests/checksum/reset_all_benchmarks.sh
@@ -127,13 +127,14 @@ then
 fi
 
 # can_beam.2Rank
-if [[ $all_tests = true ]] || [[ $one_test_name = "can_beam.2Rank" ]]
-then
-    cd $build_dir
-    ctest --output-on-failure -R can_beam.2Rank \
-        || echo "ctest command failed, maybe just because checksums are different. Keep going"
-    cd $checksum_dir
-    ./checksumAPI.py --reset-benchmark \
-                     --plotfile ${build_dir}/bin/plt00001 \
-                     --test-name can_beam.2Rank
-fi
+### This test is inactive as Hipace doesn't support parallelization yet.
+#if [[ $all_tests = true ]] || [[ $one_test_name = "can_beam.2Rank" ]]
+#then
+#    cd $build_dir
+#    ctest --output-on-failure -R can_beam.2Rank \
+#        || echo "ctest command failed, maybe just because checksums are different. Keep going"
+#    cd $checksum_dir
+#    ./checksumAPI.py --reset-benchmark \
+#                     --plotfile ${build_dir}/bin/plt00001 \
+#                     --test-name can_beam.2Rank
+#fi


### PR DESCRIPTION
Small cleaning PR. The parallel test with 2 rank is inactive, so the script to reset all benchmarks should not reset it. We will update this when we fix parallelization and reactivate the test.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
