### PR TITLE
enable multiple boxes per rank

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -54,6 +54,12 @@ General parameters
     Using the default, the beam deposits all currents `Jx`, `Jy`, `Jz`. Using
     `hipace.do_beam_jx_jy_deposition = 0` disables the transverse current deposition of the beams.
 
+* ``hipace.boxes_in_z`` (`int`) optional (default `1`)
+    Number of boxes along the z-axis. In serial runs, the arrays for 3D IO can easily exceed the
+    memory of a GPU. Using multiple boxes reduces the memory requirements by the same factor.
+    This option is only available in serial runs, in parallel runs, please use more GPU to achieve
+    the same effect.
+
 Field solver parameters
 -----------------------
 

--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -22,8 +22,7 @@ geometry.prob_lo     = -8.   -8.   -6    # physical domain
 geometry.prob_hi     =  8.    8.    6
 
 beams.names = beam
-beam.injection_type = fixed_weight
-beam.num_particles=100000
+beam.injection_type = fixed_ppc
 beam.profile = gaussian
 beam.zmin = -5.9
 beam.zmax = 5.9

--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -22,7 +22,8 @@ geometry.prob_lo     = -8.   -8.   -6    # physical domain
 geometry.prob_hi     =  8.    8.    6
 
 beams.names = beam
-beam.injection_type = fixed_ppc
+beam.injection_type = fixed_weight
+beam.num_particles=100000
 beam.profile = gaussian
 beam.zmin = -5.9
 beam.zmax = 5.9

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -176,7 +176,7 @@ public:
     /** My rank in the longitudinal communicator */
     int m_rank_z = 0;
     /** Max number of grid size in the longitudinal direction */
-    int m_grid_size_z = 0;
+    int m_boxes_in_z = 1;
     /** Send buffer for particle longitudinal parallelization (pipeline) */
     char* m_psend_buffer = nullptr;
     char* m_psend_buffer_ghost = nullptr;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -82,6 +82,8 @@ Hipace::Hipace () :
     pph.query("numprocs_x", m_numprocs_x);
     pph.query("numprocs_y", m_numprocs_y);
     pph.query("boxes_in_z", m_boxes_in_z);
+    if (m_boxes_in_z > 1) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_numprocs_z == 1,
+                            "Multiple boxes per rank only implemented for one rank.");
     pph.query("depos_order_xy", m_depos_order_xy);
     pph.query("depos_order_z", m_depos_order_z);
     pph.query("predcorr_B_error_tolerance", m_predcorr_B_error_tolerance);
@@ -247,7 +249,6 @@ Hipace::MakeNewLevelFromScratch (
         const amrex::IntVect box_size = ba[0].length();  // Uniform box size
         const int nboxes_x = m_numprocs_x;
         const int nboxes_y = m_numprocs_y;
-        //const int nboxes_z = ncells_global[2] / box_size[2];
         const int nboxes_z = (m_boxes_in_z == 1) ? ncells_global[2] / box_size[2] : m_boxes_in_z;
         AMREX_ALWAYS_ASSERT(static_cast<long>(nboxes_x) *
                             static_cast<long>(nboxes_y) *

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -81,6 +81,12 @@ Hipace::Hipace () :
     pph.query("verbose", m_verbose);
     pph.query("numprocs_x", m_numprocs_x);
     pph.query("numprocs_y", m_numprocs_y);
+    m_numprocs_z = amrex::ParallelDescriptor::NProcs() / (m_numprocs_x*m_numprocs_y);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_numprocs_z <= m_max_step+1,
+                                     "Please use more or equal time steps than number of ranks");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_numprocs_x*m_numprocs_y*m_numprocs_z
+                                     == amrex::ParallelDescriptor::NProcs(),
+                                     "Check hipace.numprocs_x and hipace.numprocs_y");
     pph.query("boxes_in_z", m_boxes_in_z);
     if (m_boxes_in_z > 1) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_numprocs_z == 1,
                             "Multiple boxes per rank only implemented for one rank.");
@@ -93,12 +99,6 @@ Hipace::Hipace () :
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_output_period != 0,
                                      "To avoid output, please use output_period = -1.");
     pph.query("beam_injection_cr", m_beam_injection_cr);
-    m_numprocs_z = amrex::ParallelDescriptor::NProcs() / (m_numprocs_x*m_numprocs_y);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_numprocs_z <= m_max_step+1,
-                                     "Please use more or equal time steps than number of ranks");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_numprocs_x*m_numprocs_y*m_numprocs_z
-                                     == amrex::ParallelDescriptor::NProcs(),
-                                     "Check hipace.numprocs_x and hipace.numprocs_y");
     pph.query("do_beam_jx_jy_deposition", m_do_beam_jx_jy_deposition);
     pph.query("do_device_synchronize", m_do_device_synchronize);
     pph.query("external_ExmBy_slope", m_external_ExmBy_slope);


### PR DESCRIPTION
This PR enables to have multiple boxes per rank, if run with just one rank.

Large 3D arrays easily exceed the memory of a GPU. This PR proposes to use multiple boxes when running with just one rank, to not allocate the full memory of the 3D array, but only 1/N_boxes of the array, similarly as it happens in the longitudinal pipelining when running with N_ranks.

With this, the memory usage can be drastically reduced and it enables large simulations in 3D on a single GPU.

Running the blowout_wake example with `../../build/bin/hipace inputs_normalized hipace.boxes_in_z=1 amr.n_cell = 256 256 512`
the memory usage was 
```
Total GPU global memory (MB) spread across MPI: [7973 ... 7973]
Free  GPU global memory (MB) spread across MPI: [2294 ... 2294]
[The         Arena] space (MB) allocated spread across MPI: [5980 ... 5980]
[The         Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Device Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The  Device Arena] space (MB) used      spread across MPI: [0 ... 0]
[The Managed Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The Managed Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Pinned Arena] space (MB) allocated spread across MPI: [4360 ... 4360]
[The  Pinned Arena] space (MB) used      spread across MPI: [0 ... 0]
```
Running with `../../build/bin/hipace inputs_normalized hipace.boxes_in_z=8 amr.n_cell = 256 256 512` requires only 
```
Total GPU global memory (MB) spread across MPI: [7973 ... 7973]
Free  GPU global memory (MB) spread across MPI: [6142 ... 6142]
[The         Arena] space (MB) allocated spread across MPI: [5980 ... 5980]
[The         Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Device Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The  Device Arena] space (MB) used      spread across MPI: [0 ... 0]
[The Managed Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The Managed Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Pinned Arena] space (MB) allocated spread across MPI: [552 ... 552]
[The  Pinned Arena] space (MB) used      spread across MPI: [0 ... 0]
```

Additionally, previously large simulations with `512*512*1024` where possible on my local GPU with 8 GB.

This PR needs cleaning and safeguards before it can be finalized.



- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
