### PR TITLE
[mini] Assert for slice beam for slice IO

### DIFF
--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -31,8 +31,8 @@ beam.radius = 1.2
 beam.density = 3.
 beam.u_mean = 0. 0. 2000
 beam.u_std = 0. 0. 0.
-beam.position_mean = 0. 0. 0
-beam.position_std = 0.3 0.3 1.41
+beam.mean = 0. 0. 0
+beam.std = 0.3 0.3 1.41
 beam.ppc = 1 1 1
 
 plasma.density = 1.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -75,7 +75,8 @@ Hipace::Hipace () :
     pph.query("slice_beam", m_slice_beam);
     pph.query("3d_on_host", m_3d_on_host);
     if (m_3d_on_host) AMREX_ALWAYS_ASSERT(m_slice_beam);
-    if (output_slice) AMREX_ALWAYS_ASSERT(m_slice_beam);
+    if (m_slice_F_xz) AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_slice_beam,
+                        "To enable slice I/O, 'hipace.slice_beam = 1' is required ");
     m_numprocs_z = amrex::ParallelDescriptor::NProcs() / (m_numprocs_x*m_numprocs_y);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_numprocs_x*m_numprocs_y*m_numprocs_z
                                      == amrex::ParallelDescriptor::NProcs(),


### PR DESCRIPTION
Previously, it was possible to use the slice IO, but not the slice beam, which lead to completely wrong results. 
This is now forbidden and a helpful error message is given.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
