### PR TITLE
Remove guard cells in the 3D array

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -580,6 +580,9 @@ Hipace::WriteDiagnostics (int output_step, bool force_output)
 
     // Write plasma particles
     {
+        amrex::ParallelContext::push(m_comm_xy);
+        m_plasma_container.Redistribute();
+        amrex::ParallelContext::pop();
         amrex::Vector<int> plot_flags(PlasmaIdx::nattribs, 1);
         amrex::Vector<int> int_flags(PlasmaIdx::nattribs, 1);
         amrex::Vector<std::string> real_names {

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -210,8 +210,6 @@ private:
     amrex::Vector<amrex::MultiFab> m_F;
     /** Vector over levels, array of 4 slices required to compute current slice */
     amrex::Vector<std::array<amrex::MultiFab, m_nslices>> m_slices;
-    /** Number of guard cells for main MultiFab */
-    amrex::IntVect m_nguards {-1, -1, -1};
     /** Number of guard cells for slices MultiFab */
     amrex::IntVect m_slices_nguards {-1, -1, -1};
     /** Whether to use Dirichlet BC for the Poisson solver. Otherwise, periodic */


### PR DESCRIPTION
This PR proposes to remove the guard cells of the 3D array. This array is mostly here to store data for IO, so it doesn't need guard cells.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
