### PR TITLE
[New Pipeline] fix beam IO for parallel runs

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -103,8 +103,9 @@ public:
     /** \brief Dump simulation data to file
      *
      * \param[in] output_step current iteration
+     * \param[in] it current box number
      */
-    void WriteDiagnostics (int output_step);
+    void WriteDiagnostics (int output_step, const int it);
 
     /** \brief Return a copy of member struct for physical constants */
     PhysConst get_phys_const () {return m_phys_const;};

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -332,7 +332,7 @@ Hipace::Evolve ()
 
             Notify(step, it);
 #ifdef HIPACE_USE_OPENPMD
-            WriteDiagnostics(step+1);
+            WriteDiagnostics(step+1, it);
 #else
             amrex::Print()<<"WARNING: In parallel runs, only openPMD supports dumping all time steps. \n";
 #endif
@@ -797,7 +797,7 @@ Hipace::NotifyFinish ()
 }
 
 void
-Hipace::WriteDiagnostics (int output_step)
+Hipace::WriteDiagnostics (int output_step, const int it)
 {
     HIPACE_PROFILE("Hipace::WriteDiagnostics()");
 
@@ -815,7 +815,8 @@ Hipace::WriteDiagnostics (int output_step)
 #ifdef HIPACE_USE_OPENPMD
     constexpr int lev = 0;
     m_openpmd_writer.WriteDiagnostics(m_fields.getDiagF(), m_multi_beam, m_fields.getDiagGeom(),
-                        m_physical_time, output_step, lev, m_fields.getDiagSliceDir(), varnames);
+                        m_physical_time, output_step, lev, m_fields.getDiagSliceDir(), varnames,
+                        it, m_box_sorters);
 #else
     constexpr int nlev = 1;
     const amrex::IntVect local_ref_ratio {1, 1, 1};

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -44,19 +44,26 @@ private:
      * \param[in,out] currSpecies openPMD species to set up
      * \param[in] offset number of particles which have already been written
      * \param[in] real_comp_names vector with the names of the real components (weight, ux, uy, uz)
+     * \param[in] box_offset offset for the particles in the current box
+     * \param[in] numParticleOnTile number of particles in this box
      */
     void SaveRealProperty(BeamParticleContainer& pc, openPMD::ParticleSpecies& currSpecies,
                           unsigned long long const offset,
-                          amrex::Vector<std::string> const& real_comp_names);
+                          amrex::Vector<std::string> const& real_comp_names,
+                          unsigned long long const box_offset,
+                          const unsigned long long numParticleOnTile);
 
     /** \brief writing openPMD beam particle data
      *
      * \param[in] beams multi beam container which is written to openPMD file
      * \param[in,out] iteration openPMD iteration to which the data is written
      * \param[in] output_step current time step to dump
+     * \param[in] it current box number
+     * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
      */
     void WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration iteration,
-                                const int output_step);
+                                const int output_step, const int it,
+                                const amrex::Vector<BoxSorter>& a_box_sorter_vec);
 
     /** \brief writing openPMD field data
      *
@@ -82,6 +89,11 @@ private:
     /** Last iteration that was written to file.
      * This is stored to make sure we don't write the last iteration multiple times. */
     int m_last_output_dumped = -1;
+
+    /** vector of length nbeams with the numbers of particles already written to file */
+    amrex::Vector<uint64_t> m_offset;
+    /** vector of length nbeams with the temporary numbers of particles already written to file */
+    amrex::Vector<uint64_t> m_tmp_offset;
 public:
     /** Constructor */
     explicit OpenPMDWriter ();
@@ -100,12 +112,15 @@ public:
      * \param[in] lev MR level
      * \param[in] slice_dir direction of slicing. 0=x, 1=y, -1=no slicing (3D array)
      * \param[in] varnames list of variable names for the fields (ExmBy, EypBx, Ey, ...)
+     * \param[in] it current box number
+     * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
      */
     void WriteDiagnostics(
         amrex::Vector<amrex::FArrayBox> const& a_mf, MultiBeam& a_multi_beam,
         amrex::Vector<amrex::Geometry> const& geom,
         const amrex::Real physical_time, const int output_step, const int lev,
-        const int slice_dir, const amrex::Vector< std::string > varnames);
+        const int slice_dir, const amrex::Vector< std::string > varnames, const int it,
+        const amrex::Vector<BoxSorter>& a_box_sorter_vec);
 
     void reset () {m_outputSeries.reset();};
 

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -193,8 +193,8 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
             beam_species["id"][scalar].storeChunk(ids, {m_offset[ibeam]}, {numParticleOnTile64});
         }
         //  save "extra" particle properties in SoA (momenta and weight)
-         SaveRealProperty(beam, beam_species, m_offset[ibeam], m_real_names, box_offset,
-                          numParticleOnTile);
+        SaveRealProperty(beam, beam_species, m_offset[ibeam], m_real_names, box_offset,
+                         numParticleOnTile);
 
          m_tmp_offset[ibeam] = numParticleOnTile64;
     }

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -114,6 +114,7 @@ public:
 
     unsigned long long m_total_num_particles {0};
 
+    // FIXME not required in new pipeline
     int get_upstream_n_part () const {return m_num_particles_on_upstream_ranks;};
 
     unsigned long long get_total_num_particles () const {return m_total_num_particles;};

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -101,6 +101,7 @@ public:
     unsigned long long get_total_num_particles (int i) const
         {return m_all_beams[i].get_total_num_particles();};
 
+    // FIXME not required in new pipeline
     /** returns the number of beam particles of the upstream ranks */
     int get_upstream_n_part (int i) const {return m_all_beams[i].get_upstream_n_part();};
 


### PR DESCRIPTION
This PR fixes the beam IO for parallel runs.

Similar to the other beam functions, the offset and number of particles per box needs to be passed to the beam IO function.

I tested the functionality by running the input script below with 4 and with 1 rank and ensured that the beam properties are the same.

Input script:
```
amr.n_cell = 64 64 100 #16 16 10

hipace.normalized_units=1
hipace.predcorr_max_iterations = 1
hipace.predcorr_B_mixing_factor = 0.05
hipace.predcorr_B_error_tolerance = -1

amr.blocking_factor = 2
amr.max_level = 0

max_step =10
hipace.output_period = 1

hipace.numprocs_x = 1
hipace.numprocs_y = 1

hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -8.   -8.   -6    # physical domain
geometry.prob_hi     =  8.    8.    6

#grid_current.use_grid_current = 0
#grid_current.peak_current_density = -0.2
#grid_current.position_mean = 0. 0. 0
#grid_current.position_std = 0.3 0.3 1.41


hipace.verbose=2

beams.names = beam
beam.injection_type = fixed_ppc
beam.num_particles = 10000
beam.profile = gaussian
beam.zmin = -5.9
beam.zmax = 5.9
beam.radius = 1.2
beam.density = 1.
beam.u_mean = 0. 0. 2000000000
beam.u_std = 0. 0. 0.
beam.position_mean = 0. 0. 0
beam.position_std = 0.3 0.3 0.5
beam.ppc = 1 1 1

plasma.density = 1.
plasma.ppc = 2 2
plasma.u_mean = 0.0 0.0 0.

diagnostic.diag_type = xyz
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
