### PR TITLE
Fix Serial compilation

### DIFF
--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -74,11 +74,13 @@ public:
                            const amrex::Geometry& geom,
                            const amrex::Real n_0);
 
+#ifdef AMREX_USE_MPI
     /** Loop over beams and pass total number of beam particles on upstream ranks */
     void NotifyNumParticles (MPI_Comm a_comm_z);
 
     /** Loop over beams and receive total number of beam particles on upstream ranks */
     void WaitNumParticles (MPI_Comm a_comm_z);
+#endif
 
     std::string get_name () const {return m_name;};
     bool m_do_z_push {true}; /**< Pushing beam particles in z direction */

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -107,6 +107,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
     m_total_num_particles = TotalNumberOfParticles();
 }
 
+#ifdef AMREX_USE_MPI
 void
 BeamParticleContainer::NotifyNumParticles (MPI_Comm a_comm_z)
 {
@@ -135,6 +136,7 @@ BeamParticleContainer::WaitNumParticles (MPI_Comm a_comm_z)
                  my_rank_z+1, comm_z_tag, a_comm_z, &status);
     }
 }
+#endif
 
 void
 BeamParticleContainer::ConvertUnits (ConvertDirection convert_direction)

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -85,11 +85,13 @@ public:
     /** returns the number of beam particles of the upstream ranks */
     int get_upstream_n_part (int i) const {return m_all_beams[i].get_upstream_n_part();};
 
+#ifdef AMREX_USE_MPI
     /** Loop over beams and pass total number of beam particles on upstream ranks */
     void NotifyNumParticles (MPI_Comm a_comm_z);
 
     /** Loop over beams and receive total number of beam particles on upstream ranks */
     void WaitNumParticles (MPI_Comm a_comm_z);
+#endif
 
     /** \brief Converts momenta from code convention (gamma * v) to SI (m * gamma * v) and vice-versa. */
     void ConvertUnits (ConvertDirection convert_dir);

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -73,6 +73,7 @@ MultiBeam::WritePlotFile (const std::string& filename)
     }
 }
 
+#ifdef AMREX_USE_MPI
 void
 MultiBeam::NotifyNumParticles (MPI_Comm a_comm_z)
 {
@@ -88,6 +89,7 @@ MultiBeam::WaitNumParticles (MPI_Comm a_comm_z)
         beam.WaitNumParticles(a_comm_z);
     }
 }
+#endif
 
 void
 MultiBeam::ConvertUnits (ConvertDirection convert_direction)


### PR DESCRIPTION
For the parallel IO with openPMD we require the number of particles in each rank upstream.
There were some `#ifdef AMREX_USE_MPI` missing, so the code would not compile in serial.

This is fixed now. It still has some warnings for unused parameters in the adaptive time step, which is quite a lot more effort to fix.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
