### PR TITLE
[DO NOT MERGE] add empty line for triggering CI

### DIFF
--- a/src/particles/pusher/UpdateForceTerms.H
+++ b/src/particles/pusher/UpdateForceTerms.H
@@ -61,6 +61,7 @@ void UpdateForceTerms(const amrex::ParticleReal& uxp,
     /* Change for psi along zeta */
     Fpsi1 = -charge_mass_ratio * (1.0_rt / phys_const.c * ( uxp * ExmByp + uyp * EypBxp ) / (psip + 1.0_rt) - Ezp );
 
+
 }
 
 /** \brief Shifting the force term coefficients


### PR DESCRIPTION
This PR solely tests the CI, because I suspect that something in the CI for the SI units is broken (might be a python problem)

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
