### PR TITLE
Full domain transversally for slice IO to avoid losing particles

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -672,8 +672,6 @@ Hipace::WriteDiagnostics (int output_step, bool force_output)
 
     // Define slice box
     int const icenter = domain.length(idim)/2;
-    prob_domain.setLo(idim, Geom(lev).ProbLo(idim));
-    prob_domain.setHi(idim, Geom(lev).ProbHi(idim));
     domain.setSmall(idim, icenter);
     domain.setBig(idim, icenter);
     if (m_slice_F_xz){


### PR DESCRIPTION
Should fix a problem where 1/2 beam particles weren't dumped.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
