### PR TITLE
fixing order of AMReX includes

### DIFF
--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -7,13 +7,15 @@
 #ifndef ANYFFT_H_
 #define ANYFFT_H_
 
-#include <AMReX_LayoutData.H>
+#include <AMReX_Config.H>
 
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #else
 #  include <fftw3.h>
 #endif
+
+#include <AMReX_LayoutData.H>
 
 /**
  * \brief Wrapper around multiple FFT libraries.


### PR DESCRIPTION
Due to recent changes in AMReX as described bei Weiqun [here](https://github.com/AMReX-Codes/amrex/pull/1566#issuecomment-731473968), we have to call `#include <AMReX_Config.H>`, before we can use
```
#ifdef AMREX_USE_CUDA
#  include <cufft.h>
#else
#  include <fftw3.h>
#endif
```
in `AnyFFT.H` 
This fixes building with CUDA.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
