### PR TITLE
[New Pipeline] enforce boundary condition for beam particles after each push

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -338,15 +338,6 @@ Hipace::Evolve ()
             Notify(step, it);
         }
 
-        // FIXME: beam disabled
-        // if (amrex::ParallelDescriptor::NProcs() == 1) {
-        //     m_multi_beam.Redistribute();
-        // } else {
-        //     m_multi_beam.RedistributeSlice(lev);
-        //     amrex::Print()<<"WARNING: In parallel runs, beam particles are only redistributed "
-        //                     " transversely. \n";
-        // }
-
         /* Passing the adaptive time step info */
         // m_adaptive_time_step.PassTimeStepInfo(step, m_comm_z);
         // Slices have already been shifted, so send

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -100,11 +100,6 @@ public:
     /** Loop over beams and receive total number of beam particles on upstream ranks */
     void WaitNumParticles (MPI_Comm a_comm_z);
 
-    /** Redistribute the particles on a slice, meaning particles, which left the box are returned
-     * periodically and if peridicity = 0, their weight is set to 0
-     * \param[in] lev MR level
-     */
-    void RedistributeSlice (int const lev);
 #endif
 
     std::string get_name () const {return m_name;};

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -228,7 +228,7 @@ BeamParticleContainer::ConvertUnits (ConvertDirection convert_direction)
     return;
 }
 
-void
+void // FIXME this function is outdated and replaced by the EnforceBC functor
 BeamParticleContainer::RedistributeSlice (int const lev)
 {
     HIPACE_PROFILE("BeamParticleContainer::RedistributeSlice()");

--- a/src/particles/BoxSort.cpp
+++ b/src/particles/BoxSort.cpp
@@ -29,7 +29,7 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
         if (dst_box < 0) {
             // particle has left domain transversely, stick it at the end and invalidate
             dst_box = num_boxes;
-            particle_ptr[i].id() = -particle_ptr[i].id();
+            particle_ptr[i].id() = -std::abs(particle_ptr[i].id());
         }
         unsigned int index = amrex::Gpu::Atomic::Inc(
             &p_box_counts[dst_box], max_unsigned_int);

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -111,12 +111,6 @@ public:
 
     /** Loop over beams and receive total number of beam particles on upstream ranks */
     void WaitNumParticles (MPI_Comm a_comm_z);
-
-    /** Redistribute the particles on a slice, meaning particles, which left the box are returned
-     * periodically and if peridicity = 0, their weight is set to 0
-     * \param[in] lev MR level
-     */
-    void RedistributeSlice (int const lev);
 #endif
 
     /** \brief Converts momenta from code convention (gamma * v) to SI (m * gamma * v) and vice-versa. */

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -99,14 +99,6 @@ MultiBeam::WaitNumParticles (MPI_Comm a_comm_z)
         beam.WaitNumParticles(a_comm_z);
     }
 }
-
-void
-MultiBeam::RedistributeSlice (int const lev)
-{
-    for (auto& beam : m_all_beams) {
-        beam.RedistributeSlice(lev);
-    }
-}
 #endif
 
 void

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -60,12 +60,11 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
     amrex::Real * const uxp = soa.GetRealData(BeamIdx::ux).data() + offset;
     amrex::Real * const uyp = soa.GetRealData(BeamIdx::uy).data() + offset;
     amrex::Real * const uzp = soa.GetRealData(BeamIdx::uz).data() + offset;
-    amrex::Real * const wp = soa.GetRealData(BeamIdx::w).data() + offset;
 
-    const auto getPosition =
-        GetParticlePosition<BeamParticleContainer>(beam, offset);
-    const auto setPosition =
-        SetParticlePosition<BeamParticleContainer>(beam, offset);
+    const auto getPosition = GetParticlePosition<BeamParticleContainer>(beam, offset);
+    const auto setPosition = SetParticlePosition<BeamParticleContainer>(beam, offset);
+    const auto enforceBC = EnforceBC<BeamParticleContainer>(beam, lev, offset);
+
     const amrex::Real zmin = xyzmin[2];
 
     // Declare a DenseBins to pass it to doDepositionShapeN, although it will not be used.
