### PR TITLE
[mini] disable check for divergence of predictor corrector loop for fixed number of iterations

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -425,7 +425,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev)
     /* resetting the particle position after they have been pushed to the next slice */
     ResetPlasmaParticles(m_plasma_container, lev);
 
-    if (relative_Bfield_error > 10.)
+    if (relative_Bfield_error > 10. && m_predcorr_B_error_tolerance > 0.)
     {
         amrex::Abort("Predictor corrector loop diverged!\n"
                      "Re-try by adjusting the following paramters in the input script:\n"


### PR DESCRIPTION
Originally, there is a safeguard for the divergence of the predictor corrector loop. It triggers, if the relative B field error > 10. 
However, if one uses a fixed number of iterations and a higher mixing factor (the standard setting in QuickPIC), the error might be above 10 for a single slice.
In this mini PR, the safeguard is only activated if the B field error tolerance > 0. Using a B field error tolerance < 0 enables a fixed number of iterations. The safeguard did not trigger, although the B field error was 11 for one slice.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
