### PR TITLE
last rank needs to resize to remove slipped beam particles from previous time step

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -654,10 +654,19 @@ Hipace::Notify (const int step, const int it)
 #ifdef AMREX_USE_MPI
     NotifyFinish(); // finish the previous send
 
-    // last step does not need to send anything
-    if (step == m_max_step -1 ) return;
-
     const int nbeams = m_multi_beam.get_nbeams();
+
+    // last step does not need to send anything, but needs to resize to remove slipped particles
+    if (step == m_max_step -1 )
+    {
+        for (int ibeam = 0; ibeam < nbeams; ibeam++){
+            const int offset_box = m_box_sorters[ibeam].boxOffsetsPtr()[it];
+            auto& ptile = m_multi_beam.getBeam(ibeam);
+            ptile.resize(offset_box);
+        }
+        return;
+    }
+
     m_np_snd.resize(nbeams);
 
     for (int ibeam = 0; ibeam < nbeams; ++ibeam)


### PR DESCRIPTION
This PR resolves #424.

In the last time step, the slipped beam particles need to be removed, because they don't belong to the current time step anymore.

Assuming we have 2 boxes (= 2 ranks) with 10 particles per box. In the last time step, 2 particles slip from the first to the second box. if that happened in a previous time step, the original 10 particles would be send to the next rank and then sorted  there. In the last time step, the particles are not send. Now, when calculating the second box, the rank has its original 10 particles in that box + the two slipped particles, which are already one time step ahead. Despite being wrong, the simulation crashed in IO, because now the number of particles exceeded the total number of particles of the beam.

This PR fixes this problem: in Notify, the particles which should have been sent to the next rank are removed by resizing (in the same way they would have been removed, if they had been sent).

This problem was tested with the following input script:
```
amr.n_cell = 127 127 300

hipace.normalized_units=1
hipace.predcorr_B_mixing_factor = 0.05
hipace.predcorr_max_iterations = 30
hipace.predcorr_B_error_tolerance = 4e-2
hipace.verbose = 1

hipace.output_slice = 1
diagnostic.diag_type=xz
diagnostic.field_data = ExmBy Ez rho

amr.blocking_factor = 1
amr.max_level = 0

max_step = 30
hipace.output_period = 1
#hipace.do_adaptive_time_step = 1
hipace.dt=3

hipace.numprocs_x = 1
hipace.numprocs_y = 1

hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -12.   -12.   -5    # physical domain
geometry.prob_hi     =  12.    12.    5

beams.names = beam #beam2
beam.profile = gaussian
beam.injection_type = fixed_weight
beam.num_particles = 1000000
beam.density = 50.
beam.u_mean = 0. 0. 50 #0
beam.u_std = 0. 0. 0.
beam.position_mean = 0. 0. 0
beam.position_std = 0.1 0.1 1.2
#beam.do_symmetrize=1
#beam.do_z_push = 0

plasma.density = 1.
plasma.radius = 1.3
plasma.ppc = 5 5
plasma.u_mean = 0.0 0.0 0.
```
Running on 6 CPUs, it fails on `development` and gives the correct results with this PR.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
