### PR TITLE
[New Pipeline] always resize to the box_offset in after sending particles

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -772,12 +772,7 @@ Hipace::Notify (const int step, const int it)
             }
             amrex::Gpu::Device::synchronize();
 
-            if (m_rank_z == m_numprocs_z-1) {
-                ptile.resize(offset_box);
-            }
-            else {
-                ptile.resize(0);
-            }
+            ptile.resize(offset_box);
             offset_beam += np;
         } // here
 


### PR DESCRIPTION
Thanks to @atmyers, this PR resolves handling the slipping beam particles.
After sending the beam particles, the beam particle container must always be resized to `offset_box`, so it has the size of all beam particles in the lower boxes.

The correct behaviour can be tested with the following input script:

```
amr.n_cell = 64 64 60 #16 16 10

hipace.normalized_units=1
hipace.predcorr_max_iterations = 1
hipace.predcorr_B_mixing_factor = 0.05
hipace.predcorr_B_error_tolerance = -1

amr.blocking_factor = 2
amr.max_level = 0

max_step =10
hipace.output_period = 1
hipace.dt = 5

hipace.numprocs_x = 1
hipace.numprocs_y = 1
hipace.depos_order_xy = 2
geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -8.   -8.   -1    # physical domain
geometry.prob_hi     =  8.    8.    1

hipace.verbose=1

beams.names = beam
beam.injection_type = fixed_ppc
beam.profile = gaussian
beam.zmin = -5.9
beam.zmax = 5.9
beam.radius = 1.2
beam.density = 0.01
beam.min_density = 0.0
beam.u_mean = 0. 0. 5
beam.u_std = 0. 0. 0.
beam.position_mean = 0. 0. 0
beam.position_std =0.3 0.3 1.0
beam.ppc = 1 1 1

plasma.density = 1.
plasma.ppc = 1 1
plasma.u_mean = 0.0 0.0 0.
diagnostic.diag_type = xyz
```

Within 10 steps, almost all of the beam slips back. With this PR, the results for a parallel and a serial run are the same.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
