### PR TITLE
fix fatal typo

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -573,7 +573,7 @@ Hipace::Wait (const int step)
     // Receive beam particles.
     {
         const amrex::Long np_total = std::accumulate(np_rcv.begin(), np_rcv.end(), 0);
-        if (np_total > 0) return;
+        if (np_total == 0) return;
         const amrex::Long psize = sizeof(BeamParticleContainer::SuperParticleType);
         const amrex::Long buffer_size = psize*np_total;
         auto recv_buffer = (char*)amrex::The_Pinned_Arena()->alloc(buffer_size);
@@ -682,7 +682,7 @@ Hipace::Notify (const int step, const int it)
     // Send beam particles. Currently only one tile.
     {
         const amrex::Long np_total = std::accumulate(m_np_snd.begin(), m_np_snd.end(), 0);
-        if (np_total > 0) return;
+        if (np_total == 0) return;
         const amrex::Long psize = sizeof(BeamParticleContainer::SuperParticleType);
         const amrex::Long buffer_size = psize*np_total;
         m_psend_buffer = (char*)amrex::The_Pinned_Arena()->alloc(buffer_size);


### PR DESCRIPTION
This typo broke parallel runs.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
