### PR TITLE
[New Pipeline] Prototype communication

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -84,8 +84,10 @@ public:
      * Initialize a buffer (in pinned memory on Nvidia GPUs) for slices to be sent (2 and 3),
      * copy from slice multifabs of current rank to the buffer, MPI_Isend the buffer to
      * the rank downstream.
+     *
+     * \param[in] step current time step
      */
-    void Notify ();
+    void Notify (const int step);
     /** \brief When slices sent to rank downstream, free buffer memory and make buffer nullptr */
     void NotifyFinish ();
 
@@ -142,12 +144,9 @@ public:
     int m_rank_z = 0;
     /** Max number of grid size in the longitudinal direction */
     int m_grid_size_z = 0;
-    /** Send buffer for longitudinal parallelization (pipeline) */
-    amrex::Real* m_send_buffer = nullptr;
-    /** Send buffer for particle longitudinal parallelization (pipeline) */
-    char* m_psend_buffer = nullptr;
-    /** status of the send request */
-    MPI_Request m_send_request = MPI_REQUEST_NULL;
+    // FIXME: beam particle communication
+    // /** Send buffer for particle longitudinal parallelization (pipeline) */
+    // char* m_psend_buffer = nullptr;
     /** status of the particle send request */
     MPI_Request m_psend_request = MPI_REQUEST_NULL;
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -196,8 +196,9 @@ Hipace::InitData ()
 #ifdef AMREX_USE_MPI
     #ifdef HIPACE_USE_OPENPMD
     // receive and pass the number of beam particles to share the offset for openPMD IO
-    m_multi_beam.WaitNumParticles(m_comm_z);
-    m_multi_beam.NotifyNumParticles(m_comm_z);
+    // FIXME: sending the total number of particles will no longer be required.
+    // m_multi_beam.WaitNumParticles(m_comm_z);
+    // m_multi_beam.NotifyNumParticles(m_comm_z);
     #endif
 #endif
 }
@@ -301,8 +302,6 @@ Hipace::Evolve ()
 
         ResetAllQuantities(lev);
 
