### PR TITLE
CMake: Quick, Local Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,18 @@ Note: this page is outdated, in order to get the latest documentation please do
 ### Install
 
 To do: users can install HiPACE with the following one-liners...
+(This needs to be done once we go open source, so we can set up conda-forge, Spack et al.)
 
 ### Usage
 
-Usage docs.
+To do: Usage docs.
 
 
 ## Developers
+
+If you are new to CMake, [this short tutorial](https://hsf-training.github.io/hsf-training-cmake-webpage/) from the HEP Software foundation is the perfect place to get started with it.
+
+If you just want to use CMake to build the project, jump into sections *1. Introduction*, *2. Building with CMake* and *9. Finding Packages*.
 
 ### Dependencies
 
@@ -100,25 +105,25 @@ export CUDAHOSTCXX=$(which g++)
 
 From the base of the HiPACE source directory, execute:
 ```bash
-mkdir -p build
-cd build
-
 # find dependencies & configure
-cmake ..
+cmake -S . -B build
 
 # build using up to four threads
-make -j 4
+cmake --build build -j 4
 
 # run tests
-ctest --output-on-failure
+(cd build; ctest --output-on-failure)
 ```
 
-You can inspect and modify build options after running `cmake ..` with either
+An executable HiPACE binary with the current compile-time options encoded in its file name will be created in ``bin/``.
+Additionally, a `symbolic link <https://en.wikipedia.org/wiki/Symbolic_link>`_ named ``hipace`` can be found in that directory, which points to the last built HiPACE executable.
+
+You can inspect and modify build options after first running `cmake` with either
 ```bash
-ccmake .
+ccmake build
 ```
 
-or by providing arguments to the CMake call: `cmake .. -D<OPTION_A>=<VALUE_A> -D<OPTION_B>=<VALUE_B>`
+or by providing arguments to the CMake call: `cmake -S . -B build -D<OPTION_A>=<VALUE_A> -D<OPTION_B>=<VALUE_B>`
 
 | CMake Option                 | Default & Values                           | Description                                         |
 |------------------------------|--------------------------------------------|-----------------------------------------------------|
@@ -126,18 +131,34 @@ or by providing arguments to the CMake call: `cmake .. -D<OPTION_A>=<VALUE_A> -D
 | `HiPACE_COMPUTE`             | **NOACC**/CUDA/SYCL/HIP/OMP                | On-node, accelerated computing backend              |
 | `HiPACE_MPI`                 | **ON**/OFF                                 | Multi-node support (message-passing)                |
 | `HiPACE_PRECISION`           | SINGLE/**DOUBLE**                          | Floating point precision (single/double)            |
-| `HiPACE_amrex_repo`          | `https://github.com/AMReX-Codes/amrex.git` | Repository URI to pull and build AMReX from         |
-| `HiPACE_amrex_branch`        | `development`                              | Repository branch for `HiPACE_amrex_repo`           |
-| `HiPACE_amrex_internal`      | **ON**/OFF                                 | Needs a pre-installed AMReX library if set to `OFF` |
-| `HiPACE_OPENPMD`             |  **ON**/OFF                                | openPMD I/O (HDF5, ADIOS2)                           |
+| `HiPACE_OPENPMD`             |  **ON**/OFF                                | openPMD I/O (HDF5, ADIOS2)                          |
 
-For example, one can also build against a local AMReX git repo.
-Assuming AMReX' source is located in `$HOME/src/amrex` and changes are committed into a branch such as `my-amrex-branch` then pass to `cmake` the arguments `-DHiPACE_amrex_repo=file://$HOME/src/amrex -DHiPACE_amrex_branch=my-amrex-branch`.
+HiPACE can be configured in further detail with options from AMReX, which are [documented in the AMReX manual](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#customization-options).
 
-For developers, HiPACE can be configured in further detail with options from AMReX, which are [documented in the AMReX manual](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#customization-options).
+**Developers** might be interested in additional options that control dependencies of HiPACE.
+By default, the most important dependencies of HiPACE are automatically downloaded for convenience:
 
-An executable HiPACE binary with the current compile-time options encoded in its file name will be created in ``bin/``.
-Additionally, a `symbolic link <https://en.wikipedia.org/wiki/Symbolic_link>`_ named ``hipace`` can be found in that directory, which points to the last built HiPACE executable.
+| CMake Option              | Default & Values                             | Description                                               |
+|---------------------------|----------------------------------------------|-----------------------------------------------------------|
+| `HiPACE_amrex_src`        | *None*                                       | Path to AMReX source directory (preferred if set)         |
+| `HiPACE_amrex_repo`       | `https://github.com/AMReX-Codes/amrex.git`   | Repository URI to pull and build AMReX from               |
+| `HiPACE_amrex_branch`     | `development`                                | Repository branch for `HiPACE_amrex_repo`                 |
+| `HiPACE_amrex_internal`   | **ON**/OFF                                   | Needs a pre-installed AMReX library if set to `OFF`       |
+| `HiPACE_openpmd_src`      | *None*                                       | Path to openPMD-api source directory (preferred if set)   |
+| `HiPACE_openpmd_repo`     | `https://github.com/openPMD/openPMD-api.git` | Repository URI to pull and build openPMD-api from         |
+| `HiPACE_openpmd_branch`   | `0.13.2`                                     | Repository branch for `HiPACE_openpmd_repo`               |
+| `HiPACE_openpmd_internal` | **ON**/OFF                                   | Needs a pre-installed openPMD-api library if set to `OFF` |
+
+For example, one can also build against a local AMReX copy.
+Assuming AMReX' source is located in `$HOME/src/amrex`, add the `cmake` argument `-DHiPACE_amrex_src=$HOME/src/amrex`.
+Relative paths are also supported, e.g. `-DHiPACE_amrex_src=../amrex`.
+
+Or build against an AMReX feature branch of a colleague.
+Assuming your colleague pushed AMReX to `https://github.com/WeiqunZhang/amrex/` in a branch `new-feature` then pass to `cmake` the arguments: `-DHiPACE_amrex_repo=https://github.com/WeiqunZhang/amrex.git -DHiPACE_amrex_branch=new-feature`.
+
+You can speed up the install further if you pre-install these dependencies, e.g. with a package manager.
+Set `-DHiPACE_<dependency-name>_internal=OFF` and add installation prefix of the dependency to the environment variable [CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/latest/envvar/CMAKE_PREFIX_PATH.html).
+Please see the [short CMake tutorial that we linked above](#Developers) if this sounds new to you.
 
 
 ## Run a first simulation and look at the results


### PR DESCRIPTION
This is a port of https://github.com/ECP-WarpX/WarpX/pull/1699 / https://github.com/ECP-WarpX/WarpX/pull/1707 from WarpX.

This adds new options to CMake for developers that like to build against local dependencies. For example:

```bash
cmake -S . -B build -DHiPACE_amrex_src=../amrex
cmake --build build -j 8
```

brings back the full "build my local source, I am working on it"-experience.

Added for all auto-downloaded dependencies:
- AMReX
- openPMD-api

## Checklist

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
