### PR TITLE
openPMD default Path: as in WarpX

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -918,7 +918,7 @@ Hipace::InitDiagnostics ()
     HIPACE_PROFILE("Hipace::InitDiagnostics()");
 
 #ifdef HIPACE_USE_OPENPMD
-    std::string filename = "diags/openPMD/openpmd.h5"; // bp or h5
+    std::string filename = "diags/h5/openpmd.h5"; // bp or h5
 #   ifdef AMREX_USE_MPI
     m_outputSeries = std::make_unique< io::Series >(
         filename, io::Access::CREATE, amrex::ParallelDescriptor::Communicator());


### PR DESCRIPTION
Unify the diagnostics path as in WarpX. This makes things
just more consistent, e.g. with openPMD-viewer's defaults: https://github.com/openPMD/openPMD-viewer/pull/263

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
