### PR TITLE
Clean test on particle validity, using id instead of w

### DIFF
--- a/src/particles/deposition/BeamDepositCurrentInner.H
+++ b/src/particles/deposition/BeamDepositCurrentInner.H
@@ -115,8 +115,7 @@ void doDepositionShapeN (const BeamParticleContainer& ptile,
         [=] AMREX_GPU_DEVICE (long idx) {
             const int ip = indices[cell_start+idx];
 
-            if ( std::abs(wp[ip]) < std::numeric_limits<amrex::Real>::epsilon() ) return;
-
+            if (pos_structs[ip].id() < 0) return;
             // --- Get particle quantities
             const amrex::Real gaminv = 1.0_rt/std::sqrt(1.0_rt + uxp[ip]*uxp[ip]*clightsq
                                                          + uyp[ip]*uyp[ip]*clightsq

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -92,13 +92,13 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
                 [=] AMREX_GPU_DEVICE (long idx) {
                 const int ip = indices[cell_start+idx];
 
-                if ( std::abs(wp[ip]) < std::numeric_limits<amrex::Real>::epsilon() ) return;
+                amrex::ParticleReal xp, yp, zp;
+                int pid;
+                getPosition(ip, xp, yp, zp, pid);
+                if (pid < 0) return;
 
                 const amrex::ParticleReal gammap = sqrt( 1.0_rt + uxp[ip]*uxp[ip]*clightsq
                                             + uyp[ip]*uyp[ip]*clightsq + uzp[ip]*uzp[ip]*clightsq);
-
-                amrex::ParticleReal xp, yp, zp;
-                getPosition(ip, xp, yp, zp);
 
                 // first we do half a step in x,y
                 // This is not required in z, which is pushed in one step later

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -53,6 +53,22 @@ struct GetParticlePosition
         y = m_structs[i].pos(1);
         z = m_structs[i].pos(2);
     }
+
+    /** \brief Get the position of the particle at index `i + a_offset`, and put it in x, y and z
+     * \param[in] i index of the particle
+     * \param[in,out] x x position of particle i, modified by this function
+     * \param[in,out] y y position of particle i, modified by this function
+     * \param[in,out] z z position of particle i, modified by this function
+     * \param[in,out] id id of particle i, modified by this function
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator() (const int i, RType& x, RType& y, RType& z, int& id) const noexcept
+    {
+        x = m_structs[i].pos(0);
+        y = m_structs[i].pos(1);
+        z = m_structs[i].pos(2);
+        id = m_structs[i].id();
+    }
 };
 
 /** \brief Functor that can be used to modify the positions of the macroparticles

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -113,10 +113,12 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
 
         amrex::ParallelFor(pti.numParticles(),
             [=] AMREX_GPU_DEVICE (long ip) {
-
-                if ( std::abs(wp[ip]) < std::numeric_limits<amrex::Real>::epsilon() ) return;
                 amrex::ParticleReal xp, yp, zp;
-                getPosition(ip, xp, yp, zp);
+                int pid;
+                getPosition(ip, xp, yp, zp, pid);
+
+                if (pid < 0) return;
+
                 // define field at particle position reals
                 amrex::ParticleReal ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
                 amrex::ParticleReal Bxp = 0._rt, Byp = 0._rt, Bzp = 0._rt;


### PR DESCRIPTION
This PR proposes to clean up particles' validity test, using `id<0` instead of `w ~ 0`.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
