### PR TITLE
[mini] Store the correct physical time in output files

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -154,7 +154,9 @@ public:
     /** Last iteration that was written to file.
      * This is stored to make sure we don't write the last iteration multiple times. */
     int m_last_output_dumped = -1;
-
+    /** Physical time of the simulation. At the end of the time step, it is the physical time
+     * at which the fields have been calculated. The beam is one step ahead. */
+    amrex::Real m_physical_time = 0.;
     /** Level of verbosity */
     static int m_verbose;
     /** Whether to use normalized units */


### PR DESCRIPTION
With adaptive time step, the physical time cannot be `dt * time_step` anymore. This PR proposes to increment a `physical_time` at each iteration, to keep track of it and use it in plotfiles. It is synchronised to give the exact physical time of the fields, not of the beam.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
