### PR TITLE
Handling of plasma particles violating the quasi-static approximation

### DIFF
--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -49,9 +49,9 @@ public:
         const amrex::RealBox& a_bounds);
 
     amrex::Real m_density {0}; /**< Density of the plasma */
-    amrex::Real m_max_gamma_per_psi_p_1 {35.}; /**< maximum weighting factor gamma/(Psi +1) before
-                                                * particle is regarded as violating the
-                                                * quasi-static approximation and is removed */
+    /** maximum weighting factor gamma/(Psi +1) before particle is regarded as violating
+     *  the quasi-static approximation and is removed */
+    amrex::Real m_max_qsa_weighting_factor {35.};
     amrex::Real m_radius {std::numeric_limits<amrex::Real>::infinity()}; /**< radius of the plasma */
     amrex::IntVect m_ppc {0,0,1}; /**< Number of particles per cell in each direction */
     amrex::RealVect m_u_mean {0,0,0}; /**< Avg momentum in each direction normalized by m*c */

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -6,7 +6,7 @@ PlasmaParticleContainer::PlasmaParticleContainer (amrex::AmrCore* amr_core)
     amrex::ParmParse pp("plasma");
     pp.query("density", m_density);
     pp.query("radius", m_radius);
-    pp.query("max_gamma_per_psi_p_1", m_max_gamma_per_psi_p_1);
+    pp.query("max_qsa_weighting_factor", m_max_qsa_weighting_factor);
     amrex::Vector<amrex::Real> tmp_vector;
     if (pp.queryarr("ppc", tmp_vector)){
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(tmp_vector.size() == AMREX_SPACEDIM-1,

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -26,7 +26,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
 
     PhysConst phys_const = get_phys_const();
 
-    const amrex::Real max_gamma_per_psi_p_1 = plasma.m_max_gamma_per_psi_p_1;
+    const amrex::Real max_qsa_weighting_factor = plasma.m_max_qsa_weighting_factor;
 
     // Loop over particle boxes
     for (PlasmaParticleIterator pti(plasma, lev); pti.isValid(); ++pti)
@@ -58,22 +58,22 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
                 doDepositionShapeN<0, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, temp_slice,
                                           deposit_jx_jy, deposit_jz, deposit_rho,
-                                          max_gamma_per_psi_p_1);
+                                          max_qsa_weighting_factor);
         } else if (Hipace::m_depos_order_xy == 1){
                 doDepositionShapeN<1, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, temp_slice,
                                           deposit_jx_jy, deposit_jz, deposit_rho,
-                                          max_gamma_per_psi_p_1);
+                                          max_qsa_weighting_factor);
         } else if (Hipace::m_depos_order_xy == 2){
                 doDepositionShapeN<2, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, temp_slice,
                                           deposit_jx_jy, deposit_jz, deposit_rho,
-                                          max_gamma_per_psi_p_1);
+                                          max_qsa_weighting_factor);
         } else if (Hipace::m_depos_order_xy == 3){
                 doDepositionShapeN<3, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, temp_slice,
                                           deposit_jx_jy, deposit_jz, deposit_rho,
-                                          max_gamma_per_psi_p_1);
+                                          max_qsa_weighting_factor);
         } else {
             amrex::Abort("unknow deposition order");
         }

--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -40,7 +40,7 @@
  * \param[in] deposit_jx_jy if true, deposit to jx and jy
  * \param[in] deposit_jz if true, deposit to jz
  * \param[in] deposit_rho if true, deposit to rho
- * \param[in] max_gamma_per_psi_p_1 maximum allowed weighting factor gamma/(Psi+1)
+ * \param[in] max_qsa_weighting_factor maximum allowed weighting factor gamma/(Psi+1)
  */
 template <int depos_order_xy, int depos_order_z>
 void doDepositionShapeN (const PlasmaParticleIterator& pti,
@@ -54,7 +54,7 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
                          amrex::Real const q,
                          const bool temp_slice,
                          const bool deposit_jx_jy, const bool deposit_jz, const bool deposit_rho,
-                         const amrex::Real max_gamma_per_psi_p_1)
+                         const amrex::Real max_qsa_weighting_factor)
 {
     using namespace amrex::literals;
 
@@ -112,60 +112,62 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
                                                                   + uyp[ip]*uyp[ip]*clightsq
                                                                   + (psi+1.0_rt)*(psi+1.0_rt));
 
-            if (( 1.0_rt/(gaminv*(psi+1)) > 0.0_rt) &&
-                ( 1.0_rt/(gaminv*(psi+1)) < max_gamma_per_psi_p_1))
+            if (( 1.0_rt/(gaminv*(psi+1.0_rt)) < 0.0_rt) ||
+                 ( 1.0_rt/(gaminv*(psi+1.0_rt)) > max_qsa_weighting_factor))
             {
-                // calculate plasma particle velocities
-                const amrex::Real vx = uxp[ip]*gaminv;
-                const amrex::Real vy = uyp[ip]*gaminv;
-                const amrex::Real vz = - psi * phys_const.c * gaminv;
+                 // This particle violates the QSA, discard it and do not deposit its current
+                 pos_structs[ip].id() = -1;
+                 return;
+            }
+            // calculate plasma particle velocities
+            const amrex::Real vx = uxp[ip]*gaminv;
+            const amrex::Real vy = uyp[ip]*gaminv;
+            const amrex::Real vz = - psi * phys_const.c * gaminv;
 
