### PR TITLE
[mini] Improving host-device performance by removing redundant copy call

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -203,8 +203,10 @@ Hipace::Evolve ()
         /* ---------- Depose current from beam particles ---------- */
         amrex::MultiFab& fields = m_fields.getF(lev);
 
-        if (!m_3d_on_host) fields.setVal(0.);
-        if (!m_slice_deposition) DepositCurrent(m_beam_container, m_fields, geom[lev], lev);
+        if (!m_slice_deposition){
+            fields.setVal(0.);
+            DepositCurrent(m_beam_container, m_fields, geom[lev], lev);
+        }
 
         const amrex::Vector<int> index_array = fields.IndexArray();
         for (auto it = index_array.rbegin(); it != index_array.rend(); ++it)
@@ -222,8 +224,11 @@ Hipace::Evolve ()
                 // for loop, the parallelcontext is the transverse communicator
                 amrex::ParallelContext::push(m_comm_xy);
 
-                if (m_3d_on_host) m_fields.getSlices(lev, WhichSlice::This).setVal(0.);
-                else m_fields.Copy(lev, islice, FieldCopyType::FtoS, 0, 0, FieldComps::nfields);
+                if (m_slice_deposition){
+                    m_fields.getSlices(lev, WhichSlice::This).setVal(0.);
+                } else {
+                    m_fields.Copy(lev, islice, FieldCopyType::FtoS, 0, 0, FieldComps::nfields);
+                }
 
                 AdvancePlasmaParticles(m_plasma_container, m_fields, geom[lev],
                                        ToSlice::This,


### PR DESCRIPTION
This PR is part of issue #144. 

With the host-device option introduced in PR #143, the 3D array can live on the host and only the computed slices are on the device. 
In the previous implementation, the slices were copied from the host to the device, calculated there, and then copied back to the host. However, with the beam living on the slice as well and depositing directly on the slices (#132), there is no information required from the host memory for the slice to be calculated. 

Therefore, the first copy call from host to device became redundant for host-device simulations and is removed in this PR.

This input script was used to test the behavior:
[inputs_normalized.txt](https://github.com/Hi-PACE/hipace/files/5177938/inputs_normalized.txt)

On my laptop, I found the expected performance improvement, while maintaining the same result:

_Before this PR:_
```
TinyProfiler total time across processes [min...avg...max]: 20.56 ... 20.56 ... 20.56

---------------------------------------------------------------------------------------------------
Name                                                NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------------
UpdateForcePushParticles_PlasmaParticleContainer()    1982      3.817      3.817      3.817  18.57%
Fields::AllocData()                                      1      3.489      3.489      3.489  16.97%
Fields::Copy()                                         400      3.294      3.294      3.294  16.02%
```
_Using this PR:_
```
TinyProfiler total time across processes [min...avg...max]: 19.2 ... 19.2 ... 19.2

---------------------------------------------------------------------------------------------------
Name                                                NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------------
UpdateForcePushParticles_PlasmaParticleContainer()    1982      3.957      3.957      3.957  20.61%
Fields::AllocData()                                      1      3.549      3.549      3.549  18.49%
FFTPoissonSolver::SolvePoissonEquation()              2182      2.966      2.966      2.966  15.45%
Fields::Copy()                                         200      1.497      1.497      1.497   7.80%
```

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
