### PR TITLE
Adding correlated energy spread to fixed weight beams

### DIFF
--- a/examples/gaussian_weight/analysis.py
+++ b/examples/gaussian_weight/analysis.py
@@ -52,6 +52,8 @@ if args.tilted_beam:
     z_avg = 2.
     dx_per_dzeta = 0.1
     dy_per_dzeta = -0.2
+    duz_per_uz0_dzeta = 0.01
+    uz_avg = 1000.
 
 # only required in the normalized units test
 ux_avg = 1.
@@ -87,10 +89,15 @@ if args.tilted_beam:
     # getting xp and yp at z_avg + 1.
     x_tilt_at_1 = xp[ np.logical_and(z_avg + 0.99 < zp, zp < z_avg + 1.01) ]
     y_tilt_at_1 = yp[ np.logical_and(z_avg + 0.99 < zp, zp < z_avg + 1.01) ]
+    uz_at_1 = uzp[ np.logical_and(z_avg + 0.99 < zp, zp < z_avg + 1.01) ]
     x_tilt_error = np.abs(np.average(x_tilt_at_1-dx_per_dzeta)/dx_per_dzeta)
     y_tilt_error = np.abs(np.average(y_tilt_at_1-dy_per_dzeta-y_avg)/dy_per_dzeta)
+    uz_error = np.abs(np.average( (uz_at_1 - (uz_avg + 1*uz_avg*duz_per_uz0_dzeta) )/
+                                (uz_avg + 1*duz_per_uz0_dzeta ) ))
+
     assert(x_tilt_error < 1e-4)
     assert(y_tilt_error < 1e-4)
+    assert(uz_error < 1e-4)
 else:
     if args.norm_units:
         charge_sim = np.sum(wp)

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -49,13 +49,15 @@ public:
 
     /** Initialize a beam with a fix number of particles, and fixed weight */
     void InitBeamFixedWeight (int num_to_add,
-                              const GetInitialMomentum& get_momentum,
                               const amrex::RealVect pos_mean,
                               const amrex::RealVect pos_std,
+                              const amrex::RealVect u_mean,
+                              const amrex::RealVect u_std,
                               const amrex::Real total_charge,
                               const bool do_symmetrize,
                               const amrex::Real dx_per_dzeta,
-                              const amrex::Real dy_per_dzeta);
+                              const amrex::Real dy_per_dzeta,
+                              const amrex::Real duz_per_uz0_dzeta);
 
     std::string get_name () {return m_name;};
 private:
@@ -64,12 +66,17 @@ private:
     amrex::Real m_zmax; /**< Max longitudinal position of the can beam */
     amrex::Real m_radius; /**< Radius of the can beam */
     amrex::IntVect m_ppc {1, 1, 1}; /**< Number of particles per cell in each direction */
-    /** Average position of the Gaussian beam. Only used for a fixed-weight beam */
+    /** Average position of the Gaussian beam. */
     amrex::RealVect m_position_mean {0., 0., 0.};
-    /** Width of the Gaussian beam. Only used for a fixed-weight beam */
+    /** Width of the Gaussian beam. */
     amrex::RealVect m_position_std {0., 0., 0.};
+    /** Average momentum of the Gaussian beam. */
+    amrex::RealVect m_u_mean {0., 0., 0.};
+    /** Spread of the momentum of the Gaussian beam. */
+    amrex::RealVect m_u_std {0., 0., 0.};
     amrex::Real m_dx_per_dzeta {0.}; /**< tilt in x direction */
     amrex::Real m_dy_per_dzeta {0.}; /**< tilt in y direction */
+    amrex::Real m_duz_per_uz0_dzeta {0.}; /**< relative energy spread per dzeta */
     /** injection type, fixed_width or fixed_ppc */
     std::string m_injection_type;
     int m_num_particles; /**< Number of particles for fixed-weigth Gaussian beam */

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -14,9 +14,11 @@ BeamParticleContainer::ReadParameters ()
     }
     pp.query("dx_per_dzeta", m_dx_per_dzeta);
     pp.query("dy_per_dzeta", m_dy_per_dzeta);
+    pp.query("duz_per_uz0_dzeta", m_duz_per_uz0_dzeta);
     if (m_injection_type == "fixed_ppc"){
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (m_dx_per_dzeta == 0.) && (m_dy_per_dzeta == 0.),
-            "Tilted beams are not yet implemented for fixed ppc beams");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (m_dx_per_dzeta == 0.) && (m_dy_per_dzeta == 0.)
+            && (m_duz_per_uz0_dzeta == 0.),
+            "Tilted beams and correlated energy spreads are not implemented for fixed ppc beams");
     }
 }
 
@@ -46,6 +48,10 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         for (int idim=0; idim<AMREX_SPACEDIM; ++idim) m_position_mean[idim] = loc_array[idim];
         pp.get("position_std", loc_array);
         for (int idim=0; idim<AMREX_SPACEDIM; ++idim) m_position_std[idim] = loc_array[idim];
