### PR TITLE
option to not compile the MG solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,10 @@ if(HiPACE_OPENPMD)
     target_link_libraries(HiPACE PUBLIC openPMD::openPMD)
 endif()
 
+if(AMReX_LINEAR_SOLVERS)
+    target_compile_definitions(HiPACE PUBLIC AMREX_USE_LINEAR_SOLVERS)
+endif()
+
 # fancy binary name for build variants
 set_hipace_binary_name()
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -11,7 +11,7 @@
 #include "utils/Constants.H"
 
 #include <AMReX_AmrCore.H>
-#ifdef AMReX_LINEAR_SOLVERS
+#ifdef AMREX_USE_LINEAR_SOLVERS
 #  include <AMReX_MLALaplacian.H>
 #  include <AMReX_MLMG.H>
 #endif
@@ -275,7 +275,7 @@ private:
     amrex::DistributionMapping m_slice_dm;
     amrex::BoxArray m_slice_ba;
 
-#ifdef AMReX_LINEAR_SOLVERS
+#ifdef AMREX_USE_LINEAR_SOLVERS
     /** Linear operator for the explicit Bx and By solver */
     std::unique_ptr<amrex::MLALaplacian> m_mlalaplacian;
     /** Geometric multigrid solver class, for the explicit Bx and By solver */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -6,7 +6,7 @@
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_IntVect.H>
-#ifdef AMReX_LINEAR_SOLVERS
+#ifdef AMREX_USE_LINEAR_SOLVERS
 #  include <AMReX_MLALaplacian.H>
 #  include <AMReX_MLMG.H>
 #endif
@@ -607,7 +607,7 @@ Hipace::ExplicitSolveBxBy (const int lev)
             );
     }
 
-#ifdef AMReX_LINEAR_SOLVERS
+#ifdef AMREX_USE_LINEAR_SOLVERS
     // For now, we construct the solver locally. Later, we want to move it to the hipace class as
     // a member so that we can reuse it.
     amrex::Geometry slice_geom = m_slice_geom;


### PR DESCRIPTION
Now one can use `cmake -DAMReX_LINEAR_SOLVERS=OFF` to avoid compiling the AMReX multigrid solver, which is taking a lot of time. Of course, by turning this off, one cannot use the explicit solver.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
