### PR TITLE
Send number of beam particles only at initialization

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -190,6 +190,14 @@ Hipace::InitData ()
     m_plasma_container.SetParticleDistributionMap(lev, m_slice_dm);
     m_plasma_container.SetParticleGeometry(lev, m_slice_geom);
     m_plasma_container.InitData();
+
+#ifdef AMREX_USE_MPI
+    #ifdef HIPACE_USE_OPENPMD
+    // receive and pass the number of beam particles to share the offset for openPMD IO
+    m_multi_beam.WaitNumParticles(m_comm_z);
+    m_multi_beam.NotifyNumParticles(m_comm_z);
+    #endif
+#endif
 }
 
 void
@@ -654,9 +662,6 @@ Hipace::Wait ()
             amrex::The_Pinned_Arena()->free(recv_buffer);
         }
     }
-    #ifdef HIPACE_USE_OPENPMD
-    m_multi_beam.WaitNumParticles(m_comm_z);
-    #endif
 #endif
 }
 
@@ -776,10 +781,6 @@ Hipace::Notify ()
                       m_rank_z-1, pcomm_z_tag, m_comm_z, &m_psend_request);
         }
     }
-    #ifdef HIPACE_USE_OPENPMD
-    /* pass the number of beam particles from the upstream ranks to get the offset for openPMD IO */
-    m_multi_beam.NotifyNumParticles(m_comm_z);
-    #endif
 #endif
 }
 


### PR DESCRIPTION
- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
