### PR TITLE
fix bug by using std::abs instead of abs

### DIFF
--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -111,7 +111,6 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
         pti.numParticles(),
         [=] AMREX_GPU_DEVICE (long ip) {
 
-            if ( std::abs(wp[ip]) < std::numeric_limits<amrex::Real>::epsilon() ) return;
             const amrex::Real psi = psip[ip] *
                 phys_const.q_e / (phys_const.m_e * phys_const.c * phys_const.c);
 


### PR DESCRIPTION
In the plasma particle pusher, we filtered the particles which left the box or violated the QSA by checking for the weight.
This PR uses the correct absolute function `std::abs` instead of using the abs just for ints `abs()`.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
