### PR TITLE
[New Pipeline] fix electrons in parallel runs

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -302,10 +302,8 @@ Hipace::Evolve ()
         ResetAllQuantities(lev);
 
         /* Store charge density of (immobile) ions into WhichSlice::RhoIons */
-        if (m_rank_z == m_numprocs_z-1){
-            DepositCurrent(m_plasma_container, m_fields, WhichSlice::RhoIons,
-                           false, false, false, true, geom[lev], lev);
-        }
+        DepositCurrent(m_plasma_container, m_fields, WhichSlice::RhoIons,
+                       false, false, false, true, geom[lev], lev);
 
         // Loop over longitudinal boxes on this rank, from head to tail
         for (int it = m_numprocs_z-1; it >= 0; --it)

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -27,7 +27,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
 
     for(amrex::MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
     {
-        if (Hipace::GetInstance().m_rank_z == Hipace::GetInstance().m_numprocs_z-1) {
 
         const amrex::Box& tile_box  = mfi.tilebox();
 
@@ -172,7 +171,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 ++pidx;
             }
         });
-        }
     }
 
     AMREX_ASSERT(OK());


### PR DESCRIPTION

This PR fixes the electrons in parallel runs.

They are now initialized by all ranks.
Additionally, all ranks now deposit rho of the ions.

In the old implementation, only the head rank would do so and pass the rho ions to the next rank downstream (like the plasma particles).

Unfortunately, the correct behaviour cannot be tested on this branch directly.
In parallel runs, the simulations fail because the binning of the beam is not working in parallel runs just yet.

Therefore, the beam operations like binning, current deposition, and beam pusher need to be commented out, before the plasma particles can be tested with a grid current.

I did this and ensured that with plasma particles and a grid current, each rank requires the same amount of iterations in the predictor corrector loop and has the same B field error. This lead to the same fields etc.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