+        pp.get("u_mean", loc_array);
+        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) m_u_mean[idim] = loc_array[idim];
+        pp.get("u_std", loc_array);
+        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) m_u_std[idim] = loc_array[idim];
         pp.get("num_particles", m_num_particles);
         bool charge_is_specified = pp.query("total_charge", m_total_charge);
         bool peak_density_is_specified = pp.query("density", m_density);
@@ -69,10 +75,9 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
             m_total_charge /= dx[0]*dx[1]*dx[2];
         }
 
-        const GetInitialMomentum get_momentum(m_name);
-        InitBeamFixedWeight(m_num_particles, get_momentum, m_position_mean,
-                            m_position_std, m_total_charge, m_do_symmetrize, m_dx_per_dzeta,
-                            m_dy_per_dzeta);
+        InitBeamFixedWeight(m_num_particles, m_position_mean, m_position_std, m_u_mean, m_u_std,
+                            m_total_charge, m_do_symmetrize, m_dx_per_dzeta, m_dy_per_dzeta,
+                            m_duz_per_uz0_dzeta);
 
     } else {
 

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -194,13 +194,15 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
 void
 BeamParticleContainer::
 InitBeamFixedWeight (int num_to_add,
-                     const GetInitialMomentum& get_momentum,
                      const amrex::RealVect pos_mean,
                      const amrex::RealVect pos_std,
+                     const amrex::RealVect u_mean,
+                     const amrex::RealVect u_std,
                      const amrex::Real total_charge,
                      const bool do_symmetrize,
                      const amrex::Real dx_per_dzeta,
-                     const amrex::Real dy_per_dzeta)
+                     const amrex::Real dy_per_dzeta,
+                     const amrex::Real duz_per_uz0_dzeta)
 {
     HIPACE_PROFILE("BeamParticleContainer::InitParticles");
 
@@ -239,8 +241,10 @@ InitBeamFixedWeight (int num_to_add,
                     const amrex::Real x = amrex::RandomNormal(0, pos_std[0]);
                     const amrex::Real y = amrex::RandomNormal(0, pos_std[1]);
                     const amrex::Real z = amrex::RandomNormal(0, pos_std[2]);
-                    amrex::Real u[3] = {0.,0.,0.};
-                    get_momentum(u[0],u[1],u[2]);
+                    const amrex::Real ux = amrex::RandomNormal(u_mean[0], u_std[0]);
+                    const amrex::Real uy = amrex::RandomNormal(u_mean[1], u_std[1]);
+                    const amrex::Real uz = amrex::RandomNormal(u_mean[2], u_std[2]) +
+                                           z*duz_per_uz0_dzeta*u_mean[2];;
 
                     const amrex::Real cental_x_pos = pos_mean[0] + z*dx_per_dzeta;
                     const amrex::Real cental_y_pos = pos_mean[1] + z*dy_per_dzeta;
@@ -249,21 +253,21 @@ InitBeamFixedWeight (int num_to_add,
                     if (!do_symmetrize)
                     {
                         AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
-                                           pos_mean[2]+z, u[0], u[1], u[2], weight,
+                                           pos_mean[2]+z, ux, uy, uz, weight,
                                            pid, procID, i, phys_const.c);
                     } else {
                         weight /= 4;
                         AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
-                                           pos_mean[2]+z, u[0], u[1], u[2], weight,
+                                           pos_mean[2]+z, ux, uy, uz, weight,
                                            pid, procID, 4*i, phys_const.c);
                         AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos+y,
-                                           pos_mean[2]+z, -u[0], u[1], u[2], weight,
+                                           pos_mean[2]+z, -ux, uy, uz, weight,
                                            pid, procID, 4*i+1, phys_const.c);
                         AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos-y,
-                                           pos_mean[2]+z, u[0], -u[1], u[2], weight,
+                                           pos_mean[2]+z, ux, -uy, uz, weight,
                                            pid, procID, 4*i+2, phys_const.c);
                         AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
-                                           pos_mean[2]+z, -u[0], -u[1], u[2], weight,
+                                           pos_mean[2]+z, -ux, -uy, uz, weight,
                                            pid, procID, 4*i+3, phys_const.c);
                     }
                 });

--- a/tests/gaussian_weight.1Rank.sh
+++ b/tests/gaussian_weight.1Rank.sh
@@ -18,6 +18,7 @@ HIPACE_TEST_DIR=${HIPACE_SOURCE_DIR}/tests
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
                     beam.dx_per_dzeta=0.1 \
                     beam.dy_per_dzeta=-0.2 \
+                    beam.duz_per_uz0_dzeta = 0.01 \
                     beam.position_std = 0.1 0.1 2.
 
 # Compare the result with theory


### PR DESCRIPTION
This PR adds the possibility to add a longitudinal chirp to the beam.
The parameter `beam.duz_per_uz0_dzeta` gives the relative correlated energy spread per zeta position.
So for `uz = 1e3` and `duz_per_uz0_dzeta = 0.1`, the beam will have a mean `uz = 1.1e3`  at `zeta = 1`.

This is tested in the fixed weight CI test. 

For the implementation, the `getMomentum` had to be removed, as we need both the final momentum of each particle as well as the mean (which was not a member of the `BeamParticleContainer`, similar as the position + beam width had to be added for the fixed weight beam in general.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [x] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
