### PR TITLE
[WIP] Solving the Poisson equations with the correct Dirichlet boundary conditions

### DIFF
--- a/examples/beam_in_vacuum/analysis.py
+++ b/examples/beam_in_vacuum/analysis.py
@@ -58,7 +58,7 @@ y = np.linspace(ds.domain_left_edge[1].v, ds.domain_right_edge[1].v, ds.domain_d
 Bx_th = -mu_0 * jz0 * y / 2.
 Bx_th[abs(y)>=R] = -mu_0 * jz0 * R**2/(2*y[abs(y)>R])
 
-jz_th = np.ones_like(x) * jz0
+jz_th = np.ones_like(x) * -jz0
 jz_th[abs(x)>=R] = 0.
 
 # Load Hipace data for By in SI units
@@ -106,7 +106,7 @@ if args.do_plot:
         plt.plot(y, Bx_th, 'k--', label='theory')
         plt.grid()
         plt.legend()
-        plt.xlim(-5., 5.)
+        # plt.xlim(-5., 5.)
         plt.xlabel('kp y')
         plt.ylabel('c Bx / E0')
 
@@ -115,7 +115,7 @@ if args.do_plot:
         plt.plot(x, By_th, 'k--', label='theory')
         plt.grid()
         plt.legend()
-        plt.xlim(-5., 5.)
+        # plt.xlim(-5., 5.)
         plt.xlabel('kp x')
         plt.ylabel('c By / E0')
 
@@ -124,7 +124,7 @@ if args.do_plot:
         plt.plot(x, jz_th, 'k--', label='theory')
         plt.grid()
         plt.legend()
-        plt.xlim(-5., 5.)
+        # plt.xlim(-5., 5.)
         plt.xlabel('kp x')
         plt.ylabel('jz /IA')
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -382,18 +382,18 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const amrex::Box& bx, const int islic
         /* Shift relative_Bfield_error values */
         relative_Bfield_error_prev_iter = relative_Bfield_error;
     } /* end of predictor corrector loop */
-    if (relative_Bfield_error > 10.)
-    {
-        amrex::Abort("Predictor corrector loop diverged!\n"
-                     "Re-try by adjusting the following paramters in the input script:\n"
-                     "- lower mixing factor: hipace.predcorr_B_mixing_factor "
-                     "(hidden default: 0.1) \n"
-                     "- lower B field error tolerance: hipace.fld_predcorr_tol_b"
-                     " (hidden default: 0.04)\n"
-                     "- higher number of iterations in the pred. cor. loop:"
-                     "hipace.fld_predcorr_n_max_iter (hidden default: 5)\n"
-                     "- higher longitudinal resolution");
-    }
+    // if (relative_Bfield_error > 10.)
+    // {
+    //     amrex::Abort("Predictor corrector loop diverged!\n"
+    //                  "Re-try by adjusting the following paramters in the input script:\n"
+    //                  "- lower mixing factor: hipace.predcorr_B_mixing_factor "
+    //                  "(hidden default: 0.1) \n"
+    //                  "- lower B field error tolerance: hipace.fld_predcorr_tol_b"
+    //                  " (hidden default: 0.04)\n"
+    //                  "- higher number of iterations in the pred. cor. loop:"
+    //                  "hipace.fld_predcorr_n_max_iter (hidden default: 5)\n"
+    //                  "- higher longitudinal resolution");
+    // }
     if (m_verbose >= 1) amrex::Print()<<"islice: " << islice << " n_iter: "<<i_iter<<
                                         " relative B field error: "<<relative_Bfield_error<< "\n";
 }

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -53,7 +53,8 @@ private:
     /** BoxArray for the spectral fields */
     amrex::BoxArray m_spectralspace_ba;
     /** Spectral fields, contains (complex) field in Fourier space */
-    SpectralField m_tmpSpectralField;
+    //SpectralField m_tmpSpectralField;
+    amrex::MultiFab m_tmpSpectralField;
     /** Staging area, contains (real) field in real space.
      * This is where the source term is stored before calling the Poisson solver */
     amrex::MultiFab m_stagingArea;

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -57,8 +57,8 @@ private:
     /** Staging area, contains (real) field in real space.
      * This is where the source term is stored before calling the Poisson solver */
     amrex::MultiFab m_stagingArea;
-    /** Multifab containing 1/(kx^2 + ky^2), to solve Poisson equation. */
-    amrex::MultiFab m_inv_k2;
+    /** Multifab containing the Dirichtlet eigenvalue matrix TO BE BETTER EXPLAINED 1/(kx^2 + ky^2), to solve Poisson equation. */
+    amrex::MultiFab m_dirichlet_eigenvalue_matrix;
     /** FFT plans */
     AnyFFT::FFTplans m_forward_plan, m_backward_plan;
 };

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
@@ -80,10 +80,10 @@ FFTPoissonSolver::define ( amrex::BoxArray const& realspace_ba,
             amrex::Real siney_sq = pow( sin(( j + 1 ) * sine_y_factor), 2);
 
             if ((sinex_sq!=0) && (siney_sq!=0)) {
-                dirichlet_eigenvalue_matrix(i,j,0) = norm_fac / ( -4.0 * ( sinex_sq / dxsquared + siney_sq / dysquared ));
+                dirichlet_eigenvalue_matrix(j,i,0) = norm_fac / ( -4.0 * ( sinex_sq / dxsquared + siney_sq / dysquared ));
             } else {
                 // Avoid division by 0
-                dirichlet_eigenvalue_matrix(i,j,0) = 0._rt;
+                dirichlet_eigenvalue_matrix(j,i,0) = 0._rt;
             }
             //std::cout << " i " << i << " j " << j << " dirichlet_eigenvalue_matrix(i,j,0) " << dirichlet_eigenvalue_matrix(i,j,0) << "\n";
         });
