### PR TITLE
[New Pipeline] fix default path to diags/hdf5/

### DIFF
--- a/examples/beam_in_vacuum/analysis.py
+++ b/examples/beam_in_vacuum/analysis.py
@@ -33,7 +33,7 @@ parser.add_argument('--do-plot',
                     help='Plot figures and save them to file')
 parser.add_argument('--output-dir',
                     dest='output_dir',
-                    default='diags/h5',
+                    default='diags/hdf5',
                     help='Path to the directory containing output files')
 args = parser.parse_args()
 

--- a/examples/beam_in_vacuum/analysis_2ranks.py
+++ b/examples/beam_in_vacuum/analysis_2ranks.py
@@ -10,11 +10,11 @@ do_plot = False
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--output-dir',
                     dest='output_dir',
-                    default='diags/h5',
+                    default='diags/hdf5',
                     help='Path to the directory containing output files')
 args = parser.parse_args()
 
-ts_ref = OpenPMDTimeSeries('./REF_diags/h5/')
+ts_ref = OpenPMDTimeSeries('./REF_diags/hdf5/')
 ts = OpenPMDTimeSeries(args.output_dir)
 
 if do_plot:

--- a/examples/beam_in_vacuum/analysis_beam_push.py
+++ b/examples/beam_in_vacuum/analysis_beam_push.py
@@ -12,7 +12,7 @@ do_plot = True
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--output-dir',
                     dest='output_dir',
-                    default='diags/h5',
+                    default='diags/hdf5',
                     help='Path to the directory containing output files')
 args = parser.parse_args()
 

--- a/examples/beam_in_vacuum/analysis_grid_current.py
+++ b/examples/beam_in_vacuum/analysis_grid_current.py
@@ -11,7 +11,7 @@ from openpmd_viewer import OpenPMDTimeSeries
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--output-dir',
                     dest='output_dir',
-                    default='diags/h5',
+                    default='diags/hdf5',
                     help='Path to the directory containing output files')
 args = parser.parse_args()
 

--- a/examples/gaussian_weight/analysis.py
+++ b/examples/gaussian_weight/analysis.py
@@ -24,7 +24,7 @@ parser.add_argument('--tilted-beam',
                     help='Run the analysis with a tilted beam')
 parser.add_argument('--output-dir',
                     dest='output_dir',
-                    default='diags/h5',
+                    default='diags/hdf5',
                     help='Path to the directory containing output files')
 args = parser.parse_args()
 

--- a/examples/linear_wake/analysis.py
+++ b/examples/linear_wake/analysis.py
@@ -39,7 +39,7 @@ parser.add_argument('--gaussian-beam',
                     help='Run the analysis on the Gaussian beam')
 parser.add_argument('--output-dir',
                     dest='output_dir',
-                    default='diags/h5',
+                    default='diags/hdf5',
                     help='Path to the directory containing output files')
 args = parser.parse_args()
 

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -110,7 +110,7 @@ public:
     void reset () {m_outputSeries.reset();};
 
     /** Prefix/path for the output files */
-    std::string m_file_prefix = "diag/hdf5";
+    std::string m_file_prefix = "diags/hdf5";
 };
 
 #endif // HIPACE_USE_OPENPMD

--- a/tests/adaptive_time_step.1Rank.sh
+++ b/tests/adaptive_time_step.1Rank.sh
@@ -56,5 +56,5 @@ $HIPACE_EXAMPLE_DIR/analysis_adaptive_ts.py
 # Compare the results with checksum benchmark
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --evaluate \
-    --file_name diags/h5 \
+    --file_name diags/hdf5 \
     --test-name adaptive_time_step.1Rank

--- a/tests/beam_in_vacuum.normalized.2Rank.sh
+++ b/tests/beam_in_vacuum.normalized.2Rank.sh
@@ -20,7 +20,7 @@ TEST_NAME="${FILE_NAME%.*}"
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         amr.n_cell=128 256 30 \
         beam.radius = 20. \
-        hipace.file_prefix=REF_diags/h5
+        hipace.file_prefix=REF_diags/hdf5
 
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         amr.n_cell=128 256 30 \

--- a/tests/checksum/reset_all_benchmarks.sh
+++ b/tests/checksum/reset_all_benchmarks.sh
@@ -75,7 +75,7 @@ fi
 #        || echo "ctest command failed, maybe just because checksums are different. Keep going"
 #    cd $checksum_dir
 #    ./checksumAPI.py --reset-benchmark \
-#                     --file_name ${build_dir}/bin/diags/h5 \
+#                     --file_name ${build_dir}/bin/diags/hdf5 \
 #                     --test-name blowout_wake.Serial
 #fi
 
@@ -87,7 +87,7 @@ fi
 #        || echo "ctest command failed, maybe just because checksums are different. Keep going"
 #    cd $checksum_dir
 #    ./checksumAPI.py --reset-benchmark \
-#                     --file_name ${build_dir}/bin/diags/h5 \
+#                     --file_name ${build_dir}/bin/diags/hdf5 \
 #                     --test-name beam_in_vacuum.SI.Serial
 #fi
 
@@ -99,7 +99,7 @@ fi
 #        || echo "ctest command failed, maybe just because checksums are different. Keep going"
 #    cd $checksum_dir
 #    ./checksumAPI.py --reset-benchmark \
-#                     --file_name ${build_dir}/bin/diags/h5 \
+#                     --file_name ${build_dir}/bin/diags/hdf5 \
 #                     --test-name beam_in_vacuum.normalized.Serial
 #fi
 
@@ -135,7 +135,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name beam_evolution.1Rank
 fi
 
@@ -147,7 +147,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name adaptive_time_step.1Rank
 fi
 
@@ -159,7 +159,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name grid_current.1Rank
 fi
 
@@ -171,7 +171,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name reset.2Rank
 fi
 
@@ -183,7 +183,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name linear_wake.normalized.1Rank
 fi
 
@@ -195,7 +195,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name linear_wake.SI.1Rank
 fi
 
@@ -207,7 +207,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name gaussian_linear_wake.normalized.1Rank
 fi
 
@@ -219,7 +219,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name gaussian_linear_wake.SI.1Rank
 fi
 
@@ -231,7 +231,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name beam_in_vacuum.SI.1Rank
 fi
 
@@ -243,7 +243,7 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name beam_in_vacuum.normalized.1Rank
 fi
 
@@ -255,6 +255,6 @@ then
         || echo "ctest command failed, maybe just because checksums are different. Keep going"
     cd $checksum_dir
     ./checksumAPI.py --reset-benchmark \
-                     --file_name ${build_dir}/bin/diags/h5 \
+                     --file_name ${build_dir}/bin/diags/hdf5 \
                      --test-name gaussian_weight.1Rank
 fi


### PR DESCRIPTION
We missed a typo in the default IO path in PR #358.
The correct path should be diags/hdf5/ not diag/hdf5.

This is changed throughout the code, also in the commented CI tests, so no problems will occur when they are reinstated.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
