### PR TITLE
[New Pipeline] fix beam redistribute slice

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -341,8 +341,6 @@ Hipace::Evolve ()
             Notify(step, it);
         }
 
-        }
-
         /* Passing the adaptive time step info */
         // m_adaptive_time_step.PassTimeStepInfo(step, m_comm_z);
         // Slices have already been shifted, so send

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -330,18 +330,17 @@ Hipace::Evolve ()
                 SolveOneSlice(isl, lev, it, bins);
             };
 
+            m_multi_beam.RedistributeSlice(lev, m_box_sorters, it);
+            amrex::Print()<<"WARNING: beam particles are only redistributed transversely yet. \n";
+
             Notify(step, it);
 #ifdef HIPACE_USE_OPENPMD
             WriteDiagnostics(step+1);
 #else
             amrex::Print()<<"WARNING: In parallel runs, only openPMD supports dumping all time steps. \n";
 #endif
+
         }
-
-        // FIXME: beam disabled
-        m_multi_beam.RedistributeSlice(lev);
-        amrex::Print()<<"WARNING: beam particles are only redistributed transversely yet. \n";
-
 
         /* Passing the adaptive time step info */
         // m_adaptive_time_step.PassTimeStepInfo(step, m_comm_z);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -339,13 +339,9 @@ Hipace::Evolve ()
         }
 
         // FIXME: beam disabled
-        // if (amrex::ParallelDescriptor::NProcs() == 1) {
-        //     m_multi_beam.Redistribute();
-        // } else {
-        //     m_multi_beam.RedistributeSlice(lev);
-        //     amrex::Print()<<"WARNING: In parallel runs, beam particles are only redistributed "
-        //                     " transversely. \n";
-        // }
+        m_multi_beam.RedistributeSlice(lev);
+        amrex::Print()<<"WARNING: beam particles are only redistributed transversely yet. \n";
+
 
         /* Passing the adaptive time step info */
         // m_adaptive_time_step.PassTimeStepInfo(step, m_comm_z);

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -103,8 +103,11 @@ public:
     /** Redistribute the particles on a slice, meaning particles, which left the box are returned
      * periodically and if peridicity = 0, their weight is set to 0
      * \param[in] lev MR level
+     * \param[in] offset offset for the particles in the current box
+     * \param[in] num_particles number of particles in this box
      */
-    void RedistributeSlice (int const lev);
+    void RedistributeSlice (int const lev, unsigned long long const offset,
+                            unsigned long long const num_particles);
 #endif
 
     std::string get_name () const {return m_name;};

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -229,7 +229,7 @@ BeamParticleContainer::ConvertUnits (ConvertDirection convert_direction)
 }
 
 void
-BeamParticleContainer::RedistributeSlice (int const lev)
+BeamParticleContainer::RedistributeSlice (int const lev, int const offset)
 {
     HIPACE_PROFILE("BeamParticleContainer::RedistributeSlice()");
 
@@ -243,9 +243,9 @@ BeamParticleContainer::RedistributeSlice (int const lev)
 
     // Extract particle properties
     auto& aos = this->GetArrayOfStructs(); // For positions
-    const auto& pos_structs = aos.begin();
+    const auto& pos_structs = aos.begin() + offset;
     auto& soa = this->GetStructOfArrays(); // For momenta and weights
-    amrex::Real * const wp = soa.GetRealData(BeamIdx::w).data();
+    amrex::Real * const wp = soa.GetRealData(BeamIdx::w).data() + offset;
 
     // Loop over particles and handle particles outside of the box
     amrex::ParallelFor(

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -229,7 +229,8 @@ BeamParticleContainer::ConvertUnits (ConvertDirection convert_direction)
 }
 
 void
-BeamParticleContainer::RedistributeSlice (int const lev, int const offset)
+BeamParticleContainer::RedistributeSlice (int const lev, unsigned long long const offset,
+                                          unsigned long long const num_particles)
 {
     HIPACE_PROFILE("BeamParticleContainer::RedistributeSlice()");
 
@@ -249,7 +250,7 @@ BeamParticleContainer::RedistributeSlice (int const lev, int const offset)
 
     // Loop over particles and handle particles outside of the box
     amrex::ParallelFor(
-        this->numParticles(),
+        num_particles,
         [=] AMREX_GPU_DEVICE (long ip) {
             // Set particle AoS
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -114,8 +114,11 @@ public:
     /** Redistribute the particles on a slice, meaning particles, which left the box are returned
      * periodically and if peridicity = 0, their weight is set to 0
      * \param[in] lev MR level
+     * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
+     * \param[in] ibox index of the current box
      */
-    void RedistributeSlice (int const lev);
+    void RedistributeSlice (int const lev, const amrex::Vector<BoxSorter>& a_box_sorter_vec,
+                            const int ibox);
 #endif
 
     /** \brief Converts momenta from code convention (gamma * v) to SI (m * gamma * v) and vice-versa. */

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -101,10 +101,13 @@ MultiBeam::WaitNumParticles (MPI_Comm a_comm_z)
 }
 
 void
-MultiBeam::RedistributeSlice (int const lev)
+MultiBeam::RedistributeSlice (int const lev, const amrex::Vector<BoxSorter>& a_box_sorter_vec,
+                              const int ibox)
 {
-    for (auto& beam : m_all_beams) {
-        beam.RedistributeSlice(lev);
+    for (int i=0; i<m_nbeams; i++) {
+        auto beam = getBeam(i);
+        beam.RedistributeSlice(lev, a_box_sorter_vec[i].boxOffsetsPtr()[ibox],
+                               a_box_sorter_vec[i].boxCountsPtr()[ibox]);
     }
 }
 #endif


### PR DESCRIPTION
This PR fixes the beam `RedistributeSlice`.
It adds the necessary offset and number of particles for each box. The function call is moved to the loop over boxes, so the beam particles are validated, before they are communicated (so that the next rank does not run into problems when doing the beam current deposition).



- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
