### PR TITLE
[SCALING TEST] [DO NOT MERGE] Allocated Pinned memory buffer only once at init

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -141,7 +141,7 @@ public:
     /** My rank in the longitudinal communicator */
     int m_rank_z = 0;
     /** Max number of grid size in the longitudinal direction */
-    int m_grid_size_z = 0;    
+    int m_grid_size_z = 0;
     /** Field send buffer for the pipeline */
     amrex::Real* m_fields_send_buffer = nullptr;
     /** Field recv buffer for the pipeline */

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -141,11 +141,15 @@ public:
     /** My rank in the longitudinal communicator */
     int m_rank_z = 0;
     /** Max number of grid size in the longitudinal direction */
-    int m_grid_size_z = 0;
-    /** Send buffer for longitudinal parallelization (pipeline) */
-    amrex::Real* m_send_buffer = nullptr;
-    /** Send buffer for particle longitudinal parallelization (pipeline) */
-    char* m_psend_buffer = nullptr;
+    int m_grid_size_z = 0;    
+    /** Field send buffer for the pipeline */
+    amrex::Real* m_fields_send_buffer = nullptr;
+    /** Field recv buffer for the pipeline */
+    amrex::Real* m_fields_recv_buffer = nullptr;
+    /** Plasma particles send buffer for the pipeline */
+    char* m_plasma_send_buffer = nullptr;
+    /** Plasma particles recv buffer for the pipeline */
+    char* m_plasma_recv_buffer = nullptr;
     /** status of the send request */
     MPI_Request m_send_request = MPI_REQUEST_NULL;
     /** status of the particle send request */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -98,14 +98,22 @@ Hipace::~Hipace ()
     NotifyFinish();
     MPI_Comm_free(&m_comm_xy);
     MPI_Comm_free(&m_comm_z);
-    amrex::The_Pinned_Arena()->free(m_fields_recv_buffer);
-    amrex::The_Pinned_Arena()->free(m_fields_send_buffer);
-    amrex::The_Pinned_Arena()->free(m_plasma_recv_buffer);
-    amrex::The_Pinned_Arena()->free(m_plasma_send_buffer);
-    m_fields_send_buffer = nullptr;
-    m_fields_recv_buffer = nullptr;
-    m_plasma_send_buffer = nullptr;
-    m_plasma_recv_buffer = nullptr;
+    if (m_fields_recv_buffer){
+        amrex::The_Pinned_Arena()->free(m_fields_recv_buffer);
+        m_fields_send_buffer = nullptr;
+    }
+    if (m_fields_send_buffer){
+        amrex::The_Pinned_Arena()->free(m_fields_send_buffer);
+        m_fields_recv_buffer = nullptr;
+    }
+    if (m_plasma_recv_buffer){
+        amrex::The_Pinned_Arena()->free(m_plasma_recv_buffer);
+        m_plasma_send_buffer = nullptr;
+    }
+    if (m_plasma_send_buffer){
+        amrex::The_Pinned_Arena()->free(m_plasma_send_buffer);
+        m_plasma_recv_buffer = nullptr;
+    }
 #endif
 }
 


### PR DESCRIPTION
We suspect that allocating Pinned memory buffers (for pipeline communication of fields and plasma particles) takes significant time, so this PR proposes to do it only once at init, and re-use the same buffers at each communication. We should still test if this is negligible.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