-                // calculate charge of the plasma particles
-                const amrex::Real wq = q*wp[ip]/(gaminv * (psi + 1.0_rt))*invvol;
+            // calculate charge of the plasma particles
+            const amrex::Real wq = q*wp[ip]/(gaminv * (psi + 1.0_rt))*invvol;
 
-                // wqx, wqy wqz are particle current in each direction
-                const amrex::Real wqx = wq*vx;
-                const amrex::Real wqy = wq*vy;
-                const amrex::Real wqz = wq*vz;
+            // wqx, wqy wqz are particle current in each direction
+            const amrex::Real wqx = wq*vx;
+            const amrex::Real wqy = wq*vy;
+            const amrex::Real wqz = wq*vz;
 
-                // --- Compute shape factors
-                // x direction
-                // j_cell leftmost cell in x that the particle touches. sx_cell shape factor along x
-                const amrex::Real xmid = (pos_structs[ip].pos(0) - xmin)*dxi;
-                amrex::Real sx_cell[depos_order_xy + 1];
-                const int j_cell = compute_shape_factor<depos_order_xy>(sx_cell, xmid - 0.5_rt);
+            // --- Compute shape factors
+            // x direction
+            // j_cell leftmost cell in x that the particle touches. sx_cell shape factor along x
+            const amrex::Real xmid = (pos_structs[ip].pos(0) - xmin)*dxi;
+            amrex::Real sx_cell[depos_order_xy + 1];
+            const int j_cell = compute_shape_factor<depos_order_xy>(sx_cell, xmid - 0.5_rt);
 
-                // y direction
-                const amrex::Real ymid = (pos_structs[ip].pos(1) - ymin)*dyi;
-                amrex::Real sy_cell[depos_order_xy + 1];
-                const int k_cell = compute_shape_factor<depos_order_xy>(sy_cell, ymid - 0.5_rt);
+            // y direction
+            const amrex::Real ymid = (pos_structs[ip].pos(1) - ymin)*dyi;
+            amrex::Real sy_cell[depos_order_xy + 1];
+            const int k_cell = compute_shape_factor<depos_order_xy>(sy_cell, ymid - 0.5_rt);
 
-                // Deposit current into jx_arr, jy_arr and jz_arr
-                for (int iy=0; iy<=depos_order_xy; iy++){
-                    for (int ix=0; ix<=depos_order_xy; ix++){
-                        if (deposit_jx_jy) {
-                            amrex::Gpu::Atomic::Add(
-                                &jx_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
-                                sx_cell[ix]*sy_cell[iy]*wqx);
-                            amrex::Gpu::Atomic::Add(
-                                &jy_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
-                                sx_cell[ix]*sy_cell[iy]*wqy);
-                        }
-                        if (deposit_jz) {
-                            amrex::Gpu::Atomic::Add(
-                                &jz_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
-                                sx_cell[ix]*sy_cell[iy]*wqz);
-                        }
-                        if (deposit_rho) {
-                            amrex::Gpu::Atomic::Add(
-                                &rho_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
-                                sx_cell[ix]*sy_cell[iy]*wq);
-                        }
+            // Deposit current into jx_arr, jy_arr and jz_arr
+            for (int iy=0; iy<=depos_order_xy; iy++){
+                for (int ix=0; ix<=depos_order_xy; ix++){
+                    if (deposit_jx_jy) {
+                        amrex::Gpu::Atomic::Add(
+                            &jx_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
+                            sx_cell[ix]*sy_cell[iy]*wqx);
+                        amrex::Gpu::Atomic::Add(
+                            &jy_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
+                            sx_cell[ix]*sy_cell[iy]*wqy);
+                    }
+                    if (deposit_jz) {
+                        amrex::Gpu::Atomic::Add(
+                            &jz_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
+                            sx_cell[ix]*sy_cell[iy]*wqz);
+                    }
+                    if (deposit_rho) {
+                        amrex::Gpu::Atomic::Add(
+                            &rho_arr(lo.x+j_cell+ix, lo.y+k_cell+iy, 0),
+                            sx_cell[ix]*sy_cell[iy]*wq);
                     }
                 }
-            } else { // if (( 1.0_rt/(gaminv*psi) > 0.0_rt) && ( 1.0_rt/(gaminv*psi) > 35.0_rt))
-                pos_structs[ip].id() = -1;
             }
+            return;
         }
         );
 }


### PR DESCRIPTION
This PR resolves #106.

If particles get relativistic, they violate the quasi-static approximation, which claims that the plasma particles and the beam evolve on a different time scale. The longitudinal momentum of the plasma particles is taken into account via the weighting factor `gamma/(Psi + 1)`. If this weighting factor gets too big, the results are non-physical and the simulation crashes.

Particles, which violate the QSA are removed.
The default value for the weighting factor is 35 (as in HiPACE-C), but can be changed as an input parameter `plasma.max_gamma_per_psi_p_1`

Setting the value to low (e.g. 1) removes all plasma particles.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
