### PR TITLE
remove deprecated parameter

### DIFF
--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -3,12 +3,6 @@
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
 
-#ifdef AMREX_USE_MPI
-namespace {
-    constexpr int comm_z_tag = 3000;
-}
-#endif
-
 void
 BeamParticleContainer::ReadParameters ()
 {


### PR DESCRIPTION
This is a leftover from #407, an unused parameter is removed which prevents a warning

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
