### PR TITLE
F needs guard cells when beam deposits on the 3d grid

### DIFF
--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -43,16 +43,15 @@ Fields::AllocData (
     // m_F is defined on F_ba, the full or the xz slice BoxArray
     amrex::BoxArray F_ba = Hipace::m_slice_F_xz ? F_slice_ba : ba;
 
+    amrex::IntVect nguards_F = Hipace::m_slice_beam ? amrex::IntVect(0,0,0) : m_slices_nguards;
+
     if (Hipace::m_3d_on_host){
         // The Arena uses pinned memory.
-        amrex::IntVect nguards_F = Hipace::m_slice_beam == true ?
-            amrex::IntVect(0,0,0)
-            : m_slices_nguards;
         m_F[lev].define(F_ba, dm, FieldComps::nfields, nguards_F,
                         amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()));
     } else {
         // The Arena uses managed memory.
-        m_F[lev].define(F_ba, dm, FieldComps::nfields, {0,0,0},
+        m_F[lev].define(F_ba, dm, FieldComps::nfields, nguards_F,
                         amrex::MFInfo().SetArena(amrex::The_Arena()));
     }
 


### PR DESCRIPTION
This should fix issue https://github.com/Hi-PACE/hipace/issues/240, @SeverinDiederichs could you check? The problem is that the 3D array `F` doesn't have guard cells. Usually, beam particles deposits on a 2D xy slice and `F` is only used for IO, so it doesn't matter, but it is still possible to deposit beam current directly into `F`. In that case, this PR proposes to add guard cells to `F`. This should not be used on GPU, as it is not to give poor IO performance.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
