### PR TITLE
add minimum density for fixed ppc beam

### DIFF
--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -47,7 +47,8 @@ public:
         const amrex::Geometry& a_geom,
         const amrex::Real     a_zmin,
         const amrex::Real     a_zmax,
-        const amrex::Real     a_radius);
+        const amrex::Real     a_radius,
+        const amrex::Real     a_min_density);
 
     /** Initialize a beam with a fix number of particles, and fixed weight */
     void InitBeamFixedWeight (int num_to_add,
@@ -145,6 +146,7 @@ private:
     int m_num_particles; /**< Number of particles for fixed-weigth Gaussian beam */
     amrex::Real m_total_charge; /**< Total beam charge for fixed-weight Gaussian beam */
     amrex::Real m_density; /**< Peak density for fixed-weight Gaussian beam */
+    amrex::Real m_min_density {0.}; /**< minimum density at which beam particles are generated */
     bool m_do_symmetrize {0}; /**< Option to symmetrize the beam */
     /** Density of plasma to convert from_file beam to normalized units */
     amrex::Real m_plasma_density;

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -39,9 +39,11 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         pp.get("zmin", m_zmin);
         pp.get("zmax", m_zmax);
         pp.get("radius", m_radius);
+        pp.query("min_density", m_min_density);
         const GetInitialDensity get_density(m_name);
         const GetInitialMomentum get_momentum(m_name);
-        InitBeamFixedPPC(m_ppc, get_density, get_momentum, geom, m_zmin, m_zmax, m_radius);
+        InitBeamFixedPPC(m_ppc, get_density, get_momentum, geom, m_zmin,
+                         m_zmax, m_radius, m_min_density);
 
     } else if (m_injection_type == "fixed_weight") {
 

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -63,7 +63,8 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                   const amrex::Geometry& a_geom,
                   const amrex::Real a_zmin,
                   const amrex::Real a_zmax,
-                  const amrex::Real a_radius)
+                  const amrex::Real a_radius,
+                  const amrex::Real a_min_density)
 {
     HIPACE_PROFILE("BeamParticleContainer::InitParticles");
 
@@ -122,6 +123,9 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
 
                 if (z >= a_zmax || z < a_zmin ||
                     (x*x+y*y) > a_radius*a_radius) continue;
+
+                const amrex::Real density = get_density(x, y, z);
+                if (density < a_min_density) continue;
 
                 int ix = i - lo.x;
                 int iy = j - lo.y;
@@ -189,10 +193,13 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                 if (z >= a_zmax || z < a_zmin ||
                     (x*x+y*y) > a_radius*a_radius) continue;
 
+                const amrex::Real density = get_density(x, y, z);
+                if (density < a_min_density) continue;
+
                 amrex::Real u[3] = {0.,0.,0.};
                 get_momentum(u[0],u[1],u[2]);
 
-                const amrex::Real weight = get_density(x, y, z) * scale_fac;
+                const amrex::Real weight =  density * scale_fac;
                 AddOneBeamParticle(pstruct, arrdata, x, y, z, u[0], u[1], u[2], weight,
                                    pid, procID, pidx, phys_const.c);
 


### PR DESCRIPTION
This PR adds the possibility to add a minimum density below which no beam particles are generated.

Without a minimum density, a Gaussian beam might look like this:
![Screenshot from 2021-02-26 17-16-03](https://user-images.githubusercontent.com/65728274/109325841-b25ea600-7856-11eb-847f-9281a2eef839.png)

Using a minimum density, it looks like that:

![Screenshot from 2021-02-26 17-15-54](https://user-images.githubusercontent.com/65728274/109325899-c4d8df80-7856-11eb-8e03-ee185676a98f.png)

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
