### PR TITLE
fix #ifdef HIPACE_USER_OPENPMD to get rid of compiler warnings

### DIFF
--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -59,6 +59,7 @@ public:
                               const amrex::Real dx_per_dzeta,
                               const amrex::Real dy_per_dzeta);
 
+#ifdef HIPACE_USE_OPENPMD
     /** Initialize a beam from an external input file using openPMD and HDF5 */
     void InitBeamFromFileHelper (std::string input_file,
                                  bool coordinates_specified,
@@ -73,6 +74,7 @@ public:
                            amrex::Array<std::string, AMREX_SPACEDIM> file_coordinates_xyz,
                            const amrex::Geometry& geom,
                            const amrex::Real n_0);
+#endif
 
     /** Loop over beams and pass total number of beam particles on upstream ranks */
     void NotifyNumParticles (MPI_Comm a_comm_z);

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -83,7 +83,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
                             m_dy_per_dzeta);
 
     } else if (m_injection_type == "from_file") {
-
+#ifdef HIPACE_USE_OPENPMD
         amrex::ParmParse pp(m_name);
         pp.get("input_file", m_input_file);
         bool coordinates_specified = pp.query("file_coordinates_xyz", m_file_coordinates_xyz);
@@ -96,7 +96,10 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 
         InitBeamFromFileHelper(m_input_file, coordinates_specified, m_file_coordinates_xyz, geom,
                                m_plasma_density);
-
+#else
+        amrex::Abort("beam particle injection via external_file requires openPMD support: "
+                     "Add HiPACE_OPENPMD=ON when compiling HiPACE++.\n");
+#endif  // HIPACE_USE_OPENPMD
     } else {
 
         amrex::Abort("Unknown beam injection type. Must be fixed_ppc, fixed_weight or from_file\n");

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -281,6 +281,7 @@ InitBeamFixedWeight (int num_to_add,
     return;
 }
 
+#ifdef HIPACE_USE_OPENPMD
 void
 BeamParticleContainer::
 InitBeamFromFileHelper (std::string input_file,
@@ -289,8 +290,6 @@ InitBeamFromFileHelper (std::string input_file,
                         const amrex::Geometry& geom,
                         const amrex::Real n_0)
 {
-#ifdef HIPACE_USE_OPENPMD
-
     HIPACE_PROFILE("BeamParticleContainer::InitParticles");
 
     openPMD::Datatype input_type = openPMD::Datatype::INT;
@@ -320,10 +319,6 @@ InitBeamFromFileHelper (std::string input_file,
     else{
         amrex::Abort("Unknown Datatype used in Beam Input file. Must use double or float\n");
     }
-#else
-        amrex::Abort("beam particle injection via external_file " + input_file +
-                     " requires openPMD support: Add HiPACE_OPENPMD=ON when compiling HiPACE++.\n");
-#endif  // HIPACE_USE_OPENPMD
     return;
 }
 
@@ -336,8 +331,6 @@ InitBeamFromFile (std::string input_file,
                   const amrex::Geometry& geom,
                   const amrex::Real n_0)
 {
-#ifdef HIPACE_USE_OPENPMD
-
     HIPACE_PROFILE("BeamParticleContainer::InitParticles");
 
     auto series = openPMD::Series( input_file , openPMD::Access::READ_ONLY);
@@ -532,9 +525,6 @@ InitBeamFromFile (std::string input_file,
         }
     }
     Redistribute();
-#else
-        amrex::Abort("beam particle injection via external_file " + input_file +
-                     " requires openPMD support: Add HiPACE_OPENPMD=ON when compiling HiPACE++.\n");
-#endif  // HIPACE_USE_OPENPMD
     return;
 }
+#endif // HIPACE_USE_OPENPMD


### PR DESCRIPTION
Previously, the readin functions from a openPMD file caused some compiler warnings for unused parameters if compiled without openPMD on CPUs.

This is fixed by placing the `#ifdef HIPACE_USE_OPENPMD` around the whole functions. The assert for openPMD is moved to the earliest position.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
