### PR TITLE
Fix multi-beam IO

### DIFF
--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -157,7 +157,10 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
         auto const numParticleOnTile = a_box_sorter_vec[ibeam].boxCountsPtr()[it];
         uint64_t const numParticleOnTile64 = static_cast<uint64_t>( numParticleOnTile );
 
-        if (numParticleOnTile == 0) return;
+        if (numParticleOnTile == 0) {
+            m_tmp_offset[ibeam] = 0;
+            continue;
+        }
 
         // get position and particle ID from aos
         // note: this implementation iterates the AoS 4x...


### PR DESCRIPTION
Previously, `return` was used, where `continue`should have been used. This lead to not initializing the IO file if a beam had no particles on the first box, but particles on the second box.

This PR fixes the issue and multi beam IO works without problems.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
