### PR TITLE
[mini] fix compiler warning for compiling without openPMD

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -744,7 +744,6 @@ void
 Hipace::WriteDiagnostics (int output_step, bool force_output)
 {
     HIPACE_PROFILE("Hipace::WriteDiagnostics()");
-    constexpr int lev = 0;
 
     // Dump before first and after last step, and every m_output_period steps in-between
     if (m_output_period < 0 ||
@@ -763,6 +762,7 @@ Hipace::WriteDiagnostics (int output_step, bool force_output)
     amrex::Vector<std::string> rfs;
 
 #ifdef HIPACE_USE_OPENPMD
+    constexpr int lev = 0;
     m_openpmd_writer.WriteDiagnostics(m_fields.getDiagF(), m_multi_beam, m_fields.getDiagGeom(),
                                       m_physical_time, output_step,  lev, m_fields.getDiagSliceDir(), varnames);
 #else


### PR DESCRIPTION
in the diagnostics `lev` is only used for openPMD, but was declared globally, resulting in an unused parameter warning, if compiled without openPMD. `lev` is now defined in the openPMD only area, fixing the warning.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
