### PR TITLE
[DO NOT MERGE] simplify parallelization assuming Nrank = Nboxes and only longitudinal parallelization

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -123,9 +123,6 @@ Hipace::DefineSliceGDB (const amrex::BoxArray& ba, const amrex::DistributionMapp
     // Slice DistributionMapping
     m_slice_dm = amrex::DistributionMapping(std::move(procmap));
 
-    amrex::Print()<<m_slice_ba<<'\n';
-    amrex::Print()<<m_slice_dm<<'\n';
-
     // Slice Geometry
     constexpr int lev = 0;
     const int dir = AMREX_SPACEDIM-1;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -104,42 +104,17 @@ Hipace::~Hipace ()
 void
 Hipace::DefineSliceGDB (const amrex::BoxArray& ba, const amrex::DistributionMapping& dm)
 {
-    std::map<int,amrex::Vector<amrex::Box> > boxes;
-    for (int i = 0; i < ba.size(); ++i) {
-        int rank = dm[i];
-        if (InSameTransverseCommunicator(rank)) {
-            boxes[rank].push_back(ba[i]);
-        }
-    }
-
-    // We assume each process may have multiple Boxes longitude direction, but only one Box in the
-    // transverse direction.  The union of all Boxes on a process is rectangular.  The slice
-    // BoxArray therefore has one Box per process.  The Boxes in the slice BoxArray have one cell in
-    // the longitude direction.  We will use the lowest longitude index in each process to construct
-    // the Boxes.  These Boxes do not have any overlaps. Transversely, there are no gaps between
-    // them.
+    AMREX_ALWAYS_ASSERT(m_numprocs_x == 1);
+    AMREX_ALWAYS_ASSERT(m_numprocs_y == 1);
+    AMREX_ALWAYS_ASSERT(ba.size() == amrex::ParallelDescriptor::NProcs());
 
     amrex::BoxList bl;
     amrex::Vector<int> procmap;
-    for (auto const& kv : boxes) {
-        int const iproc = kv.first;
-        auto const& boxes_i = kv.second;
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(boxes_i.size() > 0,
-                                         "We assume each process has at least one Box");
-        amrex::Box bx = boxes_i[0];
-        for (int j = 1; j < boxes_i.size(); ++j) {
-            amrex::Box const& bxj = boxes_i[j];
-            for (int idim = 0; idim < Direction::z; ++idim) {
-                AMREX_ALWAYS_ASSERT(bxj.smallEnd(idim) == bx.smallEnd(idim));
-                AMREX_ALWAYS_ASSERT(bxj.bigEnd(idim) == bx.bigEnd(idim));
-                if (bxj.smallEnd(Direction::z) < bx.smallEnd(Direction::z)) {
-                    bx = bxj;
-                }
-            }
-        }
+    {
+        amrex::Box bx = ba[amrex::ParallelDescriptor::MyProc()];
         bx.setBig(Direction::z, bx.smallEnd(Direction::z));
         bl.push_back(bx);
-        procmap.push_back(iproc);
+        procmap.push_back(amrex::ParallelDescriptor::MyProc());
     }
 
     // Slice BoxArray
@@ -147,6 +122,9 @@ Hipace::DefineSliceGDB (const amrex::BoxArray& ba, const amrex::DistributionMapp
 
     // Slice DistributionMapping
     m_slice_dm = amrex::DistributionMapping(std::move(procmap));
+
+    amrex::Print()<<m_slice_ba<<'\n';
+    amrex::Print()<<m_slice_dm<<'\n';
 
     // Slice Geometry
     constexpr int lev = 0;


### PR DESCRIPTION
Just to illustrate that assuming:
- no transverse parallelization
- 1 box per MPI

we can simplify the communications quite a bit. Not sure whether we want to do that, but if so all the changes should be gathered into 1 PR, so we can revert it back in the future if we need to relax one of the assumptions above.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
