### PR TITLE
[New Pipeline] add a "no_beam" option

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -179,6 +179,8 @@ public:
     static int m_verbose;
     /** Whether to use normalized units */
     static bool m_normalized_units;
+    /** Whether to run without a beam */
+    static bool m_no_beam;
     /** Struct containing physical constants (which values depends on the unit system, determined
      * at runtime): SI or normalized units. */
     PhysConst m_phys_const;

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -3,6 +3,7 @@
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/Constants.H"
 #include "utils/IOUtil.H"
+#include "Hipace.H"
 
 #ifdef HIPACE_USE_OPENPMD
 
@@ -39,8 +40,10 @@ OpenPMDWriter::WriteDiagnostics (
 
     WriteFieldData(a_mf[lev], geom[lev], slice_dir, varnames, iteration, output_step);
 
-    a_multi_beam.ConvertUnits(ConvertDirection::HIPACE_to_SI);
-    WriteBeamParticleData(a_multi_beam, iteration, output_step);
+    if (!Hipace::m_no_beam){
+        a_multi_beam.ConvertUnits(ConvertDirection::HIPACE_to_SI);
+        WriteBeamParticleData(a_multi_beam, iteration, output_step);
+    }
 
     m_outputSeries->flush();
 

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -3,9 +3,13 @@
 #include "particles/BinSort.H"
 #include "pusher/BeamParticleAdvance.H"
 
+
 MultiBeam::MultiBeam (amrex::AmrCore* /*amr_core*/)
 {
-
+    amrex::ParmParse pph("hipace");
+    bool no_beam;
+    pph.query("no_beam", no_beam);
+    if (no_beam) return;
     amrex::ParmParse pp("beams");
     pp.getarr("names", m_names);
     m_nbeams = m_names.size();


### PR DESCRIPTION

This PR adds a new parameter which can be queried via `hipace.no_beam`. 
If the option is set to true, no beam functions are called and one does not need to provide a beam in the input script.

This is helpful for testing as long as the beam is not fully functional in the new pipeline.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
