### PR TITLE
openPMD: Rebased Handle fields with Guards

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -824,10 +824,9 @@ Hipace::WriteDiagnostics (int output_step, bool force_output)
             amrex::FArrayBox const& fab = mf[mfi]; // note: this might include guards
             amrex::Box data_box = mfi.validbox();  // w/o guards in all cases
             std::shared_ptr< amrex::Real const > data;
-            if (mfi.validbox() == fab.box() )
+            if (mfi.validbox() == fab.box() ) {
                 data = io::shareRaw( fab.dataPtr( icomp ) );
-            else
-            {
+            } else {
                 // cut away guards
                 amrex::FArrayBox io_fab(mfi.validbox(), 1, amrex::The_Pinned_Arena());
                 io_fab.copy< amrex::RunOn::Host >(fab, fab.box(), icomp, mfi.validbox(), 0, 1);


### PR DESCRIPTION
This PR is work by @ax3l and was originally pushed as #271.
From PR #271:
For the corner-case of enabling guards in m_F (through hipace.3d_on_host = 0), we need to copy the validbox data out before we can present contiguous memory for I/O.

The fix from #271 actually worked, but unfortunately PR #270 broke the openPMD I/O entirely, therefore it was reverted in #273.



- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
