### PR TITLE
Use correct box for relative beam particle position in current deposition and pusher

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -109,11 +109,11 @@ public:
     /** \brief Full evolve on 1 slice
      *
      * \param[in] islice slice number
+     * \param[in] bx current box to be calculated
      * \param[in] lev MR level
      * \param[in] bins collections of beam particle indices sorted per slice
      */
-    void SolveOneSlice (
-                        int islice, int lev,
+    void SolveOneSlice (int islice, int lev, const amrex::Box bx,
                         amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>>& bins);
 
     /** \brief Reset plasma and field slice quantities to initial value.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -322,7 +322,7 @@ Hipace::Evolve ()
 //            m_multi_beam.reorderParticlesBySlice(bins);
 
             for (int isl = bx.bigEnd(Direction::z); isl >= bx.smallEnd(Direction::z); --isl){
-                SolveOneSlice(isl, lev, bins);
+                SolveOneSlice(isl, lev, bx, bins);
             };
 
             Notify(step);
@@ -360,7 +360,8 @@ Hipace::Evolve ()
 }
 
 void
-Hipace::SolveOneSlice (int islice, int lev, amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>>& bins)
+Hipace::SolveOneSlice (int islice, int lev, const amrex::Box bx,
+                       amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>>& bins)
 {
     HIPACE_PROFILE("Hipace::SolveOneSlice()");
     // Between this push and the corresponding pop at the end of this
@@ -388,7 +389,7 @@ Hipace::SolveOneSlice (int islice, int lev, amrex::Vector<amrex::DenseBins<BeamP
     m_fields.SolvePoissonExmByAndEypBx(Geom(lev), m_comm_xy, lev);
 
     m_grid_current.DepositCurrentSlice(m_fields, geom[lev], lev, islice);
-    m_multi_beam.DepositCurrentSlice(m_fields, geom[lev], lev, islice, bins);
+    m_multi_beam.DepositCurrentSlice(m_fields, geom[lev], lev, islice, bx, bins);
 
     j_slice.FillBoundary(Geom(lev).periodicity());
 
@@ -401,7 +402,7 @@ Hipace::SolveOneSlice (int islice, int lev, amrex::Vector<amrex::DenseBins<BeamP
     PredictorCorrectorLoopToSolveBxBy(islice, lev);
 
     // Push beam particles
-    m_multi_beam.AdvanceBeamParticlesSlice(m_fields, geom[lev], lev, islice, bins);
+    m_multi_beam.AdvanceBeamParticlesSlice(m_fields, geom[lev], lev, islice, bx, bins);
 
     m_fields.FillDiagnostics(lev, islice);
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -25,10 +25,11 @@ public:
      * \param[in] geom Geometry object at level lev
      * \param[in] lev MR level
      * \param[in] islice slice index in which the current is stored
+     * \param[in] bx current box to calculate in loop over longutidinal boxes
      * \param[in] bins Vector (over species) of particles sorted by slices
      */
     void DepositCurrentSlice (
-        Fields& fields, const amrex::Geometry& geom, const int lev, int islice,
+        Fields& fields, const amrex::Geometry& geom, const int lev, int islice, const amrex::Box bx,
         amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>> bins);
 
     /** Loop over all beam species and build and return the indices of particles sorted per slice
@@ -56,10 +57,11 @@ public:
      * \param[in] gm Geometry object at level lev
      * \param[in] lev MR level
      * \param[in] islice slice index in which the current is stored
+     * \param[in] bx current box to calculate in loop over longutidinal boxes
      * \param[in] bins Vector (over species) of particles sorted by slices
      */
     void AdvanceBeamParticlesSlice (
-        Fields& fields, amrex::Geometry const& gm, int const lev, const int islice,
+        Fields& fields, amrex::Geometry const& gm, int const lev, const int islice, const amrex::Box bx,
         amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>>& bins);
 
     /** Loop over species and dump them to plotfile

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -25,11 +25,11 @@ MultiBeam::InitData (const amrex::Geometry& geom)
 
 void
 MultiBeam::DepositCurrentSlice (
-    Fields& fields, const amrex::Geometry& geom, const int lev, int islice,
+    Fields& fields, const amrex::Geometry& geom, const int lev, int islice, const amrex::Box bx,
     amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>> bins)
 {
     for (int i=0; i<m_nbeams; i++) {
-        ::DepositCurrentSlice(m_all_beams[i], fields, geom, lev, islice, bins[i]);
+        ::DepositCurrentSlice(m_all_beams[i], fields, geom, lev, islice, bx, bins[i]);
     }
 }
 
@@ -56,11 +56,11 @@ MultiBeam::sortParticlesByBox (
 
 void
 MultiBeam::AdvanceBeamParticlesSlice (
-    Fields& fields, amrex::Geometry const& gm, int const lev, const int islice,
+    Fields& fields, amrex::Geometry const& gm, int const lev, const int islice, const amrex::Box bx,
     amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>>& bins)
 {
     for (int i=0; i<m_nbeams; i++) {
-        ::AdvanceBeamParticlesSlice(m_all_beams[i], fields, gm, lev, islice, bins[i]);
+        ::AdvanceBeamParticlesSlice(m_all_beams[i], fields, gm, lev, islice, bx, bins[i]);
     }
 }
 

--- a/src/particles/deposition/BeamDepositCurrent.H
+++ b/src/particles/deposition/BeamDepositCurrent.H
@@ -13,11 +13,12 @@
  * \param[in] gm Geometry of the simulation, to get the cell size etc.
  * \param[in] lev MR level
  * \param[in] islice index of the slice on which the beam particles are pushed
+ * \param[in] bx current box to calculate in loop over longutidinal boxes
  * \param[in] bins beam particle container bins, to push only the beam particles on slice islice
  */
 void
-DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
-                     amrex::Geometry const& gm, int const lev, const int islice,
+DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
+                     int const lev, const int islice, const amrex::Box bx,
                      amrex::DenseBins<BeamParticleContainer::ParticleType>& bins);
 
 

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -9,8 +9,8 @@
 #include <AMReX_DenseBins.H>
 
 void
-DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
-                     amrex::Geometry const& gm, int const lev, const int islice,
+DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
+                     int const lev, const int islice, const amrex::Box bx,
                      amrex::DenseBins<BeamParticleContainer::ParticleType>& bins)
 {
     HIPACE_PROFILE("DepositCurrentSlice_BeamParticleContainer()");
@@ -26,7 +26,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     int islice_local = islice - gm.Domain().smallEnd(2);
 
     // Extract properties associated with the extent of the current box
-    amrex::Box tilebox = gm.Domain();
+    amrex::Box tilebox = bx;
     tilebox.grow({Hipace::m_depos_order_xy, Hipace::m_depos_order_xy, Hipace::m_depos_order_z});
 
     amrex::RealBox const grid_box{tilebox, gm.CellSize(), gm.ProbLo()};

--- a/src/particles/pusher/BeamParticleAdvance.H
+++ b/src/particles/pusher/BeamParticleAdvance.H
@@ -11,11 +11,12 @@
  * \param[in] gm Geometry of the simulation, to get the cell size etc.
  * \param[in] lev MR level
  * \param[in] islice index of the slice on which the beam particles are pushed
+ * \param[in] box current box to calculate in loop over longutidinal boxes
  * \param[in] bins beam particle container bins, to push only the beam particles on slice islice
  */
 void
-AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields,
-                      amrex::Geometry const& gm, int const lev, const int islice,
+AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
+                      int const lev, const int islice, const amrex::Box box,
                       amrex::DenseBins<BeamParticleContainer::ParticleType>& bins);
 
 #endif //  BEAMPARTICLEADVANCE_H_

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -6,8 +6,8 @@
 #include "utils/HipaceProfilerWrapper.H"
 
 void
-AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields,
-                           amrex::Geometry const& gm, int const lev, const int islice,
+AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
+                           int const lev, const int islice, const amrex::Box box,
                            amrex::DenseBins<BeamParticleContainer::ParticleType>& bins)
 {
     HIPACE_PROFILE("AdvanceBeamParticlesSlice()");
@@ -26,7 +26,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields,
 
     // Extract properties associated with the extent of the current box
     const int depos_order_xy = Hipace::m_depos_order_xy;
-    amrex::Box tilebox = gm.Domain();
+    amrex::Box tilebox = box;
     tilebox.grow({depos_order_xy, depos_order_xy, Hipace::m_depos_order_z});
 
     amrex::RealBox const grid_box{tilebox, gm.CellSize(), gm.ProbLo()};


### PR DESCRIPTION
Previously, the index of the grid point, where the beam current was deposed, was based on `amrex::Box tilebox = gm.Domain();`.

In the new pipeline, this does not work anymore, because the index needs to change in the loop over boxes.
Therefore, I propose to pass the current box in the loop over the longitudinal boxes to the relevant functions (current deposition and particle pusher).

The behaviour can be tested with the following input script:

```
amr.n_cell = 16 16 20

hipace.normalized_units=1
hipace.predcorr_max_iterations = 1
hipace.predcorr_B_mixing_factor = 0.05
hipace.predcorr_B_error_tolerance = -1

amr.blocking_factor = 2
amr.max_level = 0

max_step = 3
hipace.output_period = 1

hipace.numprocs_x = 1
hipace.numprocs_y = 1

hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -8.   -8.   -6    # physical domain
geometry.prob_hi     =  8.    8.    6

hipace.verbose=2

beams.names = beam
beam.injection_type = fixed_ppc
beam.profile = gaussian
beam.zmin = -5.9
beam.zmax = 5.9
beam.radius = 1.2
beam.density = 1.
beam.u_mean = 0. 0. 2000
beam.u_std = 0. 0. 0.
beam.position_mean = 0. 0. 0
beam.position_std = 0.3 0.3 1.41
beam.ppc = 1 1 1

plasma.density = 1.
plasma.ppc = 2 2
plasma.u_mean = 0.0 0.0 0.

diagnostic.diag_type = xz
```
Running on CPUs on 2 ranks and in debug mode:
Before this PR (on dev_pipeline), the simulation fails with 
```
<stderr>:amrex::Abort::1:: (6,6,0,0) is out of bound (-2:17,-2:17,10:10,0:0) !!!
```
with the box of the jx, jy, jz FArrayBoxes being ((-2,-2,10) (17,17,10) (0,0,0)) and the (first failing) particle position being (6 6 0).

With this PR, the simulation still fails, but the index of the particle is correctly expressed as (6 6 10).
(It fails because the binning per slice still happens over all beam particles and not just the ones on the currently calculated box.)

@atmyers Could you please have a look at this? I am not sure, if this will be outdated by having an offset and np in the required functions (binning per slice, beam current deposition, and beam particle pusher), so they act just on the particles on a single box.
If that is the case, feel free to close the PR, I simply intended to raise awareness of this possible issue.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
