### PR TITLE
clean warning of unsed parameter

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -17,7 +17,6 @@
 
 #ifdef AMREX_USE_MPI
 namespace {
-    constexpr int comm_z_tag = 1000;
     constexpr int ncomm_z_tag = 1001;
     constexpr int pcomm_z_tag = 1002;
 }


### PR DESCRIPTION
When compiling on GPUs, the warning
```
warning #177-D: variable "<unnamed>::comm_z_tag" was declared but never referenced
```
arose. This PR removes the unused variable.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
