### PR TITLE
Fix slice averaging and clean up its IC

### DIFF
--- a/examples/blowout_wake/analysis_slice_IO.py
+++ b/examples/blowout_wake/analysis_slice_IO.py
@@ -2,7 +2,7 @@
 
 # This Python analysis script is part of the code Hipace
 #
-# It compares the field Ez from a simulation with full IO and from a simulation with only slice IO
+# It compares a field from a simulation with full IO and from a simulation with only slice IO
 
 import yt ; yt.funcs.mylog.setLevel(50)
 import matplotlib.pyplot as plt
@@ -15,39 +15,40 @@ import math
 import argparse
 
 do_plot = False
+field = 'Bz'
 
 ds1 = AMReXDataset('full_io')
 all_data_level_0 = ds1.covering_grid(level=0,
                                      left_edge=ds1.domain_left_edge,
                                      dims=ds1.domain_dimensions)
-Ez_full = all_data_level_0['Ez'].v.squeeze()
-Ez_full_sliced = (Ez_full[:,Ez_full.shape[1]//2,:].squeeze() +
-                  Ez_full[:,Ez_full.shape[1]//2-1,:].squeeze())/2.
+F_full = all_data_level_0[field].v.squeeze()
+F_full_sliced = (F_full[:,F_full.shape[1]//2,:].squeeze() +
+                  F_full[:,F_full.shape[1]//2-1,:].squeeze())/2.
 ds2 = AMReXDataset('slice_io')
 ad = ds2.all_data()
-Ez_slice = ad['Ez'].reshape(ds2.domain_dimensions).v.squeeze()
+F_slice = ad[field].reshape(ds2.domain_dimensions).v.squeeze()
 
 if do_plot:
     plt.figure(figsize=(12,4))
     plt.subplot(131)
     plt.title('full')
-    plt.imshow(Ez_full_sliced)
+    plt.imshow(F_full_sliced)
     plt.colorbar()
     plt.subplot(132)
     plt.title('slice')
-    plt.imshow(Ez_slice)
+    plt.imshow(F_slice)
     plt.colorbar()
     plt.subplot(133)
     plt.title('difference')
-    plt.imshow(Ez_slice-Ez_full_sliced)
+    plt.imshow(F_slice-F_full_sliced)
     plt.colorbar()
     plt.tight_layout()
     plt.savefig("image.pdf", bbox_inches='tight')
 
-error = np.max(np.abs(Ez_slice-Ez_full_sliced)) / np.max(np.abs(Ez_full_sliced))
+error = np.max(np.abs(F_slice-F_full_sliced)) / np.max(np.abs(F_full_sliced))
 
-print("Ez_full.shape", Ez_full.shape)
-print("Ez_slice.shape", Ez_slice.shape)
+print("F_full.shape", F_full.shape)
+print("F_slice.shape", F_slice.shape)
 print("error", error)
 
 assert(error < 1.e-14)

--- a/tests/slice_IO.1Rank.sh
+++ b/tests/slice_IO.1Rank.sh
@@ -13,16 +13,17 @@ HIPACE_SOURCE_DIR=$2
 HIPACE_EXAMPLE_DIR=${HIPACE_SOURCE_DIR}/examples/blowout_wake
 HIPACE_TEST_DIR=${HIPACE_SOURCE_DIR}/tests
 
-rm -rf full_io
 rm -rf plt00001
 # Run the simulation
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         hipace.output_slice=0 \
         hipace.slice_beam=1
+rm -rf full_io
 mv plt00001 full_io
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         hipace.output_slice=1 \
         hipace.slice_beam=1
+rm -rf slice_io
 mv plt00001 slice_io
 
 # assert whether the two IO types match


### PR DESCRIPTION
The averaging for the IO slice was at the wrong place (we averaged Full array -> xy slice instead of xyslice -> Full array). This PR proposes a fix, and uses field Bz for CI (more sensitive).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
