### PR TITLE
[SCALING TEST] [WIP] Non-blocking communication for number of upstream beam particles

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -777,7 +777,9 @@ Hipace::Notify ()
         }
     }
     #ifdef HIPACE_USE_OPENPMD
-    /* pass the number of beam particles from the upstream ranks to get the offset for openPMD IO */
+    // finish the previous non-blockign send of the number of upstream beam particles
+    m_multi_beam.NotifyNumParticlesFinish();
+    // pass the number of beam particles from the upstream ranks to get the offset for openPMD IO
     m_multi_beam.NotifyNumParticles(m_comm_z);
     #endif
 #endif

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -80,6 +80,9 @@ public:
     /** Loop over beams and pass total number of beam particles on upstream ranks */
     void NotifyNumParticles (MPI_Comm a_comm_z);
 
+    /** finish the non-blocking send of the number of upstream beam particles */
+    void NotifyNumParticlesFinish ();
+
     /** Loop over beams and receive total number of beam particles on upstream ranks */
     void WaitNumParticles (MPI_Comm a_comm_z);
 #endif
@@ -125,6 +128,8 @@ private:
     std::string m_input_file; /**< Path to bean input file */
     /** Coordinates used in input file, are converted to Hipace Coordinates x y z respectively */
     amrex::Array<std::string, AMREX_SPACEDIM> m_file_coordinates_xyz;
+    /** status of the send request for the beam particle offset required for I/O */
+    MPI_Request m_send_request = MPI_REQUEST_NULL;
 };
 
 /** \brief Iterator over boxes in a particle container */

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -121,9 +121,19 @@ BeamParticleContainer::NotifyNumParticles (MPI_Comm a_comm_z)
         const int num_local_particles = TotalNumberOfParticles(1,1); // get local number of particles
         const int upstream_particles = m_num_particles_on_upstream_ranks + num_local_particles;
 
-        MPI_Send(&upstream_particles, 1,
+        MPI_Isend(&upstream_particles, 1,
                  amrex::ParallelDescriptor::Mpi_typemap<int>::type(),
-                 my_rank_z-1, comm_z_tag, a_comm_z);
+                 my_rank_z-1, comm_z_tag, a_comm_z, &m_send_request);
+    }
+}
+
+void
+BeamParticleContainer::NotifyNumParticlesFinish ()
+{
+    if (m_send_request) {
+        MPI_Status status;
+        MPI_Wait(&m_send_request, &status);
+        m_send_request = MPI_REQUEST_NULL;
     }
 }
 

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -114,6 +114,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 void
 BeamParticleContainer::NotifyNumParticles (MPI_Comm a_comm_z)
 {
+    HIPACE_PROFILE("BeamParticleContainer::NotifyNumParticles()");
     const int my_rank_z = amrex::ParallelDescriptor::MyProc();
 
     if (my_rank_z >= 1)
@@ -130,6 +131,7 @@ BeamParticleContainer::NotifyNumParticles (MPI_Comm a_comm_z)
 void
 BeamParticleContainer::NotifyNumParticlesFinish ()
 {
+    HIPACE_PROFILE("BeamParticleContainer::NotifyNumParticlesFinish()");
     if (m_send_request) {
         MPI_Status status;
         MPI_Wait(&m_send_request, &status);
@@ -140,6 +142,7 @@ BeamParticleContainer::NotifyNumParticlesFinish ()
 void
 BeamParticleContainer::WaitNumParticles (MPI_Comm a_comm_z)
 {
+    HIPACE_PROFILE("BeamParticleContainer::WaitNumParticles()");
     const int my_rank_z = amrex::ParallelDescriptor::MyProc();
     if (my_rank_z  < amrex::ParallelDescriptor::NProcs()-1)
     {

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -89,6 +89,9 @@ public:
     /** Loop over beams and pass total number of beam particles on upstream ranks */
     void NotifyNumParticles (MPI_Comm a_comm_z);
 
+    /** finish the non-blocking send of the number of upstream beam particles */
+    void NotifyNumParticlesFinish ();
+
     /** Loop over beams and receive total number of beam particles on upstream ranks */
     void WaitNumParticles (MPI_Comm a_comm_z);
 #endif

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -83,6 +83,14 @@ MultiBeam::NotifyNumParticles (MPI_Comm a_comm_z)
 }
 
 void
+MultiBeam::NotifyNumParticlesFinish ()
+{
+    for (auto& beam : m_all_beams) {
+        beam.NotifyNumParticlesFinish();
+    }
+}
+
+void
 MultiBeam::WaitNumParticles (MPI_Comm a_comm_z)
 {
     for (auto& beam : m_all_beams) {


### PR DESCRIPTION
For the parallel I/O, openPMD requires the number of beam particles of the upstream ranks, to determine the offset.

Previously, this was sent via blocking MPI calls. 
In this PR, the communication is switched to non-blocking MPI sends. 

This slightly increases the performance. 
For a strong scaling test (input script below), the results on JUWELS V100s were:

development:
```
output01.txt:Hipace::Evolve()                                  1      244.2      244.2      244.2  99.88%
output02.txt:Hipace::Evolve()                                  1      128.7      128.7      128.7  99.52%
output04.txt:Hipace::Evolve()                                  1      74.24      74.24      74.24  98.88%
output08.txt:Hipace::Evolve()                                  1      50.41      50.41      50.41  98.34%
```

This PR:
```
output01.txt:Hipace::Evolve()                                  1      242.4      242.4      242.4  99.88%
output02.txt:Hipace::Evolve()                                  1      129.9      129.9      129.9  99.47%
output04.txt:Hipace::Evolve()                                  1      74.16      74.16      74.16  98.91%
output08.txt:Hipace::Evolve()                                  1      46.03      46.03      46.03  98.24%
```

Input script:
```
amr.n_cell = 1023 1023 1024

hipace.normalized_units=1
hipace.predcorr_B_mixing_factor = 0.1
hipace.predcorr_max_iterations = 1
hipace.predcorr_B_error_tolerance = -4e-2
hipace.verbose = 1

hipace.beam_injection_cr=8
diagnostic.diag_type=xz

amr.blocking_factor = 1
amr.max_level = 0

max_step = 20
hipace.dt=14

hipace.output_period = -1
hipace.numprocs_x = 1
hipace.numprocs_y = 1

hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -8.   -8.   -6    # physical domain
geometry.prob_hi     =  8.    8.    6

beams.names= beam
beam.profile = gaussian
beam.injection_type = fixed_weight
beam.do_symmetrize = 1
beam.num_particles = 10000000
beam.density = 22.2222
beam.u_mean = 0. 0. 20000
beam.u_std = 30. 30. 0.
beam.position_mean = 0. 0. 0
beam.position_std = 0.3 0.3 1.41
beam.dx_per_dzeta = -0.00354609929 # this corresponds to 0.005 per sigma
beam.do_z_push = 0

plasma.density = 1.
plasma.ppc = 1 1
plasma.u_mean = 0.0 0.0 0.
```

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
