### PR TITLE
[mini] quick fix to make the external field work on GPU

### DIFF
--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -78,6 +78,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields,
 
         const amrex::Real clightsq = 1.0_rt/(phys_const.c*phys_const.c);
         const amrex::Real charge_mass_ratio = - phys_const.q_e / phys_const.m_e;
+        const amrex::Real external_field_strength = Hipace::m_external_field_strength;
 
         amrex::ParallelFor(num_particles,
             [=] AMREX_GPU_DEVICE (long idx) {
@@ -106,7 +107,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields,
                                exmby_arr, eypbx_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                dx_arr, xyzmin_arr, lo, depos_order_xy, 0);
 
-                ApplyExternalField(xp, yp, ExmByp, EypBxp, Hipace::m_external_field_strength);
+                ApplyExternalField(xp, yp, ExmByp, EypBxp, external_field_strength);
 
                 // use intermediate fields to calculate next (n+1) transverse momenta
                 const amrex::ParticleReal ux_next = uxp[ip] + dt * charge_mass_ratio


### PR DESCRIPTION
The external field did not compile on GPU, this provides a quick fix.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
