### PR TITLE
[DO NOT MERGE] CI: Add Sanitizers

### DIFF
--- a/.github/ci/sanitizer/Leak.supp
+++ b/.github/ci/sanitizer/Leak.supp
@@ -1,0 +1,8 @@
+# OpenMPI 2.1.1 Memory Leaks
+leak:mca_io_ompi*
+leak:mca_pmix_pmix*
+leak:libopen-pal*
+leak:libopen-rte*
+leak:libmpi*
+# FFTW 3.3.7 Memory Leaks
+leak:libfftw3*

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,8 +22,8 @@ jobs:
 #        ctest --output-on-failure
 #        make install
 
-  linux_gcc_cxx17_omp_ompi:
-    name: GNU@7.5 C++17 OMP OMPI
+  linux_gcc_cxx17_omp_ompi_asan_ubsan:
+    name: GNU@7.5 C++17 OMP OMPI ASAN UBSAN
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +33,7 @@ jobs:
       run: |
         mkdir build
         cd build
+        export CXXFLAGS="-fsanitize=address,undefined"
         cmake ..                                   \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-hipace  \
             -DCMAKE_CXX_STANDARD=17

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,9 +31,12 @@ jobs:
       run: .github/workflows/setup/ubuntu_ompi.sh
     - name: Build & Install
       run: |
+        export CXXFLAGS="-fsanitize=address,undefined"
+        export ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1:fast_unwind_on_malloc=0
+        export LSAN_OPTIONS=suppressions=$PWD/.github/ci/sanitizer/Leak.supp
+
         mkdir build
         cd build
-        export CXXFLAGS="-fsanitize=address,undefined"
         cmake ..                                   \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-hipace  \
             -DCMAKE_CXX_STANDARD=17


### PR DESCRIPTION
This adds [address and undefined behavior sanitizers](https://github.com/google/sanitizers/wiki) (lingo: ASAN and UBSAN), which will checks things on CPU like out-of-bounds access, uninitialized memory, memory lifetime issues (use-after-free, etc.), memory leaks and other sources of C++ memory violations and undefined behavior at runtime in tests.

Sanitizers do not require debug mode for these checks, are faster and have a significantly lower false-positive rate than running with valgrind, but still add overall compile and runtime overhead for the tests.

CI Time:

|x | before | now |
|--|--|--|
|overall | ~8:20 | ~23:40 |
|build & run | ~7:25 | ~22:50 |

We can keep this PR open until we have open-source (free) CI time. Then we run this on a selected build matrix entry.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU**: no, this checks the CPU path of our code
- [x] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
