### PR TITLE
[openPMD] Communication of upstream beam particle number

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -297,8 +297,6 @@ Hipace::Evolve ()
 
         Wait();
 
-        m_multi_beam.RecvNumParticlesUpstreamRanks(m_comm_z);
-
         amrex::MultiFab& fields = m_fields.getF(lev);
 
         if (!m_slice_beam) m_multi_beam.DepositCurrent(m_fields, geom[lev], lev);
@@ -333,8 +331,6 @@ Hipace::Evolve ()
         // slices {2,3} from upstream to {2,3} in downstream.
         Notify();
 
-        /* pass the number of beam particles from the upstream ranks to get the offset for openPMD IO */
-        m_multi_beam.PassNumParticlesUpstreamRanks(m_comm_z);
 #ifdef HIPACE_USE_OPENPMD
         WriteDiagnostics(step+1);
 #else
@@ -643,6 +639,9 @@ Hipace::Wait ()
             amrex::The_Pinned_Arena()->free(recv_buffer);
         }
     }
+    #ifdef HIPACE_USE_OPENPMD
+    m_multi_beam.WaitNumParticles(m_comm_z);
+    #endif
 #endif
 }
 
@@ -729,6 +728,10 @@ Hipace::Notify ()
                       m_rank_z-1, pcomm_z_tag, m_comm_z, &m_psend_request);
         }
     }
+    #ifdef HIPACE_USE_OPENPMD
+    /* pass the number of beam particles from the upstream ranks to get the offset for openPMD IO */
+    m_multi_beam.NotifyNumParticles(m_comm_z);
+    #endif
 #endif
 }
 

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -57,11 +57,11 @@ public:
                               const amrex::Real dx_per_dzeta,
                               const amrex::Real dy_per_dzeta);
 
-    /**< Loop over beams and pass total number of beam particles on upstream ranks */
-    void PassNumParticlesUpstreamRanks (MPI_Comm a_comm_z);
+    /** Loop over beams and pass total number of beam particles on upstream ranks */
+    void NotifyNumParticles (MPI_Comm a_comm_z);
 
-    /**< Loop over beams and receive total number of beam particles on upstream ranks */
-    void RecvNumParticlesUpstreamRanks (MPI_Comm a_comm_z);
+    /** Loop over beams and receive total number of beam particles on upstream ranks */
+    void WaitNumParticles (MPI_Comm a_comm_z);
 
     std::string get_name () {return m_name;};
     bool m_do_z_push {true}; /**< Pushing beam particles in z direction */

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -89,7 +89,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 }
 
 void
-BeamParticleContainer::PassNumParticlesUpstreamRanks (MPI_Comm a_comm_z)
+BeamParticleContainer::NotifyNumParticles (MPI_Comm a_comm_z)
 {
     const int my_rank_z = amrex::ParallelDescriptor::MyProc();
 
@@ -105,7 +105,7 @@ BeamParticleContainer::PassNumParticlesUpstreamRanks (MPI_Comm a_comm_z)
 }
 
 void
-BeamParticleContainer::RecvNumParticlesUpstreamRanks (MPI_Comm a_comm_z)
+BeamParticleContainer::WaitNumParticles (MPI_Comm a_comm_z)
 {
     const int my_rank_z = amrex::ParallelDescriptor::MyProc();
     if (my_rank_z  < amrex::ParallelDescriptor::NProcs()-1)

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -75,14 +75,14 @@ public:
      */
     BeamParticleContainer& getBeam (int i) {return m_all_beams[i];};
 
-    /**< returns the number of beams */
+    /** returns the number of beams */
     int get_nbeams () {return m_nbeams;};
 
-    /**< Loop over beams and pass total number of beam particles on upstream ranks */
-    void PassNumParticlesUpstreamRanks (MPI_Comm a_comm_z);
+    /** Loop over beams and pass total number of beam particles on upstream ranks */
+    void NotifyNumParticles (MPI_Comm a_comm_z);
 
-    /**< Loop over beams and receive total number of beam particles on upstream ranks */
-    void RecvNumParticlesUpstreamRanks (MPI_Comm a_comm_z);
+    /** Loop over beams and receive total number of beam particles on upstream ranks */
+    void WaitNumParticles (MPI_Comm a_comm_z);
 private:
 
     amrex::Vector<BeamParticleContainer> m_all_beams; /**< contains all beam containers */

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -82,17 +82,17 @@ MultiBeam::WritePlotFile (const std::string& filename)
 }
 
 void
-MultiBeam::PassNumParticlesUpstreamRanks (MPI_Comm a_comm_z)
+MultiBeam::NotifyNumParticles (MPI_Comm a_comm_z)
 {
     for (auto& beam : m_all_beams) {
-        beam.PassNumParticlesUpstreamRanks(a_comm_z);
+        beam.NotifyNumParticles(a_comm_z);
     }
 }
 
 void
-MultiBeam::RecvNumParticlesUpstreamRanks (MPI_Comm a_comm_z)
+MultiBeam::WaitNumParticles (MPI_Comm a_comm_z)
 {
     for (auto& beam : m_all_beams) {
-        beam.RecvNumParticlesUpstreamRanks(a_comm_z);
+        beam.WaitNumParticles(a_comm_z);
     }
 }


### PR DESCRIPTION
In the parallel beam I/O, the total number of beam particles of the upstream ranks is required. This number is passed via blocking MPI communication down the pipeline.

It was tested that it gives the correct behavior on GPUs:
```
[1,4]<stdout>:num particles upstream before exchange 0
[1,4]<stdout>:num particles upstream after exchange 7
[1,3]<stdout>:num particles upstream before exchange 0
[1,3]<stdout>:num particles upstream after exchange 2901
[1,2]<stdout>:num particles upstream before exchange 0
[1,2]<stdout>:num particles upstream after exchange 49869
[1,1]<stdout>:num particles upstream before exchange 0
[1,1]<stdout>:num particles upstream after exchange 97008
[1,0]<stdout>:num particles upstream before exchange 0
[1,0]<stdout>:num particles upstream after exchange 99994
```

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
