### PR TITLE
checksum.py: unused import "re"

### DIFF
--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -7,7 +7,6 @@ License: BSD-3-Clause-LBNL
 """
 from benchmark import Benchmark
 from backend.openpmd_backend import Backend
-import re
 import sys
 import numpy as np
 


### PR DESCRIPTION
Removed an unused import.

Included in https://github.com/ECP-WarpX/WarpX/pull/1621

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
