### PR TITLE
Removing namespace io = openPMD

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -14,7 +14,6 @@
 #ifdef HIPACE_USE_OPENPMD
 #include <openPMD/openPMD.hpp>
 #include "diagnostics/OpenPMDWriter.H"
-namespace io = openPMD;
 #endif
 
 #include <memory>


### PR DESCRIPTION
This PR removes the `using namespace io = openPMD`, as the naming was inconsistent throughout the code.
This is supposed to ensure clarity.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
