### PR TITLE
Expansion and Shrink functions for real data

### DIFF
--- a/src/fields/fft_poisson_solver/CMakeLists.txt
+++ b/src/fields/fft_poisson_solver/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(HiPACE
   PRIVATE
+    FFTPoissonSolverUtil.cpp
     FFTPoissonSolver.cpp
 )
 

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
@@ -2,7 +2,7 @@
 #define FFT_POISSON_SOLVER_UTIL_H_
 
 #include <AMReX_MultiFab.H>
-
+#include "FFTPoissonSolver.H"
 
 /** \brief this function takes an nx*ny multifab src and returns an symmetrized
  * (2nx+2)(2ny+2) array. This prepares the array as an input to a 2D DFT, which
@@ -17,6 +17,19 @@ void
 ExpandRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
                 const int scomp=0, const int dcomp=0);
 
+/** \brief this function takes an nx*ny multifab src and returns an symmetrized
+ * (nx+2)(2ny+2) array. This prepares the array as an input to a 2D DFT, which
+ * yields the same result of the corrensponding 2D DST.
+ * \param[in] src input multifab
+ * \param[in,out] dst symmetrized output multifab
+ * \param[in] geom Geometry
+ * \param[in] scomp source component
+ * \param[in] dcomp destination component
+ */
+void
+ExpandComplexData (const SpectralField src, SpectralField dst, amrex::Geometry const& geom,
+                   const int scomp, const int dcomp);
+
 /** \brief this function takes an (2nx+2)(2ny+2) multifab src and extracts
 *  nx*ny array after a 2D DFT. The returned array is the result of a 2D DST.
 * \param[in] src input multifab
@@ -28,5 +41,17 @@ ExpandRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometr
 void
 ShrinkRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
                 const int scomp=0, const int dcomp=0);
+
+/** \brief this function takes an (nx+2)(2ny+2) multifab src and extracts
+*  nx*ny array after a 2D DFT. The returned array is the result of a 2D DST.
+* \param[in,out] src input multifab
+* \param[in,out] dst symmetrized output multifab
+* \param[in] geom Geometry
+* \param[in] scomp source component
+* \param[in] dcomp destination component
+*/
+void
+ShrinkComplexData (const SpectralField src, SpectralField dst, amrex::Geometry const& geom,
+                   const int scomp=0, const int dcomp=0);
 
 #endif

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
@@ -26,7 +26,7 @@ ExpandDataForDST (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geome
 * \param[in] dcomp destination component
 */
 void
-ShrinkDataForDST (const SpectralField src, amrex::MultiFab& dst,
-                  const int scomp=0, const int dcomp=0);
+ExtractDataForDST (const SpectralField src, amrex::MultiFab& dst,
+                   const int scomp=0, const int dcomp=0);
 
 #endif

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
@@ -1,0 +1,32 @@
+#ifndef FFT_POISSON_SOLVER_UTIL_H_
+#define FFT_POISSON_SOLVER_UTIL_H_
+
+#include <AMReX_MultiFab.H>
+
+
+/** \brief this function takes an nx*ny multifab src and returns an symmetrized
+ * (2nx+2)(2ny+2) array. This prepares the array as an input to a 2D DFT, which
+ * yields the same result of the corrensponding 2D DST.
+ * \param[in] src input multifab
+ * \param[in,out] dst symmetrized output multifab
+ * \param[in] geom Geometry
+ * \param[in] scomp source component
+ * \param[in] dcomp destination component
+ */
+void
+ExpandRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
+                const int scomp=0, const int dcomp=0);
+
+/** \brief this function takes an (2nx+2)(2ny+2) multifab src and extracts
+*  nx*ny array after a 2D DFT. The returned array is the result of a 2D DST.
+* \param[in] src input multifab
+* \param[in,out] dst symmetrized output multifab
+* \param[in] geom Geometry
+* \param[in] scomp source component
+* \param[in] dcomp destination component
+*/
+void
+ShrinkRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
+                const int scomp=0, const int dcomp=0);
+
+#endif

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.H
@@ -14,44 +14,19 @@
  * \param[in] dcomp destination component
  */
 void
-ExpandRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
-                const int scomp=0, const int dcomp=0);
+ExpandDataForDST (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
+                  const int scomp=0, const int dcomp=0);
 
-/** \brief this function takes an nx*ny multifab src and returns an symmetrized
- * (nx+2)(2ny+2) array. This prepares the array as an input to a 2D DFT, which
- * yields the same result of the corrensponding 2D DST.
- * \param[in] src input multifab
- * \param[in,out] dst symmetrized output multifab
- * \param[in] geom Geometry
- * \param[in] scomp source component
- * \param[in] dcomp destination component
- */
-void
-ExpandComplexData (const SpectralField src, SpectralField dst, amrex::Geometry const& geom,
-                   const int scomp, const int dcomp);
 
 /** \brief this function takes an (2nx+2)(2ny+2) multifab src and extracts
 *  nx*ny array after a 2D DFT. The returned array is the result of a 2D DST.
-* \param[in] src input multifab
-* \param[in,out] dst symmetrized output multifab
-* \param[in] geom Geometry
+* \param[in] src input spectral multifab
+* \param[in,out] dst extracted output. This is the true result of the DST
 * \param[in] scomp source component
 * \param[in] dcomp destination component
 */
 void
-ShrinkRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
-                const int scomp=0, const int dcomp=0);
-
-/** \brief this function takes an (nx+2)(2ny+2) multifab src and extracts
-*  nx*ny array after a 2D DFT. The returned array is the result of a 2D DST.
-* \param[in,out] src input multifab
-* \param[in,out] dst symmetrized output multifab
-* \param[in] geom Geometry
-* \param[in] scomp source component
-* \param[in] dcomp destination component
-*/
-void
-ShrinkComplexData (const SpectralField src, SpectralField dst, amrex::Geometry const& geom,
-                   const int scomp=0, const int dcomp=0);
+ShrinkDataForDST (const SpectralField src, amrex::MultiFab& dst,
+                  const int scomp=0, const int dcomp=0);
 
 #endif

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.cpp
@@ -6,7 +6,7 @@ void
 ExpandRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
                 const int scomp, const int dcomp)
 {
-    HIPACE_PROFILE("ExpandRealData");
+    HIPACE_PROFILE("ExpandRealData()");
     /* This function takes an nx*ny grid point multifab src as input and returns
      * a (2nx+2)*(2ny+2) multifab dst, where the data of src is symmetrized, so
      * dst is odd around 0 and the midpoint in both dimensions.
@@ -38,10 +38,42 @@ ExpandRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometr
 }
 
 void
+ExpandComplexData (const SpectralField src, SpectralField dst, amrex::Geometry const& geom,
+                   const int scomp, const int dcomp)
+{
+    HIPACE_PROFILE("ExpandComplexData()");
+    /* This function takes an nx*ny grid point multifab src as input and returns
+     * a (nx+2)*(2ny+2) multifab dst, where the data of src is symmetrized, so
+     * dst is odd around 0 and the midpoint in y-direction.
+     * This is necessary  before a 2D discrete fourtier transform to achieve the same result
+     * as a 2D discrete sine transform */
+
+    const int nx = geom.Domain().length(0);
+    const int ny = geom.Domain().length(1);
+
+    for ( amrex::MFIter mfi(src, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
+        const amrex::Box& bx = mfi.tilebox();
+        amrex::Array4<amrex::GpuComplex<amrex::Real> const> src_array = src.array(mfi);
+        amrex::Array4<amrex::GpuComplex<amrex::Real>> dst_array = dst.array(mfi);
+        amrex::ParallelFor(
+            bx,
+            [=] AMREX_GPU_DEVICE(int i, int j, int k)
+            {
+                /* upper left quadrant */
+                dst_array(i+1,j+1,k,dcomp) = src_array(i, j, k, scomp);
+                /* lower left quadrant */
+                dst_array(i+1,j+ny+2,k,dcomp) = -src_array(i, ny-1-j, k, scomp);
+            }
+            );
+    }
+}
+
+
+void
 ShrinkRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
                 const int scomp, const int dcomp)
 {
-    HIPACE_PROFILE("ShrinkRealData");
+    HIPACE_PROFILE("ShrinkRealData()");
     /* This function takes an (2nx+2)*(2ny+2) grid point multifab src as input and returns
      * an nx*ny multifab dst, where the data from the src is extracted assuming symmetry.
      * This is necessary after a 2D discrete fourtier transform to achieve the same result
@@ -54,6 +86,35 @@ ShrinkRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometr
         const amrex::Box& bx = mfi.tilebox();
         amrex::Array4<amrex::Real const> const & src_array = src.array(mfi);
         amrex::Array4<amrex::Real> const & dst_array = dst.array(mfi);
+        amrex::ParallelFor(
+            bx,
+            [=] AMREX_GPU_DEVICE(int i, int j, int k)
+            {
+                /* upper left quadrant */
+                dst_array(i,j,k,dcomp) = -src_array(i+1, j+1, k, scomp);
+            }
+            );
+    }
+}
+
+
+void
+ShrinkComplexData (const SpectralField src, SpectralField dst, amrex::Geometry const& geom,
+                   const int scomp, const int dcomp)
+{
+    HIPACE_PROFILE("ShrinkComplexData()");
+    /* This function takes an (2nx+2)*(2ny+2) grid point multifab src as input and returns
+     * an nx*ny multifab dst, where the data from the src is extracted assuming symmetry.
+     * This is necessary after a 2D discrete fourtier transform to achieve the same result
+     *  as a 2D discrete sine transform */
+
+    const int nx = geom.Domain().length(0);
+    const int ny = geom.Domain().length(1);
+
+    for ( amrex::MFIter mfi(dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
+        const amrex::Box& bx = mfi.tilebox();
+        amrex::Array4<amrex::GpuComplex<amrex::Real> const> src_array = src.array(mfi);
+        amrex::Array4<amrex::GpuComplex<amrex::Real>> dst_array = dst.array(mfi);
         amrex::ParallelFor(
             bx,
             [=] AMREX_GPU_DEVICE(int i, int j, int k)

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.cpp
@@ -39,10 +39,10 @@ ExpandDataForDST (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geome
 
 
 void
-ShrinkDataForDST (const SpectralField src, amrex::MultiFab& dst,
-                  const int scomp, const int dcomp)
+ExtractDataForDST (const SpectralField src, amrex::MultiFab& dst,
+                   const int scomp, const int dcomp)
 {
-    HIPACE_PROFILE("ShrinkDataForDST()");
+    HIPACE_PROFILE("ExtractDataForDST()");
     /* This function takes an (2nx+2)*(2ny+2) grid point multifab src as input and returns
      * an nx*ny multifab dst, where the data from the src is extracted assuming symmetry.
      * This is necessary after a 2D discrete fourtier transform to achieve the same result

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverUtil.cpp
@@ -1,0 +1,66 @@
+#include "FFTPoissonSolverUtil.H"
+#include "HipaceProfilerWrapper.H"
+#include <AMReX_GpuComplex.H>
+
+void
+ExpandRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
+                const int scomp, const int dcomp)
+{
+    HIPACE_PROFILE("ExpandRealData");
+    /* This function takes an nx*ny grid point multifab src as input and returns
+     * a (2nx+2)*(2ny+2) multifab dst, where the data of src is symmetrized, so
+     * dst is odd around 0 and the midpoint in both dimensions.
+     * This is necessary  before a 2D discrete fourtier transform to achieve the same result
+     * as a 2D discrete sine transform */
+
+    const int nx = geom.Domain().length(0);
+    const int ny = geom.Domain().length(1);
+
+    for ( amrex::MFIter mfi(src, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
+        const amrex::Box& bx = mfi.tilebox();
+        amrex::Array4<amrex::Real const> const & src_array = src.array(mfi);
+        amrex::Array4<amrex::Real> const & dst_array = dst.array(mfi);
+        amrex::ParallelFor(
+            bx,
+            [=] AMREX_GPU_DEVICE(int i, int j, int k)
+            {
+                /* upper left quadrant */
+                dst_array(i+1,j+1,k,dcomp) = src_array(i, j, k, scomp);
+                /* lower left quadrant */
+                dst_array(i+1,j+ny+2,k,dcomp) = -src_array(i, ny-1-j, k, scomp);
+                /* upper right quadrant */
+                dst_array(i+nx+2,j+1,k,dcomp) = -src_array(nx-1-i, j, k, scomp);
+                /* lower right quadrant */
+                dst_array(i+nx+2,j+ny+2,k,dcomp) = src_array(nx-1-i, ny-1-j, k, scomp);
+            }
+            );
+    }
+}
+
+void
+ShrinkRealData (const amrex::MultiFab& src, amrex::MultiFab& dst, amrex::Geometry const& geom,
+                const int scomp, const int dcomp)
+{
+    HIPACE_PROFILE("ShrinkRealData");
+    /* This function takes an (2nx+2)*(2ny+2) grid point multifab src as input and returns
+     * an nx*ny multifab dst, where the data from the src is extracted assuming symmetry.
+     * This is necessary after a 2D discrete fourtier transform to achieve the same result
+     *  as a 2D discrete sine transform */
+
+    const int nx = geom.Domain().length(0);
+    const int ny = geom.Domain().length(1);
+
+    for ( amrex::MFIter mfi(dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
+        const amrex::Box& bx = mfi.tilebox();
+        amrex::Array4<amrex::Real const> const & src_array = src.array(mfi);
+        amrex::Array4<amrex::Real> const & dst_array = dst.array(mfi);
+        amrex::ParallelFor(
+            bx,
+            [=] AMREX_GPU_DEVICE(int i, int j, int k)
+            {
+                /* upper left quadrant */
+                dst_array(i,j,k,dcomp) = -src_array(i+1, j+1, k, scomp);
+            }
+            );
+    }
+}


### PR DESCRIPTION
This PR is part of the preparation for #157. 

The discrete sine transformation (DST) is a R2R operation. Unfortunately, it is not provided by nvidia. However, one can extract a DST from a discrete Fourier transformation (DFT). To do that, the `nx*ny` input array needs to be expanded to size 
`(2nx+2)(2ny+2)` so it is odd around 0 and the middle points. After the DFT, the results of the corresponding DST can be extracted. This is done with `ExtractDataForDST()`.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
