### PR TITLE
fix sign of psi

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -517,7 +517,7 @@ Hipace::ExplicitSolveBxBy (const int lev)
                 //   psi in hipace++ has the wrong sign, it is actually -psi.
                 const amrex::Real cne     = - rho(i,j,k);
                 const amrex::Real cjz     =   jz (i,j,k);
-                const amrex::Real cpsi    = - psi(i,j,k);
+                const amrex::Real cpsi    =   psi(i,j,k);
                 const amrex::Real cjx     = - jx (i,j,k);
                 const amrex::Real cjy     = - jy (i,j,k);
                 const amrex::Real cjxx    = - jxx(i,j,k);
@@ -526,11 +526,11 @@ Hipace::ExplicitSolveBxBy (const int lev)
                 const amrex::Real cdx_jxx = - dx_jxx;
                 const amrex::Real cdx_jxy = - dx_jxy;
                 const amrex::Real cdx_jz  =   dx_jz;
-                const amrex::Real cdx_psi = - dx_psi;
+                const amrex::Real cdx_psi =   dx_psi;
                 const amrex::Real cdy_jyy = - dy_jyy;
                 const amrex::Real cdy_jxy = - dy_jxy;
                 const amrex::Real cdy_jz  =   dy_jz;
-                const amrex::Real cdy_psi = - dy_psi;
+                const amrex::Real cdy_psi =   dy_psi;
                 const amrex::Real cez     =   ez(i,j,k);
                 const amrex::Real cbz     =   bz(i,j,k);
 

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -229,7 +229,7 @@ void
 Fields::SolvePoissonExmByAndEypBx (amrex::Geometry const& geom, const MPI_Comm& m_comm_xy,
                                    const int lev)
 {
-    /* Solves Laplacian(-Psi) =  1/episilon0 * (rho-Jz/c) and
+    /* Solves Laplacian(Psi) =  1/episilon0 * -(rho-Jz/c) and
      * calculates Ex-c By, Ey + c Bx from  grad(-Psi)
      */
     HIPACE_PROFILE("Fields::SolveExmByAndEypBx()");
@@ -240,13 +240,13 @@ Fields::SolvePoissonExmByAndEypBx (amrex::Geometry const& geom, const MPI_Comm& 
     amrex::MultiFab lhs(getSlices(lev, WhichSlice::This), amrex::make_alias,
                         Comps[WhichSlice::This]["Psi"], 1);
 
-    // calculating the right-hand side 1/episilon0 * (rho-Jz/c)
+    // calculating the right-hand side 1/episilon0 * -(rho-Jz/c)
     amrex::MultiFab::Copy(m_poisson_solver->StagingArea(), getSlices(lev, WhichSlice::This),
                               Comps[WhichSlice::This]["jz"], 0, 1, 0);
     m_poisson_solver->StagingArea().mult(-1./phys_const.c);
     amrex::MultiFab::Add(m_poisson_solver->StagingArea(), getSlices(lev, WhichSlice::This),
                           Comps[WhichSlice::This]["rho"], 0, 1, 0);
-    m_poisson_solver->StagingArea().mult(1./phys_const.ep0);
+    m_poisson_solver->StagingArea().mult(-1./phys_const.ep0);
 
     m_poisson_solver->SolvePoissonEquation(lhs);
 
@@ -261,7 +261,7 @@ Fields::SolvePoissonExmByAndEypBx (amrex::Geometry const& geom, const MPI_Comm& 
         getSlices(lev, WhichSlice::This),
         Direction::x,
         geom.CellSize(Direction::x),
-        1.,
+        -1.,
         SliceOperatorType::Assign,
         Comps[WhichSlice::This]["Psi"],
         Comps[WhichSlice::This]["ExmBy"]);
@@ -271,7 +271,7 @@ Fields::SolvePoissonExmByAndEypBx (amrex::Geometry const& geom, const MPI_Comm& 
         getSlices(lev, WhichSlice::This),
         Direction::y,
         geom.CellSize(Direction::y),
-        1.,
+        -1.,
         SliceOperatorType::Assign,
         Comps[WhichSlice::This]["Psi"],
         Comps[WhichSlice::This]["EypBx"]);


### PR DESCRIPTION
Currently, the psi in the fields is actually -psi. It is only used to calculate ExmBy and EypBx and the missing minus is countered in the calculation.

This PR sets this right, so we actually calculate psi and not -psi.

No benchmarks needed to be updated, as they take the absolute.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
