### PR TITLE
Fix indexing for multi-beam recv

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -620,7 +620,7 @@ Hipace::Wait (const int step)
                         for (unsigned int index = m;
                              index < mend*psize/sizeof(double); index += blockDim.x) {
                             const double *csrc = (double *)
-                                (recv_buffer+offset_beam+blockDim.x*blockIdx.x*psize);
+                                (recv_buffer+offset_beam*psize+blockDim.x*blockIdx.x*psize);
                             double *cdest = (double *)shared;
                             cdest[index] = csrc[index];
                         }


### PR DESCRIPTION
The MPI receive buffer for beam particles is a char*, so the offset to access the first particle of beam ibeam is located at offset_beam * psize (where psize is the Byte/char size or 1 particle), and the code wrongfully used offset_beam.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
