### PR TITLE
Remove option to dump to plotfiles

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -821,6 +821,8 @@ Hipace::WriteDiagnostics (int output_step, const int it)
     m_openpmd_writer.WriteDiagnostics(m_fields.getDiagF(), m_multi_beam, m_fields.getDiagGeom(),
                         m_physical_time, output_step, lev, m_fields.getDiagSliceDir(), varnames,
                         it, m_box_sorters, geom[lev]);
+#else
+    amrex::Print()<<"WARNING: hipace++ compiled without openPMD support, the simulation has no I/O.\n";
 #endif
 }
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -4,7 +4,6 @@
 #include "particles/BoxSort.H"
 #include "utils/IOUtil.H"
 
-#include <AMReX_PlotFileUtil.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_IntVect.H>
 
@@ -822,17 +821,6 @@ Hipace::WriteDiagnostics (int output_step, const int it)
     m_openpmd_writer.WriteDiagnostics(m_fields.getDiagF(), m_multi_beam, m_fields.getDiagGeom(),
                         m_physical_time, output_step, lev, m_fields.getDiagSliceDir(), varnames,
                         it, m_box_sorters, geom[lev]);
-#else
-    constexpr int nlev = 1;
-    const amrex::IntVect local_ref_ratio {1, 1, 1};
-
-    amrex::WriteMultiLevelPlotfile(
-        filename, nlev, amrex::GetVecOfConstPtrs(m_fields.getDiagF()), varnames,
-        m_fields.getDiagGeom(), m_physical_time, {output_step}, {local_ref_ratio},
-        "HyperCLaw-V1.1", "Level_", "Cell", rfs);
-
-    // Write beam particles
-    m_multi_beam.WritePlotFile(filename);
 #endif
 }
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -74,11 +74,6 @@ public:
         amrex::Vector<amrex::DenseBins<BeamParticleContainer::ParticleType>>& bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
 
-    /** Loop over species and dump them to plotfile
-     * \param[in] filename name of the output file
-     */
-    void WritePlotFile (const std::string& filename);
-
     /** Loop over species and init them
      * \param[in] geom Simulation geometry
      */

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -72,17 +72,6 @@ MultiBeam::AdvanceBeamParticlesSlice (
     }
 }
 
-void
-MultiBeam::WritePlotFile (const std::string& /*filename*/)
-{
-    amrex::Vector<int> plot_flags(BeamIdx::nattribs, 1);
-    amrex::Vector<int> int_flags(BeamIdx::nattribs, 1);
-    amrex::Vector<std::string> real_names {"w","ux","uy","uz"};
-    AMREX_ALWAYS_ASSERT(real_names.size() == BeamIdx::nattribs);
-    amrex::Vector<std::string> int_names {};
-}
-
-
 int
 MultiBeam::NumRealComps ()
 {


### PR DESCRIPTION
This PR addresses #409, and remove the options to dump data at the AMReX plotfile format, as Hipace++ currently only supports openPMD I/O.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
