### PR TITLE
[WIP] openPMD: Handle fields with Guards

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -748,13 +748,6 @@ Hipace::NotifyFinish ()
 #endif
 }
 
-auto const copyToShared = []( amrex::Real const * data, unsigned long size ) {
-    auto d = std::shared_ptr<amrex::Real>(
-        new amrex::Real[size], std::default_delete<amrex::Real[]>());
-    std::copy(data, data + size, d.get());
-    return d;
-};
-
 void
 Hipace::WriteDiagnostics (int output_step, bool force_output)
 {
@@ -828,26 +821,32 @@ Hipace::WriteDiagnostics (int output_step, bool force_output)
         // Loop through the multifab and store each box as a chunk with openpmd
         for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi)
         {
-            amrex::FArrayBox const& fab = mf[mfi];
-            // amrex::Box const& local_box = fab.box();
-            amrex::FArrayBox io_fab(mfi.validbox());
-            io_fab.copy(fab, fab.box(), icomp, mfi.validbox(), 0, 1);
-            auto data = copyToShared(io_fab.dataPtr(0), io_fab.size());
-            // Determine the offset and size of this chunk_size
-            amrex::IntVect box_offset = io_fab.smallEnd();
+            amrex::FArrayBox const& fab = mf[mfi]; // note: this might include guards
+            amrex::Box data_box = mfi.validbox();  // w/o guards in all cases
+            std::shared_ptr< amrex::Real const > data;
+            if (mfi.validbox() == fab.box() )
+                data = io::shareRaw( fab.dataPtr( icomp ) );
+            else
+            {
+                // cut away guards
+                amrex::FArrayBox io_fab(mfi.validbox(), 1, amrex::The_Pinned_Arena());
+                io_fab.copy< amrex::RunOn::Host >(fab, fab.box(), icomp, mfi.validbox(), 0, 1);
+                // copy into a shared pointer to keep data alive
+                //   TODO: moving data of an FArrayBox would be nice here
+                auto d = std::shared_ptr< amrex::Real >(
+                    new amrex::Real[io_fab.size()],
+                    std::default_delete<amrex::Real[]>());
+                std::copy(io_fab.dataPtr(0), io_fab.dataPtr(0) + io_fab.size(), d.get());
+                data = d;
+            }
+
+            // Determine the offset and size of this data chunk in the global output
+            amrex::IntVect box_offset = data_box.smallEnd();
             if (m_slice_F_xz) box_offset[1] = 0; // setting the y offset to 0 by hand for slice I/O
             io::Offset const chunk_offset = utils::getReversedVec(box_offset);
-            io::Extent const chunk_size = utils::getReversedVec(io_fab.length());
+            io::Extent const chunk_size = utils::getReversedVec(data_box.length());
 
- //            amrex::AllPrint()<< "global_size " << global_size[0] << " " << global_size[1] << " " << global_size[2] << "\n";
- //    amrex::AllPrint()<< "local_box big end - small end " << io_fab.bigEnd()[0] - io_fab.smallEnd()[0] << io_fab.bigEnd()[1] - io_fab.smallEnd()[1]<< io_fab.bigEnd()[2] - io_fab.smallEnd()[2]<< "\n";
- //        amrex::AllPrint()<< "local_box " << io_fab.bigEnd()[0] << io_fab.bigEnd()[1] << io_fab.bigEnd()[2] << "\n";
- //            amrex::AllPrint()<< "box_offset " << box_offset[0] << " " << box_offset[1] << " " << box_offset[2] << "\n";
- // amrex::AllPrint()<< "chunk_offset " << chunk_offset[0] << " " << chunk_offset[1] << " " << chunk_offset[2] << "\n";
- // amrex::AllPrint()<< "chunk_size " << chunk_size[0] << " " << chunk_size[1] << " " << chunk_size[2] << "\n";
-            // amrex::Real const * local_data = io_fab.dataPtr( icomp );
             field_comp.storeChunk(data, chunk_offset, chunk_size);
-            // field_comp.storeChunk(io::shareRaw(local_data), chunk_offset, chunk_size);
         }
     }
     m_outputSeries->flush();


### PR DESCRIPTION
For the corner-case of enabling guards in `m_F` (through `hipace.3d_on_host = 0`), we need to copy the validbox data out before we can present contiguous memory for I/O.

To do:
- [ ] GPU test is writing zero data with this patch (even for `hipace.3d_on_host = 1`)

Normal check list:
- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
