### PR TITLE
[WIP] test for longitudinal parallelization of plasma particles

### DIFF
--- a/examples/linear_wake/analysis_2ranks.py
+++ b/examples/linear_wake/analysis_2ranks.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import yt ; yt.funcs.mylog.setLevel(50)
+import matplotlib.pyplot as plt
+import numpy as np
+from yt.frontends.boxlib.data_structures import AMReXDataset
+
+do_plot = True
+
+ds = AMReXDataset('REF_plt00001')
+ad = ds.all_data()
+dsr = AMReXDataset('plt00001')
+# I don't know why, but dsr.all_data() would give wrong results here.
+adr = dsr.covering_grid(level=0, left_edge=dsr.domain_left_edge,
+                        dims=dsr.domain_dimensions)
+
+if do_plot:
+
+    field = 'jx'
+    step = 20
+    ms = .1
+
+    plt.figure()
+
+    F = ad[field].v.reshape(ds.domain_dimensions).squeeze()
+    xp = ad['beam', 'particle_position_x'].v
+    yp = ad['beam', 'particle_position_y'].v
+    zp = ad['beam', 'particle_position_z'].v
+    uzp = ad['beam', 'particle_uz'].v
+    wp = ad['beam', 'particle_w'].v
+
+    plt.subplot(221)
+    plt.title('ref xz')
+    extent = [ds.domain_left_edge[2], ds.domain_right_edge[2],
+              ds.domain_left_edge[0], ds.domain_right_edge[0] ]
+    plt.imshow(F[:,F.shape[1]//2,:], extent=extent, aspect='auto', origin='lower', interpolation='nearest')
+    plt.plot(zp[::step], xp[::step], '.', ms=ms)
+    plt.colorbar()
+    plt.xlabel('z')
+    plt.ylabel('x')
+
+    plt.subplot(222)
+    plt.title('ref yz')
+    extent = [ds.domain_left_edge[2], ds.domain_right_edge[2],
+              ds.domain_left_edge[1], ds.domain_right_edge[1] ]
+    plt.imshow(F[F.shape[0]//2,:,:], extent=extent, aspect='auto', origin='lower', interpolation='nearest')
+    plt.plot(zp[::step], yp[::step], '.', ms=ms)
+    plt.colorbar()
+    plt.xlabel('z')
+    plt.ylabel('y')
+
+    Fr = adr[field].v.reshape(dsr.domain_dimensions).squeeze()
+    xp = adr['beam', 'particle_position_x'].v
+    yp = adr['beam', 'particle_position_y'].v
+    zp = adr['beam', 'particle_position_z'].v
+    uzp = adr['beam', 'particle_uz'].v
+    wp = adr['beam', 'particle_w'].v
+
+    plt.subplot(223)
+    plt.title('xz')
+    extent = [dsr.domain_left_edge[2], dsr.domain_right_edge[2],
+              dsr.domain_left_edge[0], dsr.domain_right_edge[0] ]
+    plt.imshow(Fr[:,Fr.shape[1]//2,:], extent=extent, aspect='auto', origin='lower', interpolation='nearest')
+    plt.plot(zp[::step], xp[::step], '.', ms=ms)
+    plt.colorbar()
+    plt.xlabel('z')
+    plt.ylabel('x')
+
+    plt.subplot(224)
+    plt.title('yz')
+    extent = [dsr.domain_left_edge[2], dsr.domain_right_edge[2],
+              dsr.domain_left_edge[1], dsr.domain_right_edge[1] ]
+    plt.imshow(Fr[Fr.shape[0]//2,:,:], extent=extent, aspect='auto', origin='lower', interpolation='nearest')
+    plt.plot(zp[::step], yp[::step], '.', ms=ms)
+    plt.colorbar()
+    plt.xlabel('z')
+    plt.ylabel('y')
+
+    plt.tight_layout()
+    plt.savefig('img.pdf', bbox_inches='tight')
+
+for field in ['ExmBy', 'EypBx', 'Ez', 'Bx', 'By', 'By', 'jz']:
+    print('comparing ' + field)
+    F = ad[field].v.reshape(ds.domain_dimensions).squeeze()
+    Fr = adr[field].v.reshape(dsr.domain_dimensions).squeeze()
+    assert( np.all( F == Fr ) )
+

--- a/tests/linear_wake.normalized.2Rank.sh
+++ b/tests/linear_wake.normalized.2Rank.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+
+# This file is part of the Hipace test suite.
+# It runs a Hipace simulation for a can beam in vacuum in serial and parallel and
+# checks that they give the same result
+
+# abort on first encounted error
+set -eu -o pipefail
+
+# Read input parameters
+HIPACE_EXECUTABLE=$1
+HIPACE_SOURCE_DIR=$2
+
+HIPACE_EXAMPLE_DIR=${HIPACE_SOURCE_DIR}/examples/linear_wake
+HIPACE_TEST_DIR=${HIPACE_SOURCE_DIR}/tests
+
+rm -rf plt* REF*
+
+mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized
+
+mv plt00001 REF_plt00001
+
+mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized
+
+$HIPACE_EXAMPLE_DIR/analysis_2ranks.py


### PR DESCRIPTION
@atmyers now that the `beam_in_vacuum` examples is fixed, we can assume that the field communications are working again. I created this PR to provide a test for plasma parallelization. running
```bash
cd test
./linear_wake.normalized.2Rank.sh
```
will run the automated test `linear_wake` in serial and parallel, plot the results, and assert that all fields are equal. It produces the image below, where top is the reference (serial run) bottom is the parallel run, left is an xz slice and right is a yz slice for a given field (here, the density). As you can expect, this fails for now (but at least you'll have an image showing the fields). In particular, there doesn't seem to be plasma particles at the head of the domain, so all fields are 0 in the first half of the box. Do you think you could start from there? Sorry again for the delay.

<img width="822" alt="Screenshot 2020-11-19 at 16 33 21" src="https://user-images.githubusercontent.com/26292713/99687702-3e597880-2a85-11eb-808b-aaac3a3d745c.png">

Another point I want to mention: at each time step, a fraction of the **beam** particles may travel from one rank to the next (typically only a few particles from the most downstream slice of a rank). While this is exactly the task of Redistribute, I don't think we can call it here, because Redistribute is a synchronous task (all ranks need to call it together) while this beam communications are part of the pipeline. We may have to do this communication by hand, but it is not clear to me how yet. We don't need to take care of it now, but I wanted to raise this question as this might slightly affect how we address plasma communication, not sure about that.