### PR TITLE
add no beam option by naming the beam no_beam

### DIFF
--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -102,7 +102,7 @@ private:
 
     amrex::Vector<BeamParticleContainer> m_all_beams; /**< contains all beam containers */
     amrex::Vector<std::string> m_names; /**< names of all beam containers */
-    int m_nbeams; /**< number of beam containers */
+    int m_nbeams {0}; /**< number of beam containers */
 };
 
 #endif // MULTIBEAM_H_

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -8,6 +8,7 @@ MultiBeam::MultiBeam (amrex::AmrCore* /*amr_core*/)
 
     amrex::ParmParse pp("beams");
     pp.getarr("names", m_names);
+    if (m_names[0] == "no_beam") return;
     m_nbeams = m_names.size();
     for (int i = 0; i < m_nbeams; ++i) {
         m_all_beams.emplace_back(BeamParticleContainer(m_names[i]));


### PR DESCRIPTION
This PR adds the possibility to run without a beam.
Therefore, the beam must be named `beams.names = no_beam`

 [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
