### PR TITLE
Print Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ target_include_directories(HiPACE PRIVATE
 # if we include <AMReX_buildInfo.H> we will need to call:
 #include(AMReXBuildInfo)
 #generate_buildinfo(HiPACE "${HiPACE_SOURCE_DIR}")
+#target_link_libraries(HiPACE PRIVATE buildInfo::HiPACE)
 
 # add sources
 add_subdirectory(src)
@@ -155,7 +156,8 @@ set_hipace_binary_name()
 # Defines #####################################################################
 #
 # Let's use them as sparsely as possible to avoid MxNxOxP... binary variants.
-#target_compile_definitions(HiPACE PRIVATE -DHiPACE_FFTW)
+get_source_version(HiPACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(HiPACE PUBLIC HIPACE_GIT_VERSION="${HiPACE_GIT_VERSION}")
 
 
 # Warnings ####################################################################

--- a/cmake/HiPACEFunctions.cmake
+++ b/cmake/HiPACEFunctions.cmake
@@ -167,12 +167,40 @@ function(set_hipace_binary_name)
 endfunction()
 
 
+# FUNCTION: get_source_version
+#
+# Retrieves source version info and sets internal cache variables
+# ${NAME}_GIT_VERSION and ${NAME}_PKG_VERSION
+#
+function(get_source_version NAME SOURCE_DIR)
+    find_package(Git QUIET)
+    set(_tmp "")
+
+    # Try to inquire software version from git
+    if(EXISTS ${SOURCE_DIR}/.git AND ${GIT_FOUND})
+        execute_process(COMMAND git describe --abbrev=12 --dirty --always --tags
+                WORKING_DIRECTORY ${SOURCE_DIR}
+                OUTPUT_VARIABLE _tmp)
+        string( STRIP ${_tmp} _tmp)
+    endif()
+
+    # Is there a CMake project version?
+    # For deployed releases that build from tarballs, this is what we want to pick
+    if(NOT _tmp AND ${NAME}_VERSION)
+        set(_tmp "${${NAME}_VERSION}-nogit")
+    endif()
+
+    set(${NAME}_GIT_VERSION "${_tmp}" CACHE INTERNAL "")
+    unset(_tmp)
+endfunction ()
+
+
 # Prints a summary of HiPACE options at the end of the CMake configuration
 #
 function(hipace_print_summary)
     message("")
     message("HiPACE build configuration:")
-    message("  Version: ${HiPACE_VERSION}")
+    message("  Version: ${HiPACE_VERSION} (${HiPACE_GIT_VERSION})")
     message("  C++ Compiler: ${CMAKE_CXX_COMPILER_ID} "
                             "${CMAKE_CXX_COMPILER_VERSION} "
                             "${CMAKE_CXX_COMPILER_WRAPPER}")

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -136,6 +136,12 @@ public:
         return amrex::ParallelDescriptor::MyProc()==amrex::ParallelDescriptor::NProcs()-1;
     }
 
+    /** Version of the HiPACE executable
+     *
+     * @return detailed version string
+     */
+    static std::string Version ();
+
     /** Transverse MPI communicator (for transverse exchanges in 1 slice in the presence of
      * transverse parallelization)
      */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -184,6 +184,8 @@ void
 Hipace::InitData ()
 {
     HIPACE_PROFILE("Hipace::InitData()");
+    amrex::Print() << "HiPACE++ (" << Hipace::Version() << ")\n";
+
     amrex::Vector<amrex::IntVect> new_max_grid_size;
     for (int ilev = 0; ilev <= maxLevel(); ++ilev) {
         amrex::IntVect mgs = maxGridSize(ilev);
@@ -818,5 +820,15 @@ Hipace::WriteDiagnostics (int output_step, const int it)
 
     // Write beam particles
     m_multi_beam.WritePlotFile(filename);
+#endif
+}
+
+std::string
+Hipace::Version ()
+{
+#ifdef HIPACE_GIT_VERSION
+    return std::string(HIPACE_GIT_VERSION);
+#else
+    return std::string("Unknown");
 #endif
 }


### PR DESCRIPTION
Print the HiPACE++ version to the terminal. Fetched from `git` as usual. Will use a proper tag-prefixed description as soon as we add tags in the git history.

Same as https://github.com/ECP-WarpX/WarpX/pull/1820

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
