### PR TITLE
openPMD: cleaning of the openPMD beam data I/O

### DIFF
--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -15,7 +15,6 @@
 
 #ifdef HIPACE_USE_OPENPMD
 #include <openPMD/openPMD.hpp>
-namespace io = openPMD;
 
 /** \brief class handling the IO with openPMD */
 class OpenPMDWriter
@@ -76,7 +75,7 @@ private:
     amrex::Vector<std::string> m_real_names {"weighting", "momentum_x", "momentum_y", "momentum_z"};
 
     /** Parallel openPMD-api Series object for output */
-    std::unique_ptr< io::Series > m_outputSeries;
+    std::unique_ptr< openPMD::Series > m_outputSeries;
 public:
     /** Constructor */
     explicit OpenPMDWriter ();

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -131,7 +131,6 @@ OpenPMDWriter::WriteFieldData (Fields& a_fields, amrex::Geometry const& geom,
             field_comp.storeChunk(data, chunk_offset, chunk_size);
         }
     }
-
 }
 
 void
@@ -154,7 +153,6 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
         // Loop over particle boxes NOTE: Only 1 particle box allowed at the moment
         for (BeamParticleIterator pti(beams.getBeam(ibeam), lev); pti.isValid(); ++pti)
         {
-
             auto const numParticleOnTile = pti.numParticles();
             uint64_t const numParticleOnTile64 = static_cast<uint64_t>( numParticleOnTile );
             // get position and particle ID from aos
@@ -191,7 +189,6 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
             }
             //  save "extra" particle properties in SoA (momenta and weight)
             SaveRealProperty(pti, beam_species, offset, m_real_names);
-
         }  // end for (BeamParticleIterator pti(beams.getBeam(ibeam), lev); pti.isValid(); ++pti)
     }
 }
@@ -223,7 +220,6 @@ OpenPMDWriter::SetupPos(openPMD::ParticleSpecies& currSpecies,
     currSpecies["positionOffset"].setUnitDimension( utils::getUnitDimension("positionOffset") );
     currSpecies["charge"].setUnitDimension( utils::getUnitDimension("charge") );
     currSpecies["mass"].setUnitDimension( utils::getUnitDimension("mass") );
-
 }
 
 void

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -80,16 +80,16 @@ public:
     /** Loop over beams and receive total number of beam particles on upstream ranks */
     void WaitNumParticles (MPI_Comm a_comm_z);
 
-    std::string get_name () {return m_name;};
+    std::string get_name () const {return m_name;};
     bool m_do_z_push {true}; /**< Pushing beam particles in z direction */
     /** Number of particles on upstream rank (required for IO) */
     int m_num_particles_on_upstream_ranks {0};
 
     unsigned long long m_total_num_particles {0};
 
-    int get_upstream_n_part () {return m_num_particles_on_upstream_ranks;};
+    int get_upstream_n_part () const {return m_num_particles_on_upstream_ranks;};
 
-    unsigned long long get_total_num_particles () {return m_total_num_particles;};
+    unsigned long long get_total_num_particles () const {return m_total_num_particles;};
 
     /** \brief Converts momenta from code convention (gamma * v) to SI (m * gamma * v) and vice-versa.
      *

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -69,19 +69,21 @@ public:
     BeamParticleContainer& getBeam (int i) {return m_all_beams[i];};
 
     /** returns the number of beams */
-    int get_nbeams () {return m_nbeams;};
+    int get_nbeams () const {return m_nbeams;};
 
     /** returns the name of a beam */
-    std::string get_name (int i) {return m_all_beams[i].get_name();};
+    std::string get_name (int i) const {return m_all_beams[i].get_name();};
 
     /** returns the local number of particles of a beam */
-    unsigned long long get_local_n_part (int i) {return m_all_beams[i].TotalNumberOfParticles(1,1);};
+    unsigned long long get_local_n_part (int i) const
+        {return m_all_beams[i].TotalNumberOfParticles(1,1);};
 
     /** returns the local number of particles of a beam */
-    unsigned long long get_total_num_particles (int i) {return m_all_beams[i].get_total_num_particles();};
+    unsigned long long get_total_num_particles (int i) const
+        {return m_all_beams[i].get_total_num_particles();};
 
     /** returns the number of beam particles of the upstream ranks */
-    int get_upstream_n_part (int i) {return m_all_beams[i].get_upstream_n_part();};
+    int get_upstream_n_part (int i) const {return m_all_beams[i].get_upstream_n_part();};
 
     /** Loop over beams and pass total number of beam particles on upstream ranks */
     void NotifyNumParticles (MPI_Comm a_comm_z);

--- a/src/utils/IOUtil.H
+++ b/src/utils/IOUtil.H
@@ -11,7 +11,6 @@
 
 #ifdef HIPACE_USE_OPENPMD
 #include <openPMD/openPMD.hpp>
-// namespace io = openPMD;
 #endif
 
 namespace utils


### PR DESCRIPTION
This PR is a follow up for #277 and includes @MaxThevenet suggestions for improving the PR.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
