### PR TITLE
Forget about assert_exit, python assert work well

### DIFF
--- a/examples/beam_in_vacuum/analysis.py
+++ b/examples/beam_in_vacuum/analysis.py
@@ -35,11 +35,6 @@ parser.add_argument('--do-plot',
 
 args = parser.parse_args()
 
-
-def assert_exit(condition):
-    if not condition:
-        sys.exit(1)
-
 ds = AMReXDataset('plt00001')
 
 if args.norm_units:
@@ -157,7 +152,6 @@ if args.do_plot:
 error_jz = np.sum((jz_sim-jz_th)**2) / np.sum((jz_th)**2)
 print("total relative error jz: " + str(error_jz) + " (tolerance = 0.1)")
 
-# Assert that the simulation result is close enough to theory
 error_rho = np.sum((rho_sim-rho_th)**2) / np.sum((rho_th)**2)
 print("total relative error rho: " + str(error_rho) + " (tolerance = 0.1)")
 
@@ -173,9 +167,9 @@ print("total relative error Ex: " + str(error_Ex) + " (tolerance = 0.01)")
 error_Ey = np.sum((Ey_sim-Ey_th)**2) / np.sum((Ey_th)**2)
 print("total relative error Ey: " + str(error_Ey) + " (tolerance = 0.002)")
 
-assert_exit(error_jz < .1)
-assert_exit(error_rho < .1)
-assert_exit(error_Bx < .002)
-assert_exit(error_By < .01)
-assert_exit(error_Ex < .01)
-assert_exit(error_Ey < .002)
+assert(error_jz < .1)
+assert(error_rho < .1)
+assert(error_Bx < .002)
+assert(error_By < .01)
+assert(error_Ex < .01)
+assert(error_Ey < .002)

--- a/examples/blowout_wake/analysis.py
+++ b/examples/blowout_wake/analysis.py
@@ -23,12 +23,6 @@ import math
 
 import argparse
 
-def assert_exit(condition):
-    try:
-        assert(condition)
-    except AssertionError:
-        sys.exit(1)
-
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--normalized-data',
                     dest='norm_data',
@@ -80,4 +74,4 @@ if args.do_plot:
 # Assert that the simulation result is close enough to theory
 error_Ez = np.sum((Ez_along_z_si/E_0-Ez_along_z_norm)**2) / np.sum((Ez_along_z_norm)**2)
 print("total relative error Ez: " + str(error_Ez) + " (tolerance = 1e-10)")
-assert_exit(error_Ez < 1e-10)
+assert(error_Ez < 1e-10)

--- a/examples/linear_wake/analysis.py
+++ b/examples/linear_wake/analysis.py
@@ -23,12 +23,6 @@ import math
 
 import argparse
 
-def assert_exit(condition):
-    try:
-        assert(condition)
-    except AssertionError:
-        sys.exit(1)
-
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--normalized-units',
                     dest='norm_units',
@@ -98,4 +92,4 @@ if args.do_plot:
 # Assert that the simulation result is close enough to theory
 error_rho = np.sum((rho_along_z-rho_th)**2) / np.sum((rho_th)**2)
 print("total relative error rho: " + str(error_rho) + " (tolerance = 0.01)")
-assert_exit(error_rho < .01)
+assert(error_rho < .01)


### PR DESCRIPTION
- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
