### PR TITLE
Fix momentum assert for symmetrized beam.

### DIFF
--- a/src/particles/profiles/GetInitialMomentum.cpp
+++ b/src/particles/profiles/GetInitialMomentum.cpp
@@ -19,10 +19,6 @@ GetInitialMomentum::GetInitialMomentum (const std::string& name)
                 m_u_std[idim] = loc_array[idim];
             }
         }
-        bool do_symmetrize;
-        pp.query("do_symmetrize", do_symmetrize);
-        if (do_symmetrize) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_u_mean[0]+m_u_mean[1] < 1e-12,
-            "Symmetrizing the beam is only implemented for no mean momentum in x and y");
     } else {
         amrex::Abort("Unknown beam momentum profile!");
     }

--- a/src/particles/profiles/GetInitialMomentum.cpp
+++ b/src/particles/profiles/GetInitialMomentum.cpp
@@ -19,6 +19,13 @@ GetInitialMomentum::GetInitialMomentum (const std::string& name)
                 m_u_std[idim] = loc_array[idim];
             }
         }
+        bool do_symmetrize = false;
+        pp.query("do_symmetrize", do_symmetrize);
+        if (do_symmetrize) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( std::fabs(m_u_mean[0]) +std::fabs(m_u_mean[1])
+                                               < std::numeric_limits<amrex::Real>::epsilon(),
+            "Symmetrizing the beam is only implemented for no mean momentum in x and y");
+        }
     } else {
         amrex::Abort("Unknown beam momentum profile!");
     }


### PR DESCRIPTION

Currently, the assert for the momentum when using a symmetrized beam is incorrect.
The do_symmetrized is not initialized and therefore true, so the assert is always triggered if no do_symmetrized is specified.
Second, the check for the mean momentum was not using abs.

The logic, however, is still correct. Because the beam container only gets a final momentum, but not a mean to symmetrize around, it can only symmetrize the beam around transverse mean momenta = 0.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
