### PR TITLE
Fix error in compute B field error

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -200,6 +200,12 @@ public:
     /** Maximum number of iterations in the predictor corrector loop
      */
     static int m_predcorr_max_iterations;
+    /** Average number of iterations in the predictor corrector loop
+     */
+    amrex::Real m_predcorr_avg_iterations = 0.;
+    /** Average transverse B field error in the predictor corrector loop
+     */
+    amrex::Real m_predcorr_avg_B_error = 0.;
     /** Mixing factor between the transverse B field iterations in the predictor corrector loop
      */
     static amrex::Real m_predcorr_B_mixing_factor;

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -493,23 +493,58 @@ Fields::ComputeRelBFieldError (
      * for both Bx and By simultaneously */
     HIPACE_PROFILE("Fields::ComputeRelBFieldError()");
 
-    /* one temporary array is needed to store the difference of B fields
-     * between previous and current iteration */
-    amrex::MultiFab temp(getSlices(lev, WhichSlice::This).boxArray(),
-                         getSlices(lev, WhichSlice::This).DistributionMap(), 1,
-                         getSlices(lev, WhichSlice::This).nGrowVect());
-    /* calculating sqrt( |Bx|^2 + |By|^2 ) */
-    amrex::Real const norm_B = sqrt(amrex::MultiFab::Dot(Bx, Bx_comp, 1, 0)
-                               + amrex::MultiFab::Dot(By, By_comp, 1, 0));
+    // /* one temporary array is needed to store the difference of B fields
+    //  * between previous and current iteration */
+    // amrex::MultiFab temp(getSlices(lev, WhichSlice::This).boxArray(),
+    //                      getSlices(lev, WhichSlice::This).DistributionMap(), 1,
+    //                      getSlices(lev, WhichSlice::This).nGrowVect());
+    // /* calculating sqrt( |Bx|^2 + |By|^2 ) */
+    // amrex::Real const norm_B = sqrt(amrex::MultiFab::Dot(Bx, Bx_comp, 1, 0)
+    //                            + amrex::MultiFab::Dot(By, By_comp, 1, 0));
 
     /* calculating sqrt( |Bx - Bx_prev_iter|^2 + |By - By_prev_iter|^2 ) */
-    amrex::MultiFab::Copy(temp, Bx, Bx_comp, 0, 1, 0);
-    amrex::MultiFab::Subtract(temp, Bx_iter, Bx_iter_comp, 0, 1, 0);
-    amrex::Real norm_Bdiff = amrex::MultiFab::Dot(temp, 0, 1, 0);
-    amrex::MultiFab::Copy(temp, By, By_comp, 0, 1, 0);
-    amrex::MultiFab::Subtract(temp, By_iter, By_iter_comp, 0, 1, 0);
-    norm_Bdiff += amrex::MultiFab::Dot(temp, 0, 1, 0);
-    norm_Bdiff = sqrt(norm_Bdiff);
+    // amrex::MultiFab::Copy(temp, Bx, Bx_comp, 0, 1, 0);
+    // amrex::MultiFab::Subtract(temp, Bx_iter, Bx_iter_comp, 0, 1, 0);
+    // amrex::Real norm_Bdiff = amrex::MultiFab::Dot(temp, 0, 1, 0);
+    // amrex::MultiFab::Copy(temp, By, By_comp, 0, 1, 0);
+    // amrex::MultiFab::Subtract(temp, By_iter, By_iter_comp, 0, 1, 0);
+    // norm_Bdiff += amrex::MultiFab::Dot(temp, 0, 1, 0);
+    // norm_Bdiff = sqrt(norm_Bdiff);
+
+    amrex::Real norm_Bdiff = 0;
+    amrex::Gpu::DeviceScalar<amrex::Real> gpu_norm_Bdiff(norm_Bdiff);
+    amrex::Real* p_norm_Bdiff = gpu_norm_Bdiff.dataPtr();
+
+    amrex::Real norm_B = 0;
+    amrex::Gpu::DeviceScalar<amrex::Real> gpu_norm_B(norm_B);
+    amrex::Real* p_norm_B = gpu_norm_B.dataPtr();
+
+    for ( amrex::MFIter mfi(Bx, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
+        const amrex::Box& bx = mfi.tilebox();
+        amrex::Array4<amrex::Real const> const & Bx_array = Bx.array(mfi);
+        amrex::Array4<amrex::Real const> const & Bx_iter_array = Bx_iter.array(mfi);
+        amrex::Array4<amrex::Real const> const & By_array = By.array(mfi);
+        amrex::Array4<amrex::Real const> const & By_iter_array = By_iter.array(mfi);
+        amrex::ParallelFor(
+            bx,
+            [=] AMREX_GPU_DEVICE(int i, int j, int k)
+            {
+                amrex::Gpu::Atomic::Add(p_norm_B,
+                     Bx_array(i, j, k, Bx_comp) * Bx_array(i, j, k, Bx_comp) +
+                     By_array(i, j, k, By_comp) * By_array(i, j, k, By_comp) 
+                  );
+                amrex::Gpu::Atomic::Add(p_norm_Bdiff,
+                    ( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, 0) ) *
+                    ( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, 0) ) +
+                    ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, 0) ) *
+                    ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, 0) )
+                  );
+            }
+            );
+    }
+    norm_Bdiff = sqrt(gpu_norm_Bdiff.dataValue() );
+    norm_B = sqrt(gpu_norm_B.dataValue() );
+
 
     const int numPts_transverse = geom.Domain().length(0) * geom.Domain().length(1);
 

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -489,27 +489,9 @@ Fields::ComputeRelBFieldError (
     const amrex::MultiFab& By_iter, const int Bx_comp, const int By_comp, const int Bx_iter_comp,
     const int By_iter_comp, const amrex::Geometry& geom, const int lev)
 {
-    /* calculates the relative B field error between two B fields
-     * for both Bx and By simultaneously */
+    // calculates the relative B field error between two B fields
+    // for both Bx and By simultaneously
     HIPACE_PROFILE("Fields::ComputeRelBFieldError()");
-
-    // /* one temporary array is needed to store the difference of B fields
-    //  * between previous and current iteration */
-    // amrex::MultiFab temp(getSlices(lev, WhichSlice::This).boxArray(),
-    //                      getSlices(lev, WhichSlice::This).DistributionMap(), 1,
-    //                      getSlices(lev, WhichSlice::This).nGrowVect());
-    // /* calculating sqrt( |Bx|^2 + |By|^2 ) */
-    // amrex::Real const norm_B = sqrt(amrex::MultiFab::Dot(Bx, Bx_comp, 1, 0)
-    //                            + amrex::MultiFab::Dot(By, By_comp, 1, 0));
-    //
-    // /* calculating sqrt( |Bx - Bx_prev_iter|^2 + |By - By_prev_iter|^2 ) */
-    // amrex::MultiFab::Copy(temp, Bx, Bx_comp, 0, 1, 0);
-    // amrex::MultiFab::Subtract(temp, Bx_iter, Bx_iter_comp, 0, 1, 0);
-    // amrex::Real norm_Bdiff = amrex::MultiFab::Dot(temp, 0, 1, 0);
-    // amrex::MultiFab::Copy(temp, By, By_comp, 0, 1, 0);
-    // amrex::MultiFab::Subtract(temp, By_iter, By_iter_comp, 0, 1, 0);
-    // norm_Bdiff += amrex::MultiFab::Dot(temp, 0, 1, 0);
-    // norm_Bdiff = sqrt(norm_Bdiff);
 
     amrex::Real norm_Bdiff = 0;
     amrex::Gpu::DeviceScalar<amrex::Real> gpu_norm_Bdiff(norm_Bdiff);
@@ -525,85 +507,32 @@ Fields::ComputeRelBFieldError (
         amrex::Array4<amrex::Real const> const & Bx_iter_array = Bx_iter.array(mfi);
         amrex::Array4<amrex::Real const> const & By_array = By.array(mfi);
         amrex::Array4<amrex::Real const> const & By_iter_array = By_iter.array(mfi);
-        // amrex::ParallelFor(
-        //     bx,
-        //     [=] AMREX_GPU_DEVICE(int i, int j, int k)
-            amrex::ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
-            {
-                        amrex::Gpu::deviceReduceSum(p_norm_B,
-                            sqrt(Bx_array(i, j, k, Bx_comp) * Bx_array(i, j, k, Bx_comp) +
-                                 By_array(i, j, k, By_comp) * By_array(i, j, k, By_comp)), handler);
-                        amrex::Gpu::deviceReduceSum(p_norm_Bdiff,
-                            sqrt(( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) *
-                                 ( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) +
-                                 ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) ) *
-                                 ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) )), handler);
-                // amrex::Gpu::Atomic::Add(p_norm_B,
-                //      sqrt(Bx_array(i, j, k, Bx_comp) * Bx_array(i, j, k, Bx_comp) +
-                //           By_array(i, j, k, By_comp) * By_array(i, j, k, By_comp))
-                //   );
-                // amrex::Gpu::Atomic::Add(p_norm_Bdiff,
-                //     sqrt(( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) *
-                //          ( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) +
-                //          ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) ) *
-                //          ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) ))
-                //   );
-            }
-            );
+
+        amrex::ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), bx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
+        {
+            amrex::Gpu::deviceReduceSum(p_norm_B, sqrt(
+                                        Bx_array(i, j, k, Bx_comp) * Bx_array(i, j, k, Bx_comp) +
+                                        By_array(i, j, k, By_comp) * By_array(i, j, k, By_comp)),
+                                        handler);
+            amrex::Gpu::deviceReduceSum(p_norm_Bdiff, sqrt(
+                            ( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) *
+                            ( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) +
+                            ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) ) *
+                            ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) )),
+                            handler);
+        }
+        );
     }
     norm_Bdiff = gpu_norm_Bdiff.dataValue();
     norm_B = gpu_norm_B.dataValue();
 