@@ -132,7 +132,7 @@ FFTPoissonSolver::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
         amrex::Array4<amrex::Real> dirichlet_eigenvalue_matrix = m_dirichlet_eigenvalue_matrix.array(mfi);
         amrex::ParallelFor( m_spectralspace_ba[mfi],
             [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                tmp_cmplx_arr(i,j,k) *= -dirichlet_eigenvalue_matrix(i,j,k);
+                tmp_cmplx_arr(i,j,k) *= dirichlet_eigenvalue_matrix(i,j,k);
             });
 
         // Perform Fourier transform from `tmpSpectralField` to the staging area

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
@@ -80,10 +80,10 @@ FFTPoissonSolver::define ( amrex::BoxArray const& realspace_ba,
             amrex::Real siney_sq = pow( sin(( j + 1 ) * sine_y_factor), 2);
 
             if ((sinex_sq!=0) && (siney_sq!=0)) {
-                dirichlet_eigenvalue_matrix(j,i,0) = norm_fac / ( -4.0 * ( sinex_sq / dxsquared + siney_sq / dysquared ));
+                dirichlet_eigenvalue_matrix(i,j,0) = norm_fac / ( -4.0 * ( sinex_sq / dxsquared + siney_sq / dysquared ));
             } else {
                 // Avoid division by 0
-                dirichlet_eigenvalue_matrix(j,i,0) = 0._rt;
+                dirichlet_eigenvalue_matrix(i,j,0) = 0._rt;
             }
             //std::cout << " i " << i << " j " << j << " dirichlet_eigenvalue_matrix(i,j,0) " << dirichlet_eigenvalue_matrix(i,j,0) << "\n";
         });

--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -65,7 +65,8 @@ namespace AnyFFT
     struct FFTplan
     {
         amrex::Real* m_real_array; /**< pointer to real array */
-        Complex* m_complex_array; /**< pointer to complex array */
+        // before Complex* m_complex_array; /**< pointer to complex array */
+        amrex::Real* m_complex_array; /**< pointer to complex array */
         VendorFFTPlan m_plan; /**< Vendor FFT plan */
         direction m_dir;  /**< direction (C2R or R2C) */
     };
@@ -80,7 +81,8 @@ namespace AnyFFT
      * \param[in] dir direction, either R2C or C2R
      */
     FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
-                        Complex * const complex_array, const direction dir);
+                        amrex::Real * const complex_array, const direction dir);
+                        //Complex * const complex_array, const direction dir);
 
     /** \brief Destroy library FFT plan.
      * \param[out] fft_plan plan to destroy

--- a/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
@@ -14,26 +14,28 @@ namespace AnyFFT
     const auto VendorCreatePlanC2R3D = fftwf_plan_dft_c2r_3d;
     const auto VendorCreatePlanR2C2D = fftwf_plan_dft_r2c_2d;
     const auto VendorCreatePlanC2R2D = fftwf_plan_dft_c2r_2d;
+    // const auto VendorCreatePlanR2R2D = fftwf_plan_dft_r2r_2d;
 #else
     const auto VendorCreatePlanR2C3D = fftw_plan_dft_r2c_3d;
     const auto VendorCreatePlanC2R3D = fftw_plan_dft_c2r_3d;
     const auto VendorCreatePlanR2C2D = fftw_plan_dft_r2c_2d;
     const auto VendorCreatePlanC2R2D = fftw_plan_dft_c2r_2d;
+    // const auto VendorCreatePlanR2R2D = fftw_plan_dft_r2r_2d;
 #endif
 
-    FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
-                        Complex * const complex_array, const direction dir)
+    FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array, amrex::Real * const complex_array, const direction dir)
+                        // Complex * const complex_array,
     {
         FFTplan fft_plan;
 
         // Initialize fft_plan.m_plan with the vendor fft plan.
         // Swap dimensions: AMReX FAB are Fortran-order but FFTW is C-order
         if (dir == direction::R2C){
-            fft_plan.m_plan = VendorCreatePlanR2C2D(
-                    real_size[1], real_size[0], real_array, complex_array, FFTW_ESTIMATE);
+            fft_plan.m_plan = fftw_plan_r2r_2d(
+                    real_size[1], real_size[0], real_array, complex_array, FFTW_RODFT00, FFTW_RODFT00, FFTW_ESTIMATE);
         } else if (dir == direction::C2R){
-            fft_plan.m_plan = VendorCreatePlanC2R2D(
-                    real_size[1], real_size[0], complex_array, real_array, FFTW_ESTIMATE);
+            fft_plan.m_plan = fftw_plan_r2r_2d(
+                    real_size[1], real_size[0], complex_array, real_array, FFTW_RODFT00, FFTW_RODFT00, FFTW_ESTIMATE);
         }
 
         // Store meta-data in fft_plan


### PR DESCRIPTION
This PR will aim to resolve #130.

It adds the Dirichlet boundary conditions by (instead of doing an FFT) doing a sine transformation and multiplying the outcome with a Dirichlet eigenvalue matrix, before another sine transformation for inversion.

This is work in progress and breaking the GPU implementation.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
