### PR TITLE
[mini] add doxygen documentation for beam slice deposition

### DIFF
--- a/src/particles/deposition/BeamDepositCurrent.H
+++ b/src/particles/deposition/BeamDepositCurrent.H
@@ -17,6 +17,14 @@ void
 DepositCurrent (BeamParticleContainer& beam, Fields& fields,
                 amrex::Geometry const& gm, int const lev);
 
+/** Depose current of beam particles on a single slice
+ * \param[in] beam species of which the current is deposited
+ * \param[in,out] fields the general field class, modified by this function
+ * \param[in] gm Geometry of the simulation, to get the cell size etc.
+ * \param[in] lev MR level
+ * \param[in] islice index of the slice on which the beam particles are pushed
+ * \param[in] bins beam particle container bins, to push only the beam particles on slice islice
+ */
 void
 DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
                      amrex::Geometry const& gm, int const lev, const int islice,


### PR DESCRIPTION
This mini PR adds the missing documentation to the beam current deposition on a slice.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
