### PR TITLE
openPMD-api: new CMake Control (tests)

### DIFF
--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -10,7 +10,7 @@ function(find_openpmd)
         set(openPMD_BUILD_CLI_TOOLS OFF           CACHE INTERNAL "")
         set(openPMD_BUILD_EXAMPLES  OFF           CACHE INTERNAL "")
         set(openPMD_BUILD_TESTING   OFF           CACHE INTERNAL "")
-        set(openPMD_INSTALL ${BUILD_SHARED_LIBS}  CACHE INTERNAL "")
+        set(openPMD_BUILD_SHARED_LIBS OFF         CACHE INTERNAL "")
 
         FetchContent_Declare(fetchedopenpmd
             GIT_REPOSITORY ${HiPACE_openpmd_repo}


### PR DESCRIPTION
Use the latest commit in openPMD-api (dev branch post 0.13.1, PR https://github.com/openPMD/openPMD-api/pull/897) that adds control for per-project build options for tests.

This saves us from building and running openPMD-api tests in the HiPACE superbuild.

Fix #307

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