@@ -106,6 +105,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
                 yp += dt * 0.5_rt * uyp[ip] / gammap;
 
                 setPosition(ip, xp, yp, zp);
+                if (enforceBC(ip)) return;
 
                 // define field at particle position reals
                 amrex::ParticleReal ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
@@ -158,6 +158,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
                 yp += dt * 0.5_rt * uy_next  / gamma_next;
                 if (do_z_push) zp += dt * ( uz_next  / gamma_next - phys_const.c );
                 setPosition(ip, xp, yp, zp);
+                enforceBC(ip);
                 uxp[ip] = ux_next;
                 uyp[ip] = uy_next;
                 uzp[ip] = uz_next;

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -109,4 +109,61 @@ struct SetParticlePosition
     }
 };
 
+/** \brief Functor that can be used to apply the boundary conditions to the macroparticles
+ *         inside a ParallelFor kernel
+ */
+template <class T_ParTile>
+struct EnforceBC
+{
+    using PType = typename T_ParTile::ParticleType;
+    using RType = amrex::ParticleReal;
+
+    PType* AMREX_RESTRICT m_structs;
+    RType* AMREX_RESTRICT m_weights;
+
+    amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_plo;
+    amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_phi;
+    amrex::GpuArray<int,AMREX_SPACEDIM> m_is_per;
+    amrex::GpuArray<int,AMREX_SPACEDIM> m_periodicity;
+
+    /** Constructor.
+     * \param a_ptile tile containing the macroparticles
+     * \param lev level of MR
+     * \param a_offset offset to apply to the particle indices
+     */
+    EnforceBC (T_ParTile& a_ptile, const int lev, int a_offset = 0) noexcept
+    {
+
+        m_plo    = Hipace::GetInstance().Geom(lev).ProbLoArray();
+        m_phi    = Hipace::GetInstance().Geom(lev).ProbHiArray();
+        m_is_per = Hipace::GetInstance().Geom(lev).isPeriodicArray();
+        AMREX_ALWAYS_ASSERT(m_is_per[0] == m_is_per[1]);
+
+        m_periodicity = {true, true, false};
+
+        auto& aos = a_ptile.GetArrayOfStructs();
+        m_structs = aos().dataPtr() + a_offset;
+        auto& soa = a_ptile.GetStructOfArrays();
+        m_weights = soa.GetRealData(BeamIdx::w).data() + a_offset;
+    }
+
+    /** \brief enforces the boundary condition to the particle at index `i + a_offset`
+     * and returns if the particle is invalid
+     * \param[in] ip index of the particle
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool operator() (const int ip) const noexcept
+    {
+        using namespace amrex::literals;
+
+        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_periodicity);
+        const bool invalid = shifted + !m_is_per[0];
+        if (invalid) {
+            m_weights[ip] = 0.0_rt;
+            m_structs[ip].id() = -1;
+        }
+        return invalid;
+    }
+};
+
 #endif // HIPACE_GETANDSETPOSITION_H_

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -66,7 +66,6 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
         amrex::Real * const uxp = soa.GetRealData(PlasmaIdx::ux).data();
         amrex::Real * const uyp = soa.GetRealData(PlasmaIdx::uy).data();
         amrex::Real * const psip = soa.GetRealData(PlasmaIdx::psi).data();
-        amrex::Real * const wp = soa.GetRealData(PlasmaIdx::w).data();
 
         amrex::Real * const x_prev = soa.GetRealData(PlasmaIdx::x_prev).data();
         amrex::Real * const y_prev = soa.GetRealData(PlasmaIdx::y_prev).data();


### PR DESCRIPTION
In the beam particle pusher, we push twice. In this PR, the boundary conditions are enforced after each push. Previously, the simulation would have crashed or caused undefined behaviour, if the beam particles left the box after the first push, as the field gather call between the two pushes would have accessed outside of the array.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
