### PR TITLE
Add virtual destructor to abstract class

### DIFF
--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -19,7 +19,11 @@ class FFTPoissonSolver
 {
 public:
 
+    /** Default constructor */
     FFTPoissonSolver () = default;
+
+    /** Abstract class needs a virtual destructor */
+    virtual ~FFTPoissonSolver () = 0;
 
     /**
      * \brief Define real space and spectral space boxes and multifabs, multiplier

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
@@ -1,5 +1,8 @@
 #include "FFTPoissonSolver.H"
 
+FFTPoissonSolver::~FFTPoissonSolver ()
+{};
+
 amrex::MultiFab&
 FFTPoissonSolver::StagingArea ()
 {

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.H
@@ -16,12 +16,16 @@
  * 2. Call FFTPoissonSolver::SolvePoissonEquation(mf), which will solve Poisson equation with RHS
  *    in the staging area and return the LHS in mf.
  */
-class FFTPoissonSolverDirichlet : public FFTPoissonSolver
+class FFTPoissonSolverDirichlet final : public FFTPoissonSolver
 {
 public:
+    /** Constructor */
     FFTPoissonSolverDirichlet ( amrex::BoxArray const& realspace_ba,
                                 amrex::DistributionMapping const& dm,
                                 amrex::Geometry const& gm);
+
+    /** virtual destructor */
+    virtual ~FFTPoissonSolverDirichlet () override final {}
 
     /**
      * \brief Define real space and spectral space boxes and multifabs, Dirichlet

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
@@ -19,12 +19,16 @@ using SpectralField = amrex::FabArray< amrex::BaseFab <amrex::GpuComplex<amrex::
  * 2. Call FFTPoissonSolver::SolvePoissonEquation(mf), which will solve Poisson equation with RHS
  *    in the staging area and return the LHS in mf.
  */
-class FFTPoissonSolverPeriodic : public FFTPoissonSolver
+class FFTPoissonSolverPeriodic final : public FFTPoissonSolver
 {
 public:
+    /** Constructor */
     FFTPoissonSolverPeriodic ( amrex::BoxArray const& realspace_ba,
                                amrex::DistributionMapping const& dm,
-                               amrex::Geometry const& gm);// :
+                               amrex::Geometry const& gm);
+
+    /** virtual destructor */
+    virtual ~FFTPoissonSolverPeriodic () override final {}
 
     /**
      * \brief Define real space and spectral space boxes and multifabs, multiplier


### PR DESCRIPTION
Since commit https://github.com/Hi-PACE/hipace/commit/36f87055c88ee258ff0f7da387d7aeb7cc290bf2, I could not run Hipace++ a MacOS laptop: it compiled fine with Clang but the run crashed with error (litterally 1 line, nothing more)
```
% ./hipace inputs_normalized 
AMReX (20.09-63-g3cad68f7a504) initialized
zsh: illegal hardware instruction  ~/hipace/build/bin/hipace inputs_normalized
%
```
Compiling in debug mode didn't change anything, so I struggled to find the issue. However, one of the compilation warnings was
```
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/memory:2368:5: warning: delete called on 'FFTPoissonSolver' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
    delete __ptr;
```
Fixing this warning also fixed my runtime issue. Provided this is not a random behaviour hiding sth else, this is an example of how having a clean compilation (without 1000 unreadable warnings) can help (@RemiLehe @ax3l may be interested).

This PR adds the missing destructors, as well as a few comments. The most important one is `FFTPoissonSolver::~FFTPoissonSolver `.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
