### PR TITLE
Revert collective open in openPMD

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -882,7 +882,8 @@ Hipace::InitDiagnostics ()
     HIPACE_PROFILE("Hipace::InitDiagnostics()");
 
 #ifdef HIPACE_USE_OPENPMD
-    std::string filename = "diags/openPMD/openpmd.h5"; // bp or h5
+    std::string filename = "diags/openPMD/openpmd_%06T.h5"; // bp or h5
+    // std::string filename = "diags/openPMD/openpmd.h5"; // writing to single file did not work
 #   ifdef AMREX_USE_MPI
     m_outputSeries = std::make_unique< io::Series >(
         filename, io::Access::CREATE, amrex::ParallelDescriptor::Communicator());
@@ -891,9 +892,9 @@ Hipace::InitDiagnostics ()
         filename, io::Access::CREATE);
 #   endif
 
-    // open files early and collectively, so later flush calls are non-collective
-    m_outputSeries->setIterationEncoding( io::IterationEncoding::groupBased );
-    m_outputSeries->flush();
+    // // open files early and collectively, so later flush calls are non-collective
+    // m_outputSeries->setIterationEncoding( io::IterationEncoding::groupBased );
+    // m_outputSeries->flush();
 
     // TODO: meta-data: author, mesh path, extensions, software
 #endif


### PR DESCRIPTION
This PR reverts #270, which broke the openPMD I/O

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
