### PR TITLE
Fixing bug with initialization of arrays

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -338,6 +338,8 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev)
     amrex::MultiFab By_iter(m_fields.getSlices(lev, WhichSlice::This).boxArray(),
                             m_fields.getSlices(lev, WhichSlice::This).DistributionMap(), 1,
                             m_fields.getSlices(lev, WhichSlice::This).nGrowVect());
+    Bx_iter.setVal(0.0);
+    By_iter.setVal(0.0);
     amrex::MultiFab Bx_prev_iter(m_fields.getSlices(lev, WhichSlice::This).boxArray(),
                                  m_fields.getSlices(lev, WhichSlice::This).DistributionMap(), 1,
                                  m_fields.getSlices(lev, WhichSlice::This).nGrowVect());

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
@@ -39,6 +39,8 @@ FFTPoissonSolverDirichlet::define ( amrex::BoxArray const& realspace_ba,
     // These arrays will store the data just before/after the FFT
     m_stagingArea = amrex::MultiFab(realspace_ba, dm, 1, 0);
     m_tmpSpectralField = amrex::MultiFab(m_spectralspace_ba, dm, 1, 0);
+    m_stagingArea.setVal(0.0);
+    m_tmpSpectralField.setVal(0.0);
 
     // This must be true even for parallel FFT.
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stagingArea.local_size() == 1,
@@ -66,9 +68,9 @@ FFTPoissonSolverDirichlet::define ( amrex::BoxArray const& realspace_ba,
             bx, [=] AMREX_GPU_DEVICE (int i, int j, int /* k */) noexcept
                 {
                     /* fast poisson solver diagonal x coeffs */
-                    amrex::Real sinex_sq = pow( sin(( i + 1 ) * sine_x_factor), 2);
+                    amrex::Real sinex_sq = sin(( i + 1 ) * sine_x_factor) * sin(( i + 1 ) * sine_x_factor);
                     /* fast poisson solver diagonal y coeffs */
-                    amrex::Real siney_sq = pow( sin(( j + 1 ) * sine_y_factor), 2);
+                    amrex::Real siney_sq = sin(( j + 1 ) * sine_y_factor) * sin(( j + 1 ) * sine_y_factor);
 
                     if ((sinex_sq!=0) && (siney_sq!=0)) {
                         eigenvalue_matrix(i,j,0) = norm_fac / ( -4.0 * ( sinex_sq / dxsquared + siney_sq / dysquared ));

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
@@ -39,7 +39,7 @@ FFTPoissonSolverDirichlet::define ( amrex::BoxArray const& realspace_ba,
     // These arrays will store the data just before/after the FFT
     m_stagingArea = amrex::MultiFab(realspace_ba, dm, 1, 0);
     m_tmpSpectralField = amrex::MultiFab(m_spectralspace_ba, dm, 1, 0);
-    m_stagingArea.setVal(0.0);
+    m_stagingArea.setVal(0.0); // this is not required
     m_tmpSpectralField.setVal(0.0);
 
     // This must be true even for parallel FFT.

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -67,6 +67,29 @@ namespace AnyDST
             );
     };
 
+    /** \brief set the dst array to 0
+     *
+     * \param[in,out] dst destination array
+     */
+    void SetExpandedPosition (amrex::FArrayBox& dst)
+    {
+        HIPACE_PROFILE("AnyDST::SetExpandedPosition()");
+        constexpr int dcomp = 0;
+
+        const amrex::Box bx = dst.box();
+        const int nx = bx.length(0);
+        const int ny = bx.length(1);
+        amrex::Array4<amrex::Real> const & dst_array = dst.array();
+
+        amrex::ParallelFor(
+            bx,
+            [=] AMREX_GPU_DEVICE(int i, int j, int k)
+            {
+                dst_array(i,j,k,dcomp) = 0.;
+            }
+            );
+    };
+
     DSTplan CreatePlan (const amrex::IntVect& real_size, amrex::FArrayBox* position_array,
                         amrex::FArrayBox* fourier_array)
     {
@@ -113,6 +136,8 @@ namespace AnyDST
     void Execute (DSTplan& dst_plan){
         HIPACE_PROFILE("AnyDST::Execute()");
 
+        // init expanded_position_array with 0s
+        SetExpandedPosition(*dst_plan.m_expanded_position_array);
         // Expand in position space m_position_array -> m_expanded_position_array
         ExpandR2R(*dst_plan.m_expanded_position_array, *dst_plan.m_position_array);
 

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -109,6 +109,12 @@ namespace AnyDST
             std::make_unique<amrex::BaseFab<amrex::GpuComplex<amrex::Real>>>(
                 expanded_fourier_box, 1);
 
+        // setting the initial values to 0
+        // we don't set the expanded Fourier array, because it will be initialized by the FFT
+        dst_plan.m_expanded_position_array->setVal<amrex::RunOn::Device>(0.,
+            dst_plan.m_expanded_position_array->box(), 0,
+            dst_plan.m_expanded_position_array->nComp());
+
         const amrex::IntVect& expanded_size = expanded_position_box.length();
 
         // Initialize fft_plan.m_plan with the vendor fft plan.
@@ -136,8 +142,6 @@ namespace AnyDST
     void Execute (DSTplan& dst_plan){
         HIPACE_PROFILE("AnyDST::Execute()");
 
-        // init expanded_position_array with 0s
-        SetExpandedPosition(*dst_plan.m_expanded_position_array);
         // Expand in position space m_position_array -> m_expanded_position_array
         ExpandR2R(*dst_plan.m_expanded_position_array, *dst_plan.m_position_array);
 

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -67,29 +67,6 @@ namespace AnyDST
             );
     };
 
-    /** \brief set the dst array to 0
-     *
-     * \param[in,out] dst destination array
-     */
-    void SetExpandedPosition (amrex::FArrayBox& dst)
-    {
-        HIPACE_PROFILE("AnyDST::SetExpandedPosition()");
-        constexpr int dcomp = 0;
-
-        const amrex::Box bx = dst.box();
-        const int nx = bx.length(0);
-        const int ny = bx.length(1);
-        amrex::Array4<amrex::Real> const & dst_array = dst.array();
-
-        amrex::ParallelFor(
-            bx,
-            [=] AMREX_GPU_DEVICE(int i, int j, int k)
-            {
-                dst_array(i,j,k,dcomp) = 0.;
-            }
-            );
-    };
-
     DSTplan CreatePlan (const amrex::IntVect& real_size, amrex::FArrayBox* position_array,
                         amrex::FArrayBox* fourier_array)
     {


### PR DESCRIPTION
We noticed that on GPUs in Debug mode the fields were returned with NaNs, although the current was correct.

Investigating the origins, we found a couple of arrays, which were declared, but not initialized properly before they were used.
The expansion of the array for the DST was causing real trouble: in the `ExpandR2C` function, some values were set, but other were left uninitialized. This caused this bug.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
