### PR TITLE
fix logic in enforceBC and reactivate gaussian_weight.1Rank

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,13 +281,11 @@ if(BUILD_TESTING)
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
 
-        # Deactivate for now, as it segfaults in BoxSort because some particles are initialized
-        # outside of the domain.
-        #add_test(NAME gaussian_weight.1Rank
-        #         COMMAND ${HiPACE_SOURCE_DIR}/tests/gaussian_weight.1Rank.sh
-        #                 $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-        #         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        #)
+        add_test(NAME gaussian_weight.1Rank
+                 COMMAND ${HiPACE_SOURCE_DIR}/tests/gaussian_weight.1Rank.sh
+                         $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
+                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        )
 
         add_test(NAME beam_in_vacuum.normalized.2Rank
                  COMMAND ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.normalized.2Rank.sh

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -175,7 +175,7 @@ struct EnforceBC
         using namespace amrex::literals;
 
         const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_periodicity);
-        const bool invalid = shifted + !m_is_per[0];
+        const bool invalid = (shifted && !m_is_per[0]);
         if (invalid) {
             m_weights[ip] = 0.0_rt;
             m_structs[ip].id() = -std::abs(m_structs[ip].id());


### PR DESCRIPTION
This PR fixes a problem in the enforceBC:

previously, in the code was an `or` which should have been an `and` statement. This caused problems for simulations with non-periodic boundary conditions. This error was found, when the `gaussian_weight.1Rank` CI test was reactivated (which has nonn-periodic BC).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