-
-    // amrex::Gpu::Buffer<amrex::Real> b_norm_B({0.0});
-    // amrex::Real* p_norm_B = b_norm_B.data();
-    // amrex::Gpu::Buffer<amrex::Real> b_norm_Bdiff({0.0});
-    // amrex::Real* p_norm_Bdiff = b_norm_Bdiff.data();
-    // amrex::Real norm_Bdiff = 0;
-    // amrex::Gpu::DeviceScalar<amrex::Real> gpu_norm_Bdiff(norm_Bdiff);
-    // amrex::Real* p_norm_Bdiff = gpu_norm_Bdiff.dataPtr();
-    //
-    // amrex::Real norm_B = 0;
-    // amrex::Gpu::DeviceScalar<amrex::Real> gpu_norm_B(norm_B);
-    // amrex::Real* p_norm_B = gpu_norm_B.dataPtr();
-    // for ( amrex::MFIter mfi(Bx, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
-    // {
-    //     const amrex::Box& bx = mfi.fabbox();
-    //     amrex::Array4<amrex::Real const> const & Bx_array = Bx.array(mfi);
-    //     amrex::Array4<amrex::Real const> const & Bx_iter_array = Bx_iter.array(mfi);
-    //     amrex::Array4<amrex::Real const> const & By_array = By.array(mfi);
-    //     amrex::Array4<amrex::Real const> const & By_iter_array = By_iter.array(mfi);
-    //
-    //     amrex::ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), bx,
-    //     [=] AMREX_GPU_DEVICE (int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
-    //     {
-    //         amrex::Gpu::deviceReduceSum(p_norm_B,
-    //             sqrt(Bx_array(i, j, k, Bx_comp) * Bx_array(i, j, k, Bx_comp) +
-    //                  By_array(i, j, k, By_comp) * By_array(i, j, k, By_comp)), handler);
-    //         amrex::Gpu::deviceReduceSum(p_norm_Bdiff,
-    //             sqrt(( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) *
-    //                  ( Bx_array(i, j, k, Bx_comp) - Bx_iter_array(i, j, k, Bx_iter_comp) ) +
-    //                  ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) ) *
-    //                  ( By_array(i, j, k, By_comp) - By_iter_array(i, j, k, By_iter_comp) )), handler);
-    //     });
-    // }
-    // norm_Bdiff = gpu_norm_Bdiff.dataValue();
-    // norm_B = gpu_norm_B.dataValue();
-    // amrex::Real* norm_B = b_norm_B.copyToHost();
-    // amrex::ParallelDescriptor::ReduceRealSum(norm_B[0]);
-    // amrex::Real* norm_Bdiff = b_norm_Bdiff.copyToHost();
-    // amrex::ParallelDescriptor::ReduceRealSum(norm_Bdiff[0]);
-
-
-
-
     const int numPts_transverse = geom.Domain().length(0) * geom.Domain().length(1);
 
