### PR TITLE
add the possibility to have different species of beams

### DIFF
--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -26,12 +26,12 @@ private:
     /** \brief setup the openPMD parameters do dump the AoS beam data
      *
      * \param[in,out] currSpecies openPMD species to set up
+     * \param[in] beam beam particle container to get mass and charge
      * \param[in] np total number of particles in the bunch
      * \param[in] geom Geometry of the simulation, to get the cell size etc.
      */
-    void SetupPos(openPMD::ParticleSpecies& currSpecies,
-                  const unsigned long long& np,
-                  const amrex::Geometry& geom);
+    void SetupPos(openPMD::ParticleSpecies& currSpecies, BeamParticleContainer& beam,
+                  const unsigned long long& np, const amrex::Geometry& geom);
 
     /** \brief setup the openPMD parameters do dump the SoA beam data
      *

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -82,6 +82,8 @@ public:
 #endif
 
     std::string get_name () const {return m_name;};
+    amrex::Real m_charge; /**< charge of each particle of this species */
+    amrex::Real m_mass; /**< mass of each particle of this species */
     bool m_do_z_push {true}; /**< Pushing beam particles in z direction */
     /** Number of particles on upstream rank (required for IO) */
     int m_num_particles_on_upstream_ranks {0};

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -3,10 +3,49 @@
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
 
+namespace
+{
+    void QueryElementSetChargeMass (amrex::ParmParse& pp, amrex::Real& charge, amrex::Real& mass)
+    {
+        // normalized_units is directly queried here so we can defined the appropriate PhysConst
+        // locally. We cannot use Hipace::m_phys_const as it has not been initialized when the
+        // PlasmaParticleContainer constructor is called.
+        amrex::ParmParse pph("hipace");
+        bool normalized_units = false;
+        pph.query("normalized_units", normalized_units);
+        PhysConst phys_const = normalized_units ? make_constants_normalized() : make_constants_SI();
+
+        std::string element;
+        bool element_is_specified = pp.query("element", element);
+        if (element_is_specified){
+            if (element == "electron"){
+                charge = -phys_const.q_e;
+                mass = phys_const.m_e;
+            } else if (element == "proton"){
+                charge = phys_const.q_e;
+                mass = phys_const.m_p;
+            } else if (element == "positron"){
+                charge = phys_const.q_e;
+                mass = phys_const.m_e;
+            }
+        } else {
+            // using electron beam as default
+            charge = -phys_const.q_e;
+            mass = phys_const.m_e;
+        }
+    }
+}
+
+
 void
 BeamParticleContainer::ReadParameters ()
 {
     amrex::ParmParse pp(m_name);
+    pp.query("charge", m_charge);
+    pp.query("mass", m_mass);
+    QueryElementSetChargeMass(pp, m_charge, m_mass);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass != 0, "The beam particle mass must not be 0");
+
     pp.get("injection_type", m_injection_type);
     amrex::Vector<amrex::Real> tmp_vector;
     if (pp.queryarr("ppc", tmp_vector)){

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -624,11 +624,9 @@ InitBeamFromFile (const std::string input_file,
 
         series.flush();
 
-        const input_type file_e_m = q_q_data.get()[0] * unit_qq / (m_m_data.get()[0] * unit_mm);
-        if( std::abs(file_e_m - ( phys_const_SI.q_e / phys_const_SI.m_e ) ) > 1e9) {
-            amrex::Abort("Charge / Mass of Beam Particle from file "
-                         "does not match electrons (1.7588e11)\n");
-        }
+        m_charge = (Hipace::m_normalized_units) ? q_q_data.get()[0] : q_q_data.get()[0] * unit_qq;
+        m_mass = (Hipace::m_normalized_units) ? m_m_data.get()[0] : m_m_data.get()[0] * unit_mm;
+
     }
     else {
         series.flush();

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -53,7 +53,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometr
     amrex::FArrayBox& jz_fab = jz[0];
 
     // For now: fix the value of the charge
-    const amrex::Real q = - phys_const.q_e;
+    const amrex::Real q = beam.m_charge;
 
     // Call deposition function in each box
     if        (Hipace::m_depos_order_xy == 0){

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -82,7 +82,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
     int const num_particles = cell_stop-cell_start;
 
     const amrex::Real clightsq = 1.0_rt/(phys_const.c*phys_const.c);
-    const amrex::Real charge_mass_ratio = - phys_const.q_e / phys_const.m_e;
+    const amrex::Real charge_mass_ratio = beam.m_charge / beam.m_mass;
     const amrex::Real external_ExmBy_slope = Hipace::m_external_ExmBy_slope;
     const amrex::Real external_Ez_slope = Hipace::m_external_Ez_slope;
     const amrex::Real external_Ez_uniform = Hipace::m_external_Ez_uniform;


### PR DESCRIPTION

This PR adds the possibility to have positron or any other species beams.

The beam particle charge and mass can now be specified, or similarly to the plasma implementation via `element = positron` etc.
As default the beam species is set to electrons. 

The charge and mass is also written to the openPMD file. When restarting simulations, now the charge and mass is read in from the file, too.

Simulations with electron and positron beams can be restarted both in SI and normalized units.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
