### PR TITLE
Fix number of beam comps exchanged

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -612,8 +612,8 @@ Hipace::Wait ()
         ptile.resize(new_size);
         const auto ptd = ptile.getParticleTileData();
 
-        const amrex::Gpu::DeviceVector<int> comm_real(m_plasma_container.NumRealComps(), 1);
-        const amrex::Gpu::DeviceVector<int> comm_int (m_plasma_container.NumIntComps(),  1);
+        const amrex::Gpu::DeviceVector<int> comm_real(m_multi_beam.NumRealComps(), 1);
+        const amrex::Gpu::DeviceVector<int> comm_int (m_multi_beam.NumIntComps(),  1);
         const auto p_comm_real = comm_real.data();
         const auto p_comm_int = comm_int.data();
 #ifdef AMREX_USE_GPU

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -709,8 +709,8 @@ Hipace::Notify (const int step, const int it)
         auto& ptile = m_multi_beam.getBeam(ibeam);
         const auto ptd = ptile.getConstParticleTileData();
 
-        const amrex::Gpu::DeviceVector<int> comm_real(m_plasma_container.NumRealComps(), 1);
-        const amrex::Gpu::DeviceVector<int> comm_int (m_plasma_container.NumIntComps(),  1);
+        const amrex::Gpu::DeviceVector<int> comm_real(m_multi_beam.NumRealComps(), 1);
+        const amrex::Gpu::DeviceVector<int> comm_int (m_multi_beam.NumIntComps(),  1);
         const auto p_comm_real = comm_real.data();
         const auto p_comm_int = comm_int.data();
         const auto p_psend_buffer = m_psend_buffer;

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -120,6 +120,14 @@ public:
 
     /** \brief Converts momenta from code convention (gamma * v) to SI (m * gamma * v) and vice-versa. */
     void ConvertUnits (ConvertDirection convert_dir);
+
+    /** \brief Check that all beams have the same number of Real components
+     * and return this number */
+    const int NumRealComps ();
+
+    /** \brief Check that all beams have the same number of Int components
+     * and return this number */
+    const int NumIntComps ();
 private:
 
     amrex::Vector<BeamParticleContainer> m_all_beams; /**< contains all beam containers */

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -116,3 +116,29 @@ MultiBeam::ConvertUnits (ConvertDirection convert_direction)
         beam.ConvertUnits(convert_direction);
     }
 }
+
+const int
+MultiBeam::NumRealComps ()
+{
+    int comps = 0;
+    if (get_nbeams() > 0){
+        comps = m_all_beams[0].NumRealComps();
+        for (auto& beam : m_all_beams) {
+            AMREX_ALWAYS_ASSERT(beam.NumRealComps() == comps);
+        }
+    }
+    return comps;
+}
+
+const int
+MultiBeam::NumIntComps ()
+{
+    int comps = 0;
+    if (get_nbeams() > 0){
+        comps = m_all_beams[0].NumIntComps();
+        for (auto& beam : m_all_beams) {
+            AMREX_ALWAYS_ASSERT(beam.NumIntComps() == comps);
+        }
+    }
+    return comps;
+}


### PR DESCRIPTION
The number of beam particle components exchanged in Notify/Wait is currently the number of plasma particle components. I believed this should be the number of beam particle components, this is what this PR proposes.