### PR TITLE
[New Pipeline] Fix IO for last time step

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -100,9 +100,8 @@ public:
     /** \brief Dump simulation data to file
      *
      * \param[in] output_step current iteration
-     * \param[in] force_output if true, dump output regardless of output_period
      */
-    void WriteDiagnostics (int output_step, bool force_output=false);
+    void WriteDiagnostics (int output_step);
 
     /** \brief Return a copy of member struct for physical constants */
     PhysConst get_phys_const () {return m_phys_const;};

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -350,7 +350,7 @@ Hipace::Evolve ()
     // the time stored in the output file is the time for the fields. The beam is one time step
     // ahead.
     m_physical_time -= m_dt;
-    WriteDiagnostics(m_max_step, true);
+
 #ifdef HIPACE_USE_OPENPMD
     if (m_output_period > 0) m_openpmd_writer.reset();
 #endif
@@ -746,13 +746,13 @@ Hipace::NotifyFinish ()
 }
 
 void
-Hipace::WriteDiagnostics (int output_step, bool force_output)
+Hipace::WriteDiagnostics (int output_step)
 {
     HIPACE_PROFILE("Hipace::WriteDiagnostics()");
 
     // Dump every m_output_period steps and after last step
     if (m_output_period < 0 ||
-        (!force_output && output_step % m_output_period != 0) ) return;
+        (!(output_step == m_max_step) && output_step % m_output_period != 0) ) return;
 
     // Write fields
     const std::string filename = amrex::Concatenate("plt", output_step);


### PR DESCRIPTION
Previously, the last time step was written by a call ` WriteDiagnostics(m_max_step, true);`
after the loop over time steps. In the new pipeline, the parallelization is via the loop over time steps, so this call would be called by all ranks, although only one of calculated this time step. 

Since the IO is serial in the new pipeline, many ranks trying to write into the same file causes the simulations to crash.

This is fixed by this PR, while maintaining the intended functionality. By checking for if the current time step is the last time step, the last time step is always written, even if it was not written by the output period.

Unfortunately, like PR 363, this can not be tested without removing the beam handling.
I removed the beam, ensured the functionality is working as intended and then created this PR with the required changes.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
