### PR TITLE
Sending info for adaptive time step via nonblocking communication

### DIFF
--- a/src/utils/AdaptiveTimeStep.H
+++ b/src/utils/AdaptiveTimeStep.H
@@ -18,6 +18,13 @@ private:
     bool m_do_adaptive_time_step = false;
     /** Number of time steps per betatron period for the adaptive time step */
     amrex::Real m_nt_per_omega_betatron = 0.07;
+    /** Send buffer for longitudinal parallelization (pipeline) */
+    amrex::Real* m_send_buffer = nullptr;
+    /** status of the send request */
+    MPI_Request m_send_request = MPI_REQUEST_NULL;
+
+    /** \brief When time step info sent to next rank, free buffer memory and make buffer nullptr */
+    void PassTimeStepInfoFinish ();
 
 public:
     /** Constructor */

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -33,18 +33,31 @@ AdaptiveTimeStep::PassTimeStepInfo (const int nt, MPI_Comm a_comm_z)
 
     if ((nt % numprocs_z == 0) && (my_rank_z >= 1))
     {
-        auto send_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(
+        PassTimeStepInfoFinish();
+        m_send_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(
             sizeof(amrex::Real)*WhichDouble::N);
         for (int idouble=0; idouble<(int) WhichDouble::N; idouble++) {
-            send_buffer[idouble] = m_timestep_data[idouble];
+            m_send_buffer[idouble] = m_timestep_data[idouble];
         }
 
-        MPI_Send(send_buffer, WhichDouble::N,
+        MPI_Isend(m_send_buffer, WhichDouble::N,
                  amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
-                 my_rank_z-1, comm_z_tag, a_comm_z);
+                 my_rank_z-1, comm_z_tag, a_comm_z, &m_send_request);
 
-        amrex::The_Pinned_Arena()->free(send_buffer);
     }
+}
+
+void
+AdaptiveTimeStep::PassTimeStepInfoFinish ()
+{
+#ifdef AMREX_USE_MPI
+    if (m_send_buffer) {
+        MPI_Status status;
+        MPI_Wait(&m_send_request, &status);
+        amrex::The_Pinned_Arena()->free(m_send_buffer);
+        m_send_buffer = nullptr;
+    }
+#endif
 }
 
 void

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -199,10 +199,11 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, const int nt, MultiBeam& beams,
         /* For serial runs, set adaptive time step right away */
         if (numprocs_z == 1) dt = new_dt;
 
-        auto send_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(sizeof(amrex::Real));
-        send_buffer[WhichDouble::Dt] = new_dt;
-        MPI_Send(send_buffer, 1, amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
-                 numprocs_z-1, comm_z_tag, a_comm_z);
-        amrex::The_Pinned_Arena()->free(send_buffer);
+        PassTimeStepInfoFinish();
+        m_send_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc(sizeof(amrex::Real));
+        m_send_buffer[WhichDouble::Dt] = new_dt;
+        MPI_Isend(m_send_buffer, 1, amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
+                 numprocs_z-1, comm_z_tag, a_comm_z, &m_send_request);
+
     }
 }


### PR DESCRIPTION
Previously, the adaptive time step info was send via blocking `MPI_Send`. This PR changes it into a nonblocking `MPI_Isend`. 

The performance gain is not a lot, but visible. 
In my tests, the average time spent in the `CalculateAdaptiveTimeStep` was reduced by 5%. The function is still sometimes taking way too much time (15% of the run time), due to the blocking `MPI_Recv`.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