-        // Wait();
-
         /* Store charge density of (immobile) ions into WhichSlice::RhoIons */
         if (m_rank_z == m_numprocs_z-1){
             DepositCurrent(m_plasma_container, m_fields, WhichSlice::RhoIons,
@@ -312,6 +311,8 @@ Hipace::Evolve ()
         // Loop over longitudinal boxes on this rank, from head to tail
         for (int it = m_numprocs_z-1; it >= 0; --it)
         {
+            if (step > 0) Wait();
+
             const amrex::Box& bx = boxArray(lev)[it];
             // FIXME use amrex::FArrayBox::resize(bx) to re-use the same memory
             // amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>> bins; FIXME: beam disabled
@@ -320,6 +321,8 @@ Hipace::Evolve ()
             for (int isl = bx.bigEnd(Direction::z); isl >= bx.smallEnd(Direction::z); --isl){
                 SolveOneSlice(isl, lev); //, bins); FIXME: beam disabled
             };
+
+            Notify(step);
         }
 
         // FIXME: beam disabled
@@ -335,7 +338,6 @@ Hipace::Evolve ()
         // m_adaptive_time_step.PassTimeStepInfo(step, m_comm_z);
         // Slices have already been shifted, so send
         // slices {2,3} from upstream to {2,3} in downstream.
-        // Notify();
 
 #ifdef HIPACE_USE_OPENPMD
         WriteDiagnostics(step+1);
@@ -348,7 +350,7 @@ Hipace::Evolve ()
     // the time stored in the output file is the time for the fields. The beam is one time step
     // ahead.
     m_physical_time -= m_dt;
-    WriteDiagnostics(m_max_step, true);
+    // WriteDiagnostics(m_max_step, true);
 #ifdef HIPACE_USE_OPENPMD
     if (m_output_period > 0) m_openpmd_writer.reset();
 #endif
@@ -556,235 +558,174 @@ Hipace::Wait ()
 {
     HIPACE_PROFILE("Hipace::Wait()");
 #ifdef AMREX_USE_MPI
+    int recv_buffer;
+    MPI_Status status;
+
     if (m_rank_z != m_numprocs_z-1) {
-        {
-        const int lev = 0;
-        amrex::MultiFab& slice2 = m_fields.getSlices(lev, WhichSlice::Previous1);
-        amrex::MultiFab& slice3 = m_fields.getSlices(lev, WhichSlice::Previous2);
-        amrex::MultiFab& slice4 = m_fields.getSlices(lev, WhichSlice::RhoIons);
-        // Note that there is only one local Box in slice multifab's boxarray.
-        const int box_index = slice2.IndexArray()[0];
-        amrex::Array4<amrex::Real> const& slice_fab2 = slice2.array(box_index);
-        amrex::Array4<amrex::Real> const& slice_fab3 = slice3.array(box_index);
-        amrex::Array4<amrex::Real> const& slice_fab4 = slice4.array(box_index);
-        const amrex::Box& bx = slice2.boxArray()[box_index]; // does not include ghost cells
-        const std::size_t nreals_valid_slice2 = bx.numPts()*slice_fab2.nComp();
-        const std::size_t nreals_valid_slice3 = bx.numPts()*slice_fab3.nComp();
-        const std::size_t nreals_valid_slice4 = bx.numPts()*slice_fab4.nComp();
-        const std::size_t nreals_total =
-            nreals_valid_slice2 + nreals_valid_slice3 + nreals_valid_slice4;
-        auto recv_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc
-            (sizeof(amrex::Real)*nreals_total);
-        auto const buf2 = amrex::makeArray4(recv_buffer,
-                                            bx, slice_fab2.nComp());
-        auto const buf3 = amrex::makeArray4(recv_buffer+nreals_valid_slice2,
-                                            bx, slice_fab3.nComp());
-        auto const buf4 = amrex::makeArray4(recv_buffer+nreals_valid_slice2+nreals_valid_slice3,
-                                            bx, slice_fab4.nComp());
-        MPI_Status status;
-        MPI_Recv(recv_buffer, nreals_total,
-                 amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
-                 m_rank_z+1, comm_z_tag, m_comm_z, &status);
-        amrex::ParallelFor
-            (bx, slice_fab2.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-             {
-                 slice_fab2(i,j,k,n) = buf2(i,j,k,n);
-             },
-             bx, slice_fab3.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-             {
-                 slice_fab3(i,j,k,n) = buf3(i,j,k,n);
-             },
-             bx, slice_fab4.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-             {
-                 slice_fab4(i,j,k,n) = buf4(i,j,k,n);
-             });
-
-        amrex::Gpu::Device::synchronize();
-        amrex::The_Pinned_Arena()->free(recv_buffer);
-        }
-
-        // Same thing for the plasma particles. Currently only one tile.
-        {
-            const int lev = 0;
-            const amrex::Long np = m_plasma_container.m_num_exchange;
-            const amrex::Long psize = m_plasma_container.superParticleSize();
-            const amrex::Long buffer_size = psize*np;
-            auto recv_buffer = (char*)amrex::The_Pinned_Arena()->alloc(buffer_size);
-
-            MPI_Status status;
-            MPI_Recv(recv_buffer, buffer_size,
-                     amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
-                     m_rank_z+1, pcomm_z_tag, m_comm_z, &status);
-
-            auto& ptile = m_plasma_container.DefineAndReturnParticleTile(lev, 0, 0);
-            ptile.resize(np);
-            const auto ptd = ptile.getParticleTileData();
-
-            const amrex::Gpu::DeviceVector<int> comm_real(m_plasma_container.NumRealComps(), 1);
-            const amrex::Gpu::DeviceVector<int> comm_int (m_plasma_container.NumIntComps(),  1);
-            const auto p_comm_real = comm_real.data();
-            const auto p_comm_int = comm_int.data();
-#ifdef AMREX_USE_GPU
-            if (amrex::Gpu::inLaunchRegion()) {
-                int const np_per_block = 128;
-                int const nblocks = (np+np_per_block-1)/np_per_block;
-                std::size_t const shared_mem_bytes = np_per_block * psize;
-                // NOTE - TODO DPC++
-                amrex::launch(nblocks, np_per_block, shared_mem_bytes, amrex::Gpu::gpuStream(),
-                [=] AMREX_GPU_DEVICE () noexcept
-                {
-                    amrex::Gpu::SharedMemory<char> gsm;
-                    char* const shared = gsm.dataPtr();
-
-                    // Copy packed data from recv_buffer (in pinned memory) to shared memory
-                    const int i = blockDim.x*blockIdx.x+threadIdx.x;
-                    const unsigned int m = threadIdx.x;
-                    const unsigned int mend = amrex::min<unsigned int>(blockDim.x, np-blockDim.x*blockIdx.x);
-                    for (unsigned int index = m;
-                         index < mend*psize/sizeof(double); index += blockDim.x) {
-                        const double *csrc = (double *)(recv_buffer+blockDim.x*blockIdx.x*psize);
-                        double *cdest = (double *)shared;
-                        cdest[index] = csrc[index];
-                    }
-
-                    __syncthreads();
-                    // Unpack in shared memory, and move to device memory
-                    if (i < np) {
-                        ptd.unpackParticleData(shared, m*psize, i, p_comm_real, p_comm_int);
-                    }
-                });
-            } else
-#endif
-            {
-                for (int i = 0; i < np; ++i)
-                {
-                    ptd.unpackParticleData(recv_buffer, i*psize, i, p_comm_real, p_comm_int);
-                }
-            }
-
-            amrex::Gpu::Device::synchronize();
-            amrex::The_Pinned_Arena()->free(recv_buffer);
-        }
+        // all ranks except the head rank receive from one rank upstream
+        MPI_Recv(&recv_buffer, 1,
+                 amrex::ParallelDescriptor::Mpi_typemap<int>::type(),
+                 m_rank_z+1, pcomm_z_tag, m_comm_z, &status);
+    } else {
+        // the head rank receives the data from the tail rank
+        MPI_Recv(&recv_buffer, 1,
+                 amrex::ParallelDescriptor::Mpi_typemap<int>::type(),
+                 0, pcomm_z_tag, m_comm_z, &status);
     }
+// FIXME these should be beam particles
+//         // Same thing for the plasma particles. Currently only one tile.
+//         {
+//             const int lev = 0;
+//             const amrex::Long np = m_plasma_container.m_num_exchange;
+//             const amrex::Long psize = m_plasma_container.superParticleSize();
+//             const amrex::Long buffer_size = psize*np;
+//             auto recv_buffer = (char*)amrex::The_Pinned_Arena()->alloc(buffer_size);
+//
+//             MPI_Status status;
+//             MPI_Recv(recv_buffer, buffer_size,
+//                      amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
+//                      m_rank_z+1, pcomm_z_tag, m_comm_z, &status);
+//
+//             auto& ptile = m_plasma_container.DefineAndReturnParticleTile(lev, 0, 0);
+//             ptile.resize(np);
+//             const auto ptd = ptile.getParticleTileData();
+//
+//             const amrex::Gpu::DeviceVector<int> comm_real(m_plasma_container.NumRealComps(), 1);
+//             const amrex::Gpu::DeviceVector<int> comm_int (m_plasma_container.NumIntComps(),  1);
+//             const auto p_comm_real = comm_real.data();
+//             const auto p_comm_int = comm_int.data();
+// #ifdef AMREX_USE_GPU
+//             if (amrex::Gpu::inLaunchRegion()) {
+//                 int const np_per_block = 128;
+//                 int const nblocks = (np+np_per_block-1)/np_per_block;
+//                 std::size_t const shared_mem_bytes = np_per_block * psize;
+//                 // NOTE - TODO DPC++
+//                 amrex::launch(nblocks, np_per_block, shared_mem_bytes, amrex::Gpu::gpuStream(),
+//                 [=] AMREX_GPU_DEVICE () noexcept
+//                 {
+//                     amrex::Gpu::SharedMemory<char> gsm;
+//                     char* const shared = gsm.dataPtr();
+//
+//                     // Copy packed data from recv_buffer (in pinned memory) to shared memory
+//                     const int i = blockDim.x*blockIdx.x+threadIdx.x;
+//                     const unsigned int m = threadIdx.x;
+//                     const unsigned int mend = amrex::min<unsigned int>(blockDim.x, np-blockDim.x*blockIdx.x);
+//                     for (unsigned int index = m;
+//                          index < mend*psize/sizeof(double); index += blockDim.x) {
+//                         const double *csrc = (double *)(recv_buffer+blockDim.x*blockIdx.x*psize);
+//                         double *cdest = (double *)shared;
+//                         cdest[index] = csrc[index];
+//                     }
+//
+//                     __syncthreads();
+//                     // Unpack in shared memory, and move to device memory
+//                     if (i < np) {
+//                         ptd.unpackParticleData(shared, m*psize, i, p_comm_real, p_comm_int);
+//                     }
+//                 });
+//             } else
+// #endif
+//             {
+//                 for (int i = 0; i < np; ++i)
+//                 {
+//                     ptd.unpackParticleData(recv_buffer, i*psize, i, p_comm_real, p_comm_int);
+//                 }
+//             }
+//
+//             amrex::Gpu::Device::synchronize();
+//             amrex::The_Pinned_Arena()->free(recv_buffer);
+//         }
+
 #endif
 }
 
 void
-Hipace::Notify ()
+Hipace::Notify (const int step)
 {
     HIPACE_PROFILE("Hipace::Notify()");
     // Send from slices 2 and 3 (or main MultiFab's first two valid slabs) to receiver's slices 2
     // and 3.
 
 #ifdef AMREX_USE_MPI
+    NotifyFinish(); // finish the previous send
+
+    const int test_int = 1;
     if (m_rank_z != 0) {
-        NotifyFinish(); // finish the previous send
-
-        {
-        const int lev = 0;
-        const amrex::MultiFab& slice2 = m_fields.getSlices(lev, WhichSlice::Previous1);
-        const amrex::MultiFab& slice3 = m_fields.getSlices(lev, WhichSlice::Previous2);
-        const amrex::MultiFab& slice4 = m_fields.getSlices(lev, WhichSlice::RhoIons);
-        // Note that there is only one local Box in slice multifab's boxarray.
-        const int box_index = slice2.IndexArray()[0];
-        amrex::Array4<amrex::Real const> const& slice_fab2 = slice2.array(box_index);
-        amrex::Array4<amrex::Real const> const& slice_fab3 = slice3.array(box_index);
-        amrex::Array4<amrex::Real const> const& slice_fab4 = slice4.array(box_index);
-        const amrex::Box& bx = slice2.boxArray()[box_index]; // does not include ghost cells
-        const std::size_t nreals_valid_slice2 = bx.numPts()*slice_fab2.nComp();
-        const std::size_t nreals_valid_slice3 = bx.numPts()*slice_fab3.nComp();
-        const std::size_t nreals_valid_slice4 = bx.numPts()*slice_fab4.nComp();
-        const std::size_t nreals_total =
-            nreals_valid_slice2 + nreals_valid_slice3 + nreals_valid_slice4;
-        m_send_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc
-            (sizeof(amrex::Real)*nreals_total);
-        auto const buf2 = amrex::makeArray4(m_send_buffer,
-                                            bx, slice_fab2.nComp());
-        auto const buf3 = amrex::makeArray4(m_send_buffer+nreals_valid_slice2,
-                                            bx, slice_fab3.nComp());
-        auto const buf4 = amrex::makeArray4(m_send_buffer+nreals_valid_slice2+nreals_valid_slice3,
-                                            bx, slice_fab4.nComp());
-        amrex::ParallelFor
-            (bx, slice_fab2.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-             {
-                 buf2(i,j,k,n) = slice_fab2(i,j,k,n);
-             },
-             bx, slice_fab3.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-             {
-                 buf3(i,j,k,n) = slice_fab3(i,j,k,n);
-             },
-             bx, slice_fab4.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-             {
-                 buf4(i,j,k,n) = slice_fab4(i,j,k,n);
-             });
-
-        amrex::Gpu::Device::synchronize();
-        MPI_Isend(m_send_buffer, nreals_total,
-                  amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
-                  m_rank_z-1, comm_z_tag, m_comm_z, &m_send_request);
-        }
-
-        // Same thing for the plasma particles. Currently only one tile.
-        {
-            const int lev = 0;
-            const amrex::Long np = m_plasma_container.m_num_exchange;
-            const amrex::Long psize = m_plasma_container.superParticleSize();
-            const amrex::Long buffer_size = psize*np;
-            m_psend_buffer = (char*)amrex::The_Pinned_Arena()->alloc(buffer_size);
-
-            const auto& ptile = m_plasma_container.ParticlesAt(lev, 0, 0);
-            const auto ptd = ptile.getConstParticleTileData();
-
-            const amrex::Gpu::DeviceVector<int> comm_real(m_plasma_container.NumRealComps(), 1);
-            const amrex::Gpu::DeviceVector<int> comm_int (m_plasma_container.NumIntComps(),  1);
-            const auto p_comm_real = comm_real.data();
-            const auto p_comm_int = comm_int.data();
-            const auto p_psend_buffer = m_psend_buffer;
-#ifdef AMREX_USE_GPU
-            if (amrex::Gpu::inLaunchRegion()) {
-                const int np_per_block = 128;
-                const int nblocks = (np+np_per_block-1)/np_per_block;
-                const std::size_t shared_mem_bytes = np_per_block * psize;
-                // NOTE - TODO DPC++
-                amrex::launch(nblocks, np_per_block, shared_mem_bytes, amrex::Gpu::gpuStream(),
-                [=] AMREX_GPU_DEVICE () noexcept
-                {
-                    amrex::Gpu::SharedMemory<char> gsm;
-                    char* const shared = gsm.dataPtr();
-
-                    // Pack particles from device memory to shared memory
-                    const int i = blockDim.x*blockIdx.x+threadIdx.x;
-                    const unsigned int m = threadIdx.x;
-                    const unsigned int mend = amrex::min<unsigned int>(blockDim.x, np-blockDim.x*blockIdx.x);
-                    if (i < np) {
-                        ptd.packParticleData(shared, i, m*psize, p_comm_real, p_comm_int);
-                    }
-
-                    __syncthreads();
-
-                    // Copy packed particles from shared memory to psend_buffer in pinned memory
-                    for (unsigned int index = m;
-                         index < mend*psize/sizeof(double); index += blockDim.x) {
-                        const double *csrc = (double *)shared;
-                        double *cdest = (double *)(p_psend_buffer+blockDim.x*blockIdx.x*psize);
-                        cdest[index] = csrc[index];
-                    }
-                });
-            } else
-#endif
-            {
-                for (int i = 0; i < np; ++i)
-                {
-                    ptd.packParticleData(p_psend_buffer, i, i*psize, p_comm_real, p_comm_int);
-                }
-            }
-
-            amrex::Gpu::Device::synchronize();
-            MPI_Isend(m_psend_buffer, buffer_size,
-                      amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
-                      m_rank_z-1, pcomm_z_tag, m_comm_z, &m_psend_request);
+        // all ranks except the tail rank send their data downstream
+        MPI_Isend(&test_int, 1,
+                  amrex::ParallelDescriptor::Mpi_typemap<int>::type(),
+                  m_rank_z-1, pcomm_z_tag, m_comm_z, &m_psend_request);
+    } else {
+        // the tail rank sends its beam data to the head rank,
+        // if there are more time steps to calculate
+        if (step < m_max_step -1 ) {
+            MPI_Isend(&test_int, 1,
+                      amrex::ParallelDescriptor::Mpi_typemap<int>::type(),
+                      m_numprocs_z-1, pcomm_z_tag, m_comm_z, &m_psend_request);
         }
     }
+// FIXME these should be beam particles
+//         // Same thing for the plasma particles. Currently only one tile.
+//         {
+//             const int lev = 0;
+//             const amrex::Long np = m_plasma_container.m_num_exchange;
+//             const amrex::Long psize = m_plasma_container.superParticleSize();
+//             const amrex::Long bufNotifyFinish(); // finish the previous sendNotifyFinish(); // finish the previous sendfer_size = psize*np;
+//             m_psend_buffer = (char*)amrex::The_Pinned_Arena()->alloc(buffer_size);
+//
+//             const auto& ptile = m_plasma_container.ParticlesAt(lev, 0, 0);
+//             const auto ptd = ptile.getConstParticleTileData();
+//
+//             const amrex::Gpu::DeviceVector<int> comm_real(m_plasma_container.NumRealComps(), 1);
+//             const amrex::Gpu::DeviceVector<int> comm_int (m_plasma_container.NumIntComps(),  1);
+//             const auto p_comm_real = comm_real.data();
+//             const auto p_comm_int = comm_int.data();
+//             const auto p_psend_buffer = m_psend_buffer;
+// #ifdef AMREX_USE_GPU
+//             if (amrex::Gpu::inLaunchRegion()) {
+//                 const int np_per_block = 128;
+//                 const int nblocks = (np+np_per_block-1)/np_per_block;
+//                 const std::size_t shared_mem_bytes = np_per_block * psize;
+//                 // NOTE - TODO DPC++
+//                 amrex::launch(nblocks, np_per_block, shared_mem_bytes, amrex::Gpu::gpuStream(),
+//                 [=] AMREX_GPU_DEVICE () noexcept
+//                 {
+//                     amrex::Gpu::SharedMemory<char> gsm;
+//                     char* const shared = gsm.dataPtr();
+//
+//                     // Pack particles from device memory to shared memory
+//                     const int i = blockDim.x*blockIdx.x+threadIdx.x;
+//                     const unsigned int m = threadIdx.x;
+//                     const unsigned int mend = amrex::min<unsigned int>(blockDim.x, np-blockDim.x*blockIdx.x);
+//                     if (i < np) {
+//                         ptd.packParticleData(shared, i, m*psize, p_comm_real, p_comm_int);
+//                     }
+//
+//                     __syncthreads();
+//
+//                     // Copy packed particles from shared memory to psend_buffer in pinned memory
+//                     for (unsigned int index = m;
+//                          index < mend*psize/sizeof(double); index += blockDim.x) {
+//                         const double *csrc = (double *)shared;
+//                         double *cdest = (double *)(p_psend_buffer+blockDim.x*blockIdx.x*psize);
+//                         cdest[index] = csrc[index];
+//                     }
+//                 });
+//             } else
+// #endif
+//             {
+//                 for (int i = 0; i < np; ++i)
+//                 {
+//                     ptd.packParticleData(p_psend_buffer, i, i*psize, p_comm_real, p_comm_int);
+//                 }
+//             }
+//
+//             amrex::Gpu::Device::synchronize();
+//             MPI_Isend(m_psend_buffer, buffer_size,
+//                       amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
+//                       m_rank_z-1, pcomm_z_tag, m_comm_z, &m_psend_request);
+//         }
+
 #endif
 }
 
@@ -792,20 +733,15 @@ void
 Hipace::NotifyFinish ()
 {
 #ifdef AMREX_USE_MPI
-    if (m_rank_z != 0) {
-        if (m_send_buffer) {
-            MPI_Status status;
-            MPI_Wait(&m_send_request, &status);
-            amrex::The_Pinned_Arena()->free(m_send_buffer);
-            m_send_buffer = nullptr;
-        }
-        if (m_psend_buffer) {
-            MPI_Status status;
-            MPI_Wait(&m_psend_request, &status);
-            amrex::The_Pinned_Arena()->free(m_psend_buffer);
-            m_psend_buffer = nullptr;
-        }
-    }
+    // FIXME this will be needed for the beam particle communication
+    // if (m_rank_z != 0) {
+    //     if (m_psend_buffer) {
+    //         MPI_Status status;
+    //         MPI_Wait(&m_psend_request, &status);
+    //         amrex::The_Pinned_Arena()->free(m_psend_buffer);
+    //         m_psend_buffer = nullptr;
+    //     }
+    // }
 #endif
 }
 


### PR DESCRIPTION
This PR adds a prototype of the communication pattern for the new pipeline.
It addresses 2. of the plan in #345.

Wait and Notify are moved to the loop over boxes and are not called in the loop over time steps any more. 
The communication of the field data is removed.
The communication of the plasma particle data is commented out, because the beam particle communication will be very similar.

Then, we send a single integer for testing purposes with a non-blocking send and a blocking receive.
This simulates the actual behaviour which we expect later in the code.

A few changes are needed in comparison to the old pipeline:
The head rank cannot start right away, but has to receive the beam particles from the tail rank for the previous time step.
Similar to the adaptive time step communication, the tail rank only needs to send the data, if there is another time step.

The correct behaviour can be tested with the following input script:

```
amr.n_cell = 64 64 16

hipace.normalized_units=1
hipace.predcorr_max_iterations = 100
hipace.predcorr_B_mixing_factor = 0.05
hipace.predcorr_B_error_tolerance = -1

amr.blocking_factor = 2
amr.max_level = 0

max_step = 7
hipace.output_period = 1

hipace.numprocs_x = 1
hipace.numprocs_y = 1

hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -8.   -8.   -6    # physical domain
geometry.prob_hi     =  8.    8.    6

grid_current.use_grid_current = 1
grid_current.amplitude = -0.2
grid_current.position_mean = 0. 0. 0
grid_current.position_std = 0.3 0.3 1.41


hipace.verbose=2

beams.names = beam
beam.injection_type = fixed_ppc
beam.profile = gaussian
beam.zmin = -5.9
beam.zmax = 5.9
beam.radius = 1.2
beam.density = 0.
beam.u_mean = 0. 0. 2000
beam.u_std = 0. 0. 0.
beam.position_mean = 0. 0. 0
beam.position_std = 0.3 0.3 1.41
beam.ppc = 0 0 0

plasma.density = 0.
plasma.ppc = 0 0
plasma.u_mean = 0.0 0.0 0.

diagnostic.diag_type = xyz
```

Running `mpiexec -n 4 --tag-output ../../build/bin/hipace inputs_normalized 1> output.txt`

I got 
[output.txt](https://github.com/Hi-PACE/hipace/files/5989453/output.txt)

In the output, one can see, that the next rank starts exactly when it should start (after the previous rank finished its part).
Thus, this demonstrates the communication pattern in a simple way.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
