### PR TITLE
fixing index error in DST

### DIFF
--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -32,13 +32,13 @@ namespace AnyDST
             [=] AMREX_GPU_DEVICE(int i, int j, int k)
             {
                 /* upper left quadrant */
-                dst_array(i+1,j+1,k,dcomp) = src_array(i, j, k, scomp);
+                dst_array(i+1,j+1,0,dcomp) = src_array(i, j, k, scomp);
                 /* lower left quadrant */
-                dst_array(i+1,j+ny+2,k,dcomp) = -src_array(i, ny-1-j, k, scomp);
+                dst_array(i+1,j+ny+2,0,dcomp) = -src_array(i, ny-1-j, k, scomp);
                 /* upper right quadrant */
-                dst_array(i+nx+2,j+1,k,dcomp) = -src_array(nx-1-i, j, k, scomp);
+                dst_array(i+nx+2,j+1,0,dcomp) = -src_array(nx-1-i, j, k, scomp);
                 /* lower right quadrant */
-                dst_array(i+nx+2,j+ny+2,k,dcomp) = src_array(nx-1-i, ny-1-j, k, scomp);
+                dst_array(i+nx+2,j+ny+2,0,dcomp) = src_array(nx-1-i, ny-1-j, k, scomp);
             }
             );
     };
@@ -62,7 +62,7 @@ namespace AnyDST
             [=] AMREX_GPU_DEVICE(int i, int j, int k)
             {
                 /* upper left quadrant */
-                dst_array(i,j,k,dcomp) = -src_array(i+1, j+1, k, scomp).real();
+                dst_array(i,j,k,dcomp) = -src_array(i+1, j+1, 0, scomp).real();
             }
             );
     };


### PR DESCRIPTION
This fixes and indexing error in the expand and shrink functions. It caused GPU runs to fail with more than 1 rank.
Now, they work for a beam in vacuum.

There is still another bug with the plasma particles. Although they are seen by the rank downstream, the charge density rho is +1 everywhere, as if the particles were absent. 

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
