### PR TITLE
Proper number of grid points in the error calculation

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -175,12 +175,10 @@ private:
      * This modifies component FieldComps::Bx and By, of slice 1 in m_fields.m_slices
      * as well as the plasma particle force terms.
      *
-     * \param[in] bx current Box
      * \param[in] islice index of calculated slice
      * \param[in] lev current level
      */
-    void PredictorCorrectorLoopToSolveBxBy (const amrex::Box& bx, const int islice,
-                                            const int lev);
+    void PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev);
 
 };
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -261,7 +261,7 @@ Hipace::Evolve ()
                 /* Modifies Bx and By in the current slice
                  * and the force terms of the plasma particles
                  */
-                PredictorCorrectorLoopToSolveBxBy(bx, islice, lev);
+                PredictorCorrectorLoopToSolveBxBy(islice, lev);
 
                 m_fields.Copy(lev, islice, FieldCopyType::StoF, 0, 0, FieldComps::nfields);
 
@@ -282,7 +282,7 @@ Hipace::Evolve ()
 }
 
 void
-Hipace::PredictorCorrectorLoopToSolveBxBy (const amrex::Box& bx, const int islice, const int lev)
+Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev)
 {
     HIPACE_PROFILE("Hipace::PredictorCorrectorLoopToSolveBxBy()");
 
@@ -292,7 +292,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const amrex::Box& bx, const int islic
         m_fields.getSlices(lev, WhichSlice::Previous1),
         m_fields.getSlices(lev, WhichSlice::Previous2),
         m_fields.getSlices(lev, WhichSlice::Previous2),
-        FieldComps::Bx, FieldComps::By,FieldComps::Bx, FieldComps::By, bx, lev);
+        FieldComps::Bx, FieldComps::By,FieldComps::Bx, FieldComps::By, Geom(lev), lev);
 
     /* Guess Bx and By */
     m_fields.InitialBfieldGuess(relative_Bfield_error, m_predcorr_B_error_tolerance, lev);
@@ -363,7 +363,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const amrex::Box& bx, const int islic
                                                m_fields.getSlices(lev, WhichSlice::This),
                                                m_fields.getSlices(lev, WhichSlice::This),
                                                Bx_iter, By_iter, FieldComps::Bx,
-                                               FieldComps::By, 0, 0, bx, lev);
+                                               FieldComps::By, 0, 0, Geom(lev), lev);
 
         if (i_iter == 1) relative_Bfield_error_prev_iter = relative_Bfield_error;
 

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -185,14 +185,14 @@ public:
      *            (usually either FieldComps::Bx or 0)
      * \param[in] By_iter_comp component of the By field of the previous iteration in the MultiFab
      *            (usually either FieldComps::By or 0)
-     * \param[in] bx current Box
+     * \param[in] geom Geometry of the problem
      * \param[in] lev current level
      */
     amrex::Real ComputeRelBFieldError (const amrex::MultiFab& Bx, const amrex::MultiFab& By,
                                        const amrex::MultiFab& Bx_iter,
                                        const amrex::MultiFab& By_iter, const int Bx_comp,
                                        const int By_comp, const int Bx_iter_comp,
-                                       const int By_iter_comp, const amrex::Box& bx,
+                                       const int By_iter_comp, const amrex::Geometry& geom,
                                        const int lev);
 
 private:

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -486,7 +486,7 @@ amrex::Real
 Fields::ComputeRelBFieldError (
     const amrex::MultiFab& Bx, const amrex::MultiFab& By, const amrex::MultiFab& Bx_iter,
     const amrex::MultiFab& By_iter, const int Bx_comp, const int By_comp, const int Bx_iter_comp,
-    const int By_iter_comp, const amrex::Box& bx, const int lev)
+    const int By_iter_comp, const amrex::Geometry& geom, const int lev)
 {
     /* calculates the relative B field error between two B fields
      * for both Bx and By simultaneously */
@@ -510,9 +510,11 @@ Fields::ComputeRelBFieldError (
     norm_Bdiff += amrex::MultiFab::Dot(temp, 0, 1, 0);
     norm_Bdiff = sqrt(norm_Bdiff);
 
+    const int numPts_transverse = geom.Domain().length(0) * geom.Domain().length(1);
+
     /* calculating the relative error
      * Warning: this test might be not working in SI units! */
-     const amrex::Real relative_Bfield_error = (norm_B/bx.numPts() > 1e-10)
+     const amrex::Real relative_Bfield_error = (norm_B/numPts_transverse > 1e-10)
                                                 ? norm_Bdiff/norm_B : 0.;
 
     return relative_Bfield_error;


### PR DESCRIPTION
This is a minor bug fix, the average field error on 1 slice was computed based on the number of grid points in the 3d domain, it should be in the 2d domain.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
