### PR TITLE
[mini] set default for skip empty comms to false

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -246,7 +246,7 @@ public:
      * Used to avoid send/recv for empty data */
     int m_leftmost_box_rcv = std::numeric_limits<int>::max();
     /** Whether to skip communications of boxes that contain no beam particles */
-    int m_skip_empty_comms = true;
+    int m_skip_empty_comms = false;
 
 private:
     /** Pointer to current (and only) instance of class Hipace */


### PR DESCRIPTION
We observed some weird behaviour with the skipping of the empty comms, slowing down the simulation.
Until this is investigated and resolved, we switch the default to false for safety.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
