### PR TITLE
Fix a classic implicit capture of *this bug

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -699,9 +699,10 @@ Hipace::Notify ()
             amrex::Gpu::DeviceVector<int> comm_int (m_plasma_container.NumIntComps(),  1);
             auto p_comm_real = comm_real.data();
             auto p_comm_int = comm_int.data();
+            auto p_psend_buffer = m_psend_buffer;
             amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept
             {
-                ptd.packParticleData(m_psend_buffer, i, i*psize, p_comm_real, p_comm_int);
+                ptd.packParticleData(p_psend_buffer, i, i*psize, p_comm_real, p_comm_int);
             });
 
             MPI_Isend(m_psend_buffer, buffer_size,


### PR DESCRIPTION
- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
