### PR TITLE
Add missing Device::synchronize() calls to Wait() and Notify().

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -603,6 +603,8 @@ Hipace::Wait ()
              {
                  slice_fab4(i,j,k,n) = buf4(i,j,k,n);
              });
+
+        amrex::Gpu::Device::synchronize();
         amrex::The_Pinned_Arena()->free(recv_buffer);
         }
 
@@ -632,6 +634,7 @@ Hipace::Wait ()
                 ptd.unpackParticleData(recv_buffer, i*psize, i, p_comm_real, p_comm_int);
             });
 
+            amrex::Gpu::Device::synchronize();
             amrex::The_Pinned_Arena()->free(recv_buffer);
         }
     }
@@ -686,6 +689,8 @@ Hipace::Notify ()
              {
                  buf4(i,j,k,n) = slice_fab4(i,j,k,n);
              });
+
+        amrex::Gpu::Device::synchronize();
         MPI_Isend(m_send_buffer, nreals_total,
                   amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
                   m_rank_z-1, comm_z_tag, m_comm_z, &m_send_request);
@@ -713,6 +718,7 @@ Hipace::Notify ()
                 ptd.packParticleData(p_psend_buffer, i, i*psize, p_comm_real, p_comm_int);
             });
 
+            amrex::Gpu::Device::synchronize();
             MPI_Isend(m_psend_buffer, buffer_size,
                       amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
                       m_rank_z-1, pcomm_z_tag, m_comm_z, &m_psend_request);


### PR DESCRIPTION
I noticed that with `CUDA_LAUNCH_BLOCKING=1`, I no longer got any QSA violating particles. I believe all four of these syncs are needed.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
