### PR TITLE
[mini] Fixing typo in notify finish

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -747,7 +747,7 @@ Hipace::NotifyFinish ()
             amrex::The_Pinned_Arena()->free(m_send_buffer);
             m_send_buffer = nullptr;
         }
-        if (m_send_buffer) {
+        if (m_psend_buffer) {
             MPI_Status status;
             MPI_Wait(&m_psend_request, &status);
             amrex::The_Pinned_Arena()->free(m_psend_buffer);


### PR DESCRIPTION
There was a typo in notify finish, which led to the warning
`mpool.c:43   UCX  WARN  object 0x11ba3bc0 was not returned to mpool ucp_requests`
because the `MPI_Wait` call for `m_psend_request` was not executed. Additionally, the buffer `m_psend_buffer` was not freed. Not freeing the memory would cause the simulation to segfault for larger runs.
This PR fixes the issue and the problem is not occurring anymore.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
