### PR TITLE
A few bugfixes for longitudinal parallelization for beam particles.

### DIFF
--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -63,7 +63,7 @@ DepositCurrent (BeamParticleContainer& beam, Fields & fields,
                 doDepositionShapeN<0, 3>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, 0, bins, false);
             } else {
-                amrex::Abort("unknow deposition order");
+                amrex::Abort("unknown deposition order");
             }
         } else if (Hipace::m_depos_order_xy == 1){
             if        (Hipace::m_depos_order_z == 0){
@@ -79,7 +79,7 @@ DepositCurrent (BeamParticleContainer& beam, Fields & fields,
                 doDepositionShapeN<1, 3>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, 0, bins, false);
             } else {
-                amrex::Abort("unknow deposition order");
+                amrex::Abort("unknown deposition order");
             }
         } else if (Hipace::m_depos_order_xy == 2){
             if        (Hipace::m_depos_order_z == 0){
@@ -95,7 +95,7 @@ DepositCurrent (BeamParticleContainer& beam, Fields & fields,
                 doDepositionShapeN<2, 3>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, 0, bins, false);
             } else {
-                amrex::Abort("unknow deposition order");
+                amrex::Abort("unknown deposition order");
             }
         } else if (Hipace::m_depos_order_xy == 3){
             if        (Hipace::m_depos_order_z == 0){
@@ -111,10 +111,10 @@ DepositCurrent (BeamParticleContainer& beam, Fields & fields,
                 doDepositionShapeN<3, 3>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
                                           dx, xyzmin, lo, q, 0, bins, false);
             } else {
-                amrex::Abort("unknow deposition order m_depos_order_z");
+                amrex::Abort("unknown deposition order m_depos_order_z");
             }
         } else {
-            amrex::Abort("unknow deposition order m_depos_order_xy");
+            amrex::Abort("unknown deposition order m_depos_order_xy");
         }
     }
 }
@@ -136,6 +136,9 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     // Loop over particle boxes, transversally. MUST be exactly 1.
     for (BeamParticleIterator pti(beam, lev); pti.isValid(); ++pti)
     {
+        // Assumes '2' == 'z' == 'the long dimension'.
+        int islice_local = islice - pti.tilebox().smallEnd(2);
+
         // Extract properties associated with the extent of the current box
         const amrex::Box tilebox = pti.tilebox().grow(
             {Hipace::m_depos_order_xy, Hipace::m_depos_order_xy,
@@ -151,11 +154,14 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
         amrex::MultiFab jy(S, amrex::make_alias, FieldComps::jy, 1);
         amrex::MultiFab jz(S, amrex::make_alias, FieldComps::jz, 1);
         amrex::MultiFab rho(S, amrex::make_alias, FieldComps::rho, 1);
-        // Extract FabArray for this box
-        amrex::FArrayBox& jx_fab = jx[pti];
-        amrex::FArrayBox& jy_fab = jy[pti];
-        amrex::FArrayBox& jz_fab = jz[pti];
-        amrex::FArrayBox& rho_fab = rho[pti];
+
+        // Extract FabArray for this box (because there is currently no transverse
+        // parallelization, the index we want in the slice multifab is always 0.
+        // Fix later.
+        amrex::FArrayBox& jx_fab = jx[0];
+        amrex::FArrayBox& jy_fab = jy[0];
+        amrex::FArrayBox& jz_fab = jz[0];
+        amrex::FArrayBox& rho_fab = rho[0];
 
         // For now: fix the value of the charge
         const amrex::Real q = - phys_const.q_e;
@@ -163,18 +169,18 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
         // Call deposition function in each box
         if        (Hipace::m_depos_order_xy == 0){
             doDepositionShapeN<0, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
-                                      dx, xyzmin, lo, q, islice, bins, true);
+                                      dx, xyzmin, lo, q, islice_local, bins, true);
         } else if (Hipace::m_depos_order_xy == 1){
             doDepositionShapeN<1, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
-                                      dx, xyzmin, lo, q, islice, bins, true);
+                                      dx, xyzmin, lo, q, islice_local, bins, true);
         } else if (Hipace::m_depos_order_xy == 2){
             doDepositionShapeN<2, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
-                                      dx, xyzmin, lo, q, islice, bins, true);
+                                      dx, xyzmin, lo, q, islice_local, bins, true);
         } else if (Hipace::m_depos_order_xy == 3){
             doDepositionShapeN<3, 0>( pti, jx_fab, jy_fab, jz_fab, rho_fab,
-                                      dx, xyzmin, lo, q, islice, bins, true);
+                                      dx, xyzmin, lo, q, islice_local, bins, true);
         } else {
-            amrex::Abort("unknow deposition order");
+            amrex::Abort("unknown deposition order");
         }
     }
 }


### PR DESCRIPTION
This fixes a few bugs that were exposed when trying to run the `normalized linear wake` problem on 2 MPI ranks. Specifically:

1. The `pti` used to access the slice multifabs when depositing or advancing beam particles was wrong - it should refer to the slice boxarray, not the full boxarray. Since there is currently no transverse parallelization, we can always use '0' for this index, but this will need to be generalized later.

2. The index used when accessing a slice worth of beam particles via the `DenseBins` object go from 0 to the number of local slices, not the number of global slices.

3. I also fixed a small typo in some print statements. 

Note that the tests answer is still not correct with longitudinal parallelization, however with these changes it does run to completion. 

Addresses Issue #188.
