### PR TITLE
[mini] change assert in predictor corrector loop to Warning

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -550,7 +550,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev)
 
     if (relative_Bfield_error > 10. && m_predcorr_B_error_tolerance > 0.)
     {
-        amrex::Abort("Predictor corrector loop diverged!\n"
+        amrex::Print() << "WARNING: Predictor corrector loop may have diverged!\n"
                      "Re-try by adjusting the following paramters in the input script:\n"
                      "- lower mixing factor: hipace.predcorr_B_mixing_factor "
                      "(hidden default: 0.1) \n"
@@ -558,7 +558,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev)
                      " (hidden default: 0.04)\n"
                      "- higher number of iterations in the pred. cor. loop:"
                      "hipace.predcorr_max_iterations (hidden default: 5)\n"
-                     "- higher longitudinal resolution");
+                     "- higher longitudinal resolution";
     }
 
     // adding relative B field error for diagnostic


### PR DESCRIPTION
I found the assert being hit in simulations, which did not fully diverge and still produced reasonable results, but exited because the assert was hit. Therefore, this PR changes the assert for the predictor corrector loop to a warning.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
