### PR TITLE
fix transverse beam currents for explicit solver

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -391,8 +391,14 @@ Hipace::SolveOneSlice (int islice, int lev, const int ibox,
         m_fields, WhichSlice::This, false, true, true, true, m_explicit, geom[lev], lev);
 
         if (m_explicit){
+            amrex::MultiFab j_slice_next(m_fields.getSlices(lev, WhichSlice::Next),
+                                         amrex::make_alias, Comps[WhichSlice::Next]["jx"], 4);
+            j_slice_next.setVal(0.);
             m_multi_beam.DepositCurrentSlice(m_fields, geom[lev], lev, islice, bx, bins, m_box_sorters,
                                              ibox, m_do_beam_jx_jy_deposition, WhichSlice::Next);
+            m_fields.AddBeamCurrents(lev, WhichSlice::Next);
+            // need to exchange jx jy jx_beam jy_beam
+            j_slice_next.FillBoundary(Geom(lev).periodicity());
         }
 
     m_fields.AddRhoIons(lev);


### PR DESCRIPTION
This PR fixes the explicit solver in handling transverse beam currents.

Previously, the beam currents on the next slice were not added to general currents on the next slice. Additionally, the next slice was not reset, leading to a build up of transverse currents on the next slice, which caused the longitudinal derivative to be wrong.

With this PR, the predictor-corrector loop (PC) and the explicit solver show the same behavior in the strong hosing regime:

 
![image](https://user-images.githubusercontent.com/65728274/116240219-e0cc0500-a763-11eb-9200-0fb92d2f9b5d.png)

This shows the evolution of the tail of a hosing beam.

The input script was
```
amr.n_cell = 256 256 256
hipace.normalized_units=1
hipace.predcorr_max_iterations = 30
hipace.predcorr_B_mixing_factor = 0.05
hipace.predcorr_B_error_tolerance = 4e-2

amr.blocking_factor = 2
amr.max_level = 0

max_step = 10
hipace.output_period = 1
hipace.dt = 6

hipace.numprocs_x = 1
hipace.numprocs_y = 1

hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     0      # Is periodic?
geometry.prob_lo     = -8.   -8.   -6    # physical domain
geometry.prob_hi     =  8.    8.    6

beams.names = beam
beam.injection_type = fixed_weight
beam.num_particles = 1000000
beam.profile = gaussian
beam.zmin = -5.9
beam.zmax = 5.9
beam.radius = 1.2
beam.density = 200.
beam.u_mean = 0. 0. 2000
beam.u_std = 0. 0. 0.
beam.position_mean = 0. 0. 0
beam.position_std = 0.1 0.1 1.41
beam.ppc = 1 1 1
beam.dx_per_dzeta = 0.2

plasmas.names = plasma
plasma.density = 1.
plasma.ppc = 1 1
plasma.u_mean = 0.0 0.0 0.
plasma.element = electron
hipace.verbose=1
diagnostic.diag_type = xz
``` 


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
