### PR TITLE
Remove configure_mpiexec from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,6 @@ if(BUILD_TESTING)
 
     else()
 
-        configure_mpiexec(1)  # one rank in MPI_TEST_EXE
         add_test(NAME blowout_wake.2Rank
                  COMMAND ${HiPACE_SOURCE_DIR}/tests/blowout_wake.2Rank.sh
                          $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
@@ -292,14 +291,6 @@ if(BUILD_TESTING)
                          $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
-
-        # This test is temporarily removed, due to bugs in the parallelization
-        # configure_mpiexec(2)  # two ranks in MPI_TEST_EXE
-        # add_test(NAME blowout_wake.2Rank
-        #         COMMAND ${HiPACE_SOURCE_DIR}/tests/blowout_wake.2Rank.sh
-        #                 $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-        #         WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        #)
 
     endif()
 endif()

--- a/cmake/HiPACEFunctions.cmake
+++ b/cmake/HiPACEFunctions.cmake
@@ -167,31 +167,6 @@ function(set_hipace_binary_name)
 endfunction()
 
 
-# Set an MPI_TEST_EXE variable for test runs which runs num_ranks
-# ranks. On some systems, you might need to use the a specific
-# mpiexec wrapper, e.g. on Summit (ORNL) pass the hint
-# -DMPIEXEC_EXECUTABLE=$(which jsrun) to run ctest.
-#
-function(configure_mpiexec num_ranks)
-    # OpenMPI root guard: https://github.com/open-mpi/ompi/issues/4451
-    if("$ENV{USER}" STREQUAL "root")
-        # calling even --help as root will abort and warn on stderr
-        execute_process(COMMAND ${MPIEXEC_EXECUTABLE} --help
-            ERROR_VARIABLE MPIEXEC_HELP_TEXT
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-            if(${MPIEXEC_HELP_TEXT} MATCHES "^.*allow-run-as-root.*$")
-                set(MPI_ALLOW_ROOT --allow-run-as-root)
-            endif()
-    endif()
-    set(MPI_TEST_EXE
-        ${MPIEXEC_EXECUTABLE}
-        ${MPI_ALLOW_ROOT}
-        ${MPIEXEC_NUMPROC_FLAG} ${num_ranks}
-        PARENT_SCOPE
-    )
-endfunction()
-
-
 # Prints a summary of HiPACE options at the end of the CMake configuration
 #
 function(hipace_print_summary)


### PR DESCRIPTION
The `mpiexec` command is currently in a separate bash script for each test, so that we have easy control to the simulation AND post-processing commands (checksum, compare with theory, etc.). Consequently, the `configure_mpiexec` CMake function isn't needed anymore. This PR proposes to delete its definition. It also includes minor cleaning of the CMakeLists.txt

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
