### PR TITLE
[mini] Fix typo in the example Jupyter notebook

### DIFF
--- a/tools/visualize.ipynb
+++ b/tools/visualize.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "# Get field data into a numpy array\n",
-    "Ez = ad['Ez'].reshape(ds.domain_dimensions).squeeze()"
+    "Ez = ad['Ez'].v.reshape(ds.domain_dimensions).squeeze()"
    ]
   },
   {


### PR DESCRIPTION
Typo fix to avoid a Python error in the Jupiter notebook: yt arrays are unit-aware. This PR adds a `.v` do extract the numpy array, somehow easier to manipulate.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
