### PR TITLE
only init openPMD data if outputperiod > 0

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -335,7 +335,7 @@ Hipace::Evolve ()
     m_physical_time -= m_dt;
     WriteDiagnostics(m_max_step, true);
 #ifdef HIPACE_USE_OPENPMD
-    m_openpmd_writer.reset();
+    if (m_output_period > 0) m_openpmd_writer.reset();
 #endif
 }
 


### PR DESCRIPTION
Previously, even if `output_period = -1`, a `diags` folder was created. Now, only if there actually will be some output, the `diags` folder will be created.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
