### PR TITLE
cuFFTUtils: Add Missing Include

### DIFF
--- a/src/fields/fft_poisson_solver/fft/CuFFTUtils.H
+++ b/src/fields/fft_poisson_solver/fft/CuFFTUtils.H
@@ -3,6 +3,9 @@
 
 #include <cufft.h>
 
+#include <string>
+
+
 namespace CuFFTUtils
 {
     /** \brief This method converts a cufftResult


### PR DESCRIPTION
`std::string` from `<string>` is used in this file.

Fixes a user bug report (compilation error).

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
