### PR TITLE
Reactivate parallel tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,11 +209,11 @@ if(BUILD_TESTING)
     else()
 
         configure_mpiexec(1)  # one rank in MPI_TEST_EXE
-        #add_test(NAME blowout_wake.2Rank
-        #        COMMAND ${HiPACE_SOURCE_DIR}/tests/blowout_wake.2Rank.sh
-        #                $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-        #        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        #)
+        add_test(NAME blowout_wake.2Rank
+                COMMAND ${HiPACE_SOURCE_DIR}/tests/blowout_wake.2Rank.sh
+                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
+                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
 
         add_test(NAME beam_evolution.1Rank
                  COMMAND ${HiPACE_SOURCE_DIR}/tests/beam_evolution.1Rank.sh
@@ -257,11 +257,11 @@ if(BUILD_TESTING)
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
 
-        #add_test(NAME reset.2Rank
-        #         COMMAND ${HiPACE_SOURCE_DIR}/tests/reset.2Rank.sh
-        #                 $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-        #         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        #)
+        add_test(NAME reset.2Rank
+                 COMMAND ${HiPACE_SOURCE_DIR}/tests/reset.2Rank.sh
+                         $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
+                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
 
         add_test(NAME beam_in_vacuum.SI.1Rank
                  COMMAND ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.SI.1Rank.sh
@@ -289,11 +289,11 @@ if(BUILD_TESTING)
         #         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         #)
 
-        #add_test(NAME beam_in_vacuum.normalized.2Rank
-        #         COMMAND ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.normalized.2Rank.sh
-        #                 $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-        #         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        #)
+        add_test(NAME beam_in_vacuum.normalized.2Rank
+                 COMMAND ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.normalized.2Rank.sh
+                         $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
+                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
 
         # This test is temporarily removed, due to bugs in the parallelization
         # configure_mpiexec(2)  # two ranks in MPI_TEST_EXE

--- a/tests/beam_in_vacuum.normalized.2Rank.sh
+++ b/tests/beam_in_vacuum.normalized.2Rank.sh
@@ -20,11 +20,13 @@ TEST_NAME="${FILE_NAME%.*}"
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         amr.n_cell=128 256 30 \
         beam.radius = 20. \
-        hipace.file_prefix=REF_diags/hdf5
+        hipace.file_prefix=REF_diags/hdf5 \
+        max_step = 2
 
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         amr.n_cell=128 256 30 \
         beam.radius = 20. \
-        hipace.file_prefix=$TEST_NAME
+        hipace.file_prefix=$TEST_NAME \
+        max_step = 2
 
 $HIPACE_EXAMPLE_DIR/analysis_2ranks.py --output-dir=$TEST_NAME

--- a/tests/blowout_wake.2Rank.sh
+++ b/tests/blowout_wake.2Rank.sh
@@ -19,15 +19,18 @@ rm -rf si_data_fixed_weight
 rm -rf normalized_data
 # Run the simulation
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_SI \
-        hipace.file_prefix=si_data/h5
+        hipace.file_prefix=si_data/h5 \
+        max_step=2
 
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_SI \
         beam.injection_type=fixed_weight \
         beam.num_particles=1000000 \
-        hipace.file_prefix=si_data_fixed_weight/h5
+        hipace.file_prefix=si_data_fixed_weight/h5 \
+        max_step=2
 
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
-        hipace.file_prefix=normalized_data/h5
+        hipace.file_prefix=normalized_data/h5 \
+        max_step=2
 
 # Compare the result with theory
 $HIPACE_EXAMPLE_DIR/analysis.py \
@@ -39,4 +42,5 @@ $HIPACE_EXAMPLE_DIR/analysis.py \
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --evaluate \
     --file_name normalized_data/h5 \
-    --test-name blowout_wake.2Rank
+    --test-name blowout_wake.2Rank \
+    --skip "{'beam': 'id'}"

--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -69,7 +69,7 @@ class Checksum:
 
         return data
 
-    def evaluate(self, rtol=1.e-9, atol=1.e-40):
+    def evaluate(self, rtol=1.e-9, atol=1.e-40, skip_dict={}):
         '''Compare IO file checksum with benchmark.
 
         Read checksum from IO file, read benchmark
@@ -110,6 +110,8 @@ class Checksum:
         checksums_differ = False
         for key1 in ref_benchmark.data.keys():
             for key2 in ref_benchmark.data[key1].keys():
+                if key1 in skip_dict.keys() and key2 in skip_dict[key1]:
+                    continue
                 passed = np.isclose(self.data[key1][key2],
                                     ref_benchmark.data[key1][key2],
                                     rtol=rtol, atol=atol)

--- a/tests/checksum/checksumAPI.py
+++ b/tests/checksum/checksumAPI.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
                         regression_testing/regtest.py')
 
     args = parser.parse_args()
-    
+
     if args.reset_benchmark:
         reset_benchmark(args.test_name, args.file_name,
                         do_fields=args.do_fields,

--- a/tests/checksum/checksumAPI.py
+++ b/tests/checksum/checksumAPI.py
@@ -11,6 +11,7 @@ License: BSD-3-Clause-LBNL
 from checksum import Checksum
 from benchmark import Benchmark
 import argparse
+import ast
 import glob
 import sys
 import os
@@ -35,7 +36,7 @@ API for WarpX checksum tests. It can be used in two ways:
 
 
 def evaluate_checksum(test_name, file_name, rtol=1.e-9, atol=1.e-40,
-                      do_fields=True, do_particles=True):
+                      do_fields=True, do_particles=True, skip_dict={}):
     '''Compare IO file checksum with benchmark.
 
     Read checksum from input file_name, read benchmark
@@ -50,7 +51,7 @@ def evaluate_checksum(test_name, file_name, rtol=1.e-9, atol=1.e-40,
     '''
     test_checksum = Checksum(test_name, file_name, do_fields=do_fields,
                              do_particles=do_particles)
-    test_checksum.evaluate(rtol=rtol, atol=atol)
+    test_checksum.evaluate(rtol=rtol, atol=atol, skip_dict=skip_dict)
 
 
 def reset_benchmark(test_name, file_name, do_fields=True, do_particles=True):
@@ -115,6 +116,9 @@ if __name__ == '__main__':
     parser.add_argument('--skip-particles', dest='do_particles',
                         default=True, action='store_false',
                         help='If used, do not read/write particle checksums')
+    parser.add_argument('--skip', dest='skip_dict', default={},
+                        type=ast.literal_eval, help="Dictionary of a quantity \
+                        to skip, e.g., \"{'beam':['x', 'y']}\"")
 
     # Fields and/or particles are read from IO file/written to benchmark?
     parser.add_argument('--rtol', dest='rtol',
@@ -136,7 +140,7 @@ if __name__ == '__main__':
                         regression_testing/regtest.py')
 
     args = parser.parse_args()
-
+    
     if args.reset_benchmark:
         reset_benchmark(args.test_name, args.file_name,
                         do_fields=args.do_fields,
@@ -145,7 +149,8 @@ if __name__ == '__main__':
     if args.evaluate:
         evaluate_checksum(args.test_name, args.file_name, rtol=args.rtol,
                           atol=args.atol, do_fields=args.do_fields,
-                          do_particles=args.do_particles)
+                          do_particles=args.do_particles,
+                          skip_dict=args.skip_dict)
 
     if args.reset_all_benchmarks:
         # WARNING: this mode does not support skip-fields/particles

--- a/tests/reset.2Rank.sh
+++ b/tests/reset.2Rank.sh
@@ -25,4 +25,5 @@ mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized max_step=2
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --evaluate \
     --file_name $TEST_NAME \
-    --test-name $TEST_NAME
+    --test-name $TEST_NAME \
+    --skip "{'beam': 'id'}"


### PR DESCRIPTION
This PR proposes to reactivate the parallel tests, they should now work well with the new pipeline. Some parallel tests use the same benchmarks as serial tests, so we can check that the results do not depend on the parallelization. However, the particle ID depends on the parallelization, which make these tests crash. For this reason, an option `--skip` was added to the checksum library, so some fields can be ignored in the checksum evaluation.