-    /* calculating the relative error
-     * Warning: this test might be not working in SI units! */
-     const amrex::Real relative_Bfield_error = (norm_B/numPts_transverse > 1e-10)
-                                                ? norm_Bdiff/norm_B : 0.;
+    // calculating the relative error
+    // Warning: this test might be not working in SI units!
+    const amrex::Real relative_Bfield_error = (norm_B/numPts_transverse > 1e-10)
+                                               ? norm_Bdiff/norm_B : 0.;
 
     return relative_Bfield_error;
 }


### PR DESCRIPTION
In the predictor corrector loop, the B field error was calculated in a convoluted way using dot products.
However, there must have been some small error, leading to slightly different results.

In the proposed implementation of this PR, the B field error is calculated by using a reduction by hand.

This approach is much cleaner and easier to overlook. 

In 2 tests (one high resolution run, one low resolution run in the blowout regime), the new approach yields very similar results to the old approach. However, fewer iterations are required and the calculation of the B field error per iteration is faster for the lower resolution and the same speed for the high resolution.

The high resolution input script was
```
amr.n_cell = 1024 1024 2048

hipace.normalized_units=1
hipace.predcorr_B_mixing_factor = 0.1
hipace.predcorr_max_iterations = 1
hipace.predcorr_B_error_tolerance = -4e-2
hipace.verbose = 2

hipace.beam_injection_cr=16

diagnostic.diag_type=xz
amr.blocking_factor = 1
amr.max_level = 0

max_step = 1
#hipace.do_adaptive_time_step=1
hipace.output_period = 1
hipace.numprocs_x = 1
hipace.numprocs_y = 1

hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -8.   -8.   -7    # physical domain
geometry.prob_hi     =  8.    8.    5

beams.names= beam beam2
beam.profile = gaussian
beam.injection_type = fixed_ppc
#beam.do_symmetrize = 1
#beam.num_particles = 1000000
beam.zmin = -5
beam.zmax = 5
beam.min_density = 0.1
beam.radius = 1.3
beam.density = 10.
beam.u_mean = 0. 0. 2000
beam.u_std = 0 0 0 # 10. 10. 20.
beam.position_mean = 0. 0. 0
beam.position_std = 0.3 0.3 1.41
#beam.dx_per_dzeta = 0.00709219858 # this corresponds to 0.01 per sigma
beam.ppc = 1 1 1


beam2.profile = gaussian
beam2.injection_type = fixed_ppc
beam2.zmin = -6
beam2.zmax = -4
beam2.radius = 0.9
beam2.min_density = 1
beam2.density = 100.
beam2.u_mean = 0. 0. 2000
beam2.u_std = 0 0 0 # 10. 10. 0.
beam2.position_mean = 0. 0. -5
beam2.position_std = 0.1 0.1 0.2

plasma.density = 1.
plasma.ppc = 2 2
plasma.u_mean = 0.0 0.0 0.
```
Profiling for development:
```
Rank 0: avg. number of iterations 1.774414062 avg. transverse B field error 0.01200395488


TinyProfiler total time across processes [min...avg...max]: 298.6 ... 298.6 ... 298.6

---------------------------------------------------------------------------------------------------
Name                                                NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------------
FFTPoissonSolverDirichlet::SolvePoissonEquation()    13412      162.5      162.5      162.5  54.44%
UpdateForcePushParticles_PlasmaParticleContainer()   11364      82.79      82.79      82.79  27.73%
DepositCurrent_PlasmaParticleContainer()              5683      28.41      28.41      28.41   9.51%
Fields::TransverseDerivative()                       19556       3.62       3.62       3.62   1.21%
Fields::ComputeRelBFieldError()                       5682      2.639      2.639      2.639   0.88%
ResetPlasmaParticles()                                2049      2.061      2.061      2.061   0.69%
```

Profiling for this PR:
```
Rank 0: avg. number of iterations 1.485839844 avg. transverse B field error 0.009902057107


TinyProfiler total time across processes [min...avg...max]: 284.6 ... 284.6 ... 284.6

---------------------------------------------------------------------------------------------------
Name                                                NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------------
FFTPoissonSolverDirichlet::SolvePoissonEquation()    12230      150.6      150.6      150.6  52.91%
UpdateForcePushParticles_PlasmaParticleContainer()   10182      75.22      75.22      75.22  26.43%
DepositCurrent_PlasmaParticleContainer()              5092      25.75      25.75      25.75   9.05%
Hipace::Evolve()                                         1      7.668      7.668      7.668   2.69%
Fields::TransverseDerivative()                       18374       4.85       4.85       4.85   1.70%
Fields::ComputeRelBFieldError()                       5091      2.356      2.356      2.356   0.83%
```


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
