### PR TITLE
change parabolic profile from channel_radius to parabolic_curvature

### DIFF
--- a/doc/source/run/parameters.rst
+++ b/doc/source/run/parameters.rst
@@ -102,9 +102,9 @@ plasma parameters for each plasma are specified via `plasma_name.plasma_property
 * ``plasma_name.radius`` (`float`) optional (default `infinity`)
     Radius of the plasma. Set a value to run simulations in a plasma column.
 
-* ``plasma_name.channel_radius`` (`float`) optional (default `0.`)
-    Channel radius of a parabolic plasma profile. The plasma density is set to
-    :math:`\mathrm{plasma.density} * (1 + r^2/\mathrm{plasma.channel\_radius}^2)`.
+* ``plasma_name.parabolic_curvature`` (`float`) optional (default `0.`)
+    Curvature of a parabolic plasma profile. The plasma density is set to
+    :math:`\mathrm{plasma.density} * (1 + \mathrm{plasma.parabolic\_curvature}*r^2)`.
 
 * ``plasma_name.max_qsa_weighting_factor`` (`float`) optional (default `35.`)
     The maximum allowed weighting factor :math:`\gamma /(\psi+1)` before particles are considered

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -67,8 +67,8 @@ public:
      *  the quasi-static approximation and is removed */
     amrex::Real m_max_qsa_weighting_factor {35.};
     amrex::Real m_radius {std::numeric_limits<amrex::Real>::infinity()}; /**< radius of the plasma */
-    /** defines the channel radius of a parabolic plasma profile */
-    amrex::Real m_channel_radius {std::numeric_limits<amrex::Real>::infinity()};
+    /** defines the curvature of a parabolic plasma profile */
+    amrex::Real m_parabolic_curvature {0.};
     amrex::IntVect m_ppc {0,0,1}; /**< Number of particles per cell in each direction */
     amrex::RealVect m_u_mean {0,0,0}; /**< Avg momentum in each direction normalized by m*c */
     amrex::RealVect m_u_std {0,0,0}; /**< Thermal momentum in each direction normalized by m*c */

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -46,9 +46,7 @@ PlasmaParticleContainer::ReadParameters ()
     pp.query("neutralize_background", m_neutralize_background);
     pp.query("density", m_density);
     pp.query("radius", m_radius);
-    pp.query("channel_radius", m_channel_radius);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_channel_radius != 0,
-                                     "The plasma channel radius must not be 0");
+    pp.query("parabolic_curvature", m_parabolic_curvature);
     pp.query("max_qsa_weighting_factor", m_max_qsa_weighting_factor);
     amrex::Vector<amrex::Real> tmp_vector;
     if (pp.queryarr("ppc", tmp_vector)){

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -90,7 +90,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
 
         PhysConst phys_const = get_phys_const();
 
-        const amrex::Real channel_radius = m_channel_radius;
+        const amrex::Real parabolic_curvature = m_parabolic_curvature;
 
         amrex::ParallelFor(tile_box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -135,9 +135,9 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 p.pos(2) = z;
 
                 arrdata[PlasmaIdx::w        ][pidx] =
-                        a_density*(1. + rp*rp/(channel_radius*channel_radius)) * scale_fac;
+                        a_density*(1. + parabolic_curvature*rp*rp) * scale_fac;
                 arrdata[PlasmaIdx::w0       ][pidx] =
-                        a_density*(1. + rp*rp/(channel_radius*channel_radius)) * scale_fac;
+                        a_density*(1. + parabolic_curvature*rp*rp) * scale_fac;
                 arrdata[PlasmaIdx::ux       ][pidx] = u[0] * phys_const.c;
                 arrdata[PlasmaIdx::uy       ][pidx] = u[1] * phys_const.c;
                 arrdata[PlasmaIdx::psi      ][pidx] = 0.;


### PR DESCRIPTION
The parabolic profile is now defined via a `parabolic_curvature` instead of a `channel_radius` to allow for negatively curved parabolic profile.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
