### PR TITLE
communicate physical time

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -103,13 +103,13 @@ public:
 
     /** \brief When slices sent to rank downstream, free buffer memory and make buffer nullptr
      *
+     * \param[in] it current box number
      * \param[in] only_ghost whether to pack only ghost particles (or only valid particles)
      */
     void NotifyFinish (const int it=0, bool only_ghost=false);
 
     /** \brief return whether rank is in the same transverse communicator w/ me
      *
-     * \param[in] it current box number
      * \param[in] rank MPI rank to test
      */
     bool InSameTransverseCommunicator (int rank) const;

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -105,10 +105,11 @@ public:
      *
      * \param[in] only_ghost whether to pack only ghost particles (or only valid particles)
      */
-    void NotifyFinish (bool only_ghost=false);
+    void NotifyFinish (const int it=0, bool only_ghost=false);
 
     /** \brief return whether rank is in the same transverse communicator w/ me
      *
+     * \param[in] it current box number
      * \param[in] rank MPI rank to test
      */
     bool InSameTransverseCommunicator (int rank) const;
@@ -188,6 +189,8 @@ public:
     /** status of the particle send request */
     MPI_Request m_psend_request = MPI_REQUEST_NULL;
     MPI_Request m_psend_request_ghost = MPI_REQUEST_NULL;
+    /** status of the physical time send request */
+    MPI_Request m_tsend_request = MPI_REQUEST_NULL;
 
     /** All field data (3D array, slices) and field methods */
     Fields m_fields;


### PR DESCRIPTION
This PR resolves #404.

In the old pipeline, each rank had the correct physical time, but dt needed to be communicated. 
In the new pipeline, each rank calculates its own dt, but the physical time needs to be communicated.

Before this fix, each rank would start at `t = 0` and then only add its own dt, missing the time of the other time steps.

In this PR, the physical time is communicated in the head box.

The correctness can be tested with the following input script:

```
amr.n_cell = 32 32 32

hipace.normalized_units=1

amr.blocking_factor = 2
amr.max_level = 0

max_step = 20
hipace.output_period = 1

hipace.numprocs_x = 1
hipace.numprocs_y = 1
hipace.predcorr_B_mixing_factor = 0.95
hipace.predcorr_max_iterations = 5
geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = 1     1     1      # Is periodic?
geometry.prob_lo     = -2.   -2.   -2.    # physical domain
geometry.prob_hi     =  2.    2.    2.

beams.names = beam
beam.injection_type = fixed_ppc
beam.profile = flattop
beam.zmin = -10.
beam.zmax = 10.
beam.u_mean = 0. 0. 2.e3
beam.u_std = 0. 0. 0.
beam.density = 1.e-8
beam.radius = 1.
beam.ppc = 4 4 1


plasmas.names = no_plasma

diagnostic.diag_type = xyz

hipace.dt = 3.
hipace.external_Ez_slope = -.5
hipace.verbose=1
plasmas.adaptive_density=1
```

The physical time for a run with 4 ranks (dt = 3) is now:
`[ 0.  3.  6.  9. 12. 15. 18. 21. 24. 27. 30. 33. 36. 39. 42. 45. 48. 51. 54. 57. 60.]`
On development, it was:
`[ 0.  0.  0.  0.  3.  3.  3.  3.  6.  6.  6.  6.  9.  9.  9.  9. 12. 12. 12. 12. 15.]`

This also fixes the adaptive time step in parallel.



- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
