### PR TITLE
[mini] renaming to the correctly describing name peak_current_density

### DIFF
--- a/src/utils/GridCurrent.H
+++ b/src/utils/GridCurrent.H
@@ -15,7 +15,7 @@ private:
     amrex::RealVect m_position_mean {0., 0., 0.};
     /** Width of the Gaussian grid current. */
     amrex::RealVect m_position_std {0., 0., 0.};
-    amrex::Real m_amplitude {0.}; /**< peak amplitude for grid current */
+    amrex::Real m_peak_current_density {0.}; /**< peak density for the grid current */
 
 public:
     /** Constructor */

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -8,7 +8,7 @@ GridCurrent::GridCurrent ()
     amrex::ParmParse pp("grid_current");
 
     if (pp.query("use_grid_current", m_use_grid_current) ) {
-        pp.get("amplitude", m_amplitude);
+        pp.get("peak_current_density", m_peak_current_density);
         amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
         pp.get("position_mean", loc_array);
         for (int idim=0; idim < AMREX_SPACEDIM; ++idim) m_position_mean[idim] = loc_array[idim];
@@ -45,7 +45,7 @@ GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, i
     const amrex::Real z = plo[2] + islice*dx_arr[2];
     const amrex::Real delta_z = (z - pos_mean[2]) / pos_std[2];
     const amrex::Real long_pos_factor =  std::exp( -0.5_rt*(delta_z*delta_z) );
-    const amrex::Real loc_amplitude = m_amplitude;
+    const amrex::Real loc_peak_current_density = m_peak_current_density;
 
     for ( amrex::MFIter mfi(S, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
         const amrex::Box& bx = mfi.tilebox();
@@ -62,7 +62,7 @@ GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, i
             const amrex::Real trans_pos_factor =  std::exp( -0.5_rt*(delta_x*delta_x
                                                                     + delta_y*delta_y) );
 
-            jz_arr(i, j, k) += loc_amplitude*trans_pos_factor*long_pos_factor;
+            jz_arr(i, j, k) += loc_peak_current_density*trans_pos_factor*long_pos_factor;
         });
     }
 }

--- a/tests/grid_current.1Rank.sh
+++ b/tests/grid_current.1Rank.sh
@@ -22,7 +22,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         geometry.prob_lo = -8. -8. -6. \
         geometry.prob_hi =  8.  8.  6. \
         grid_current.use_grid_current = 1 \
-        grid_current.amplitude= 0.2 \
+        grid_current.peak_current_density= 0.2 \
         grid_current.position_mean = 0. 0. 0. \
         grid_current.position_std = 0.3 0.3 1.41 \
         hipace.output_period = 1 \


### PR DESCRIPTION
As @MaxThevenet pointed out, the name `amplitude` for the grid current is a bit misleading.
This PR names it correctly to `peak_current_density`, which it is. 

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
