### PR TITLE
openPMD: Collective Open & Group Based

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -882,7 +882,7 @@ Hipace::InitDiagnostics ()
     HIPACE_PROFILE("Hipace::InitDiagnostics()");
 
 #ifdef HIPACE_USE_OPENPMD
-    std::string filename = "diags/openPMD/openpmd_%06T.h5"; // bp or h5
+    std::string filename = "diags/openPMD/openpmd.h5"; // bp or h5
 #   ifdef AMREX_USE_MPI
     m_outputSeries = std::make_unique< io::Series >(
         filename, io::Access::CREATE, amrex::ParallelDescriptor::Communicator());
@@ -890,6 +890,10 @@ Hipace::InitDiagnostics ()
     m_outputSeries = std::make_unique< io::Series >(
         filename, io::Access::CREATE);
 #   endif
+
+    // open files early and collectively, so later flush calls are non-collective
+    m_outputSeries->setIterationEncoding( io::IterationEncoding::groupBased );
+    m_outputSeries->flush();
 
     // TODO: meta-data: author, mesh path, extensions, software
 #endif


### PR DESCRIPTION
Write in parallel into one file, which we open collectively.
This has the nice side-effect, that later iteration flushes can be performed as non-collective writes.

Note: we generally see issues on the CPU code path right now.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
