### PR TITLE
Fix typo in beam from_file

### DIFF
--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -322,16 +322,16 @@ InitBeamFromFileHelper (const std::string input_file,
         }
 
         if( input_type == openPMD::Datatype::INT || (species_specified && !species_known)) {
-          std::string err = "Error, the particle species name " + species_name +
-                " was not found or doss not contain any data. The input file contains the" +
-                " following particle species names:\n";
-          for( auto const& species_type : series.iterations[num_iteration].particles ) {
-              err += species_type.first + "\n";
-          }
-          if( !species_specified ) {
-              err += "Use beam.openPMD_species_name NAME to specify a paricle species\n";
-          }
-          amrex::Abort(err);
+            std::string err = "Error, the particle species name " + species_name +
+                  " was not found or does not contain any data. The input file contains the" +
+                  " following particle species names:\n";
+            for( auto const& species_type : series.iterations[num_iteration].particles ) {
+                err += species_type.first + "\n";
+            }
+            if( !species_specified ) {
+                err += "Use beam.openPMD_species_name NAME to specify a paricle species\n";
+            }
+            amrex::Abort(err);
         }
 
     }


### PR DESCRIPTION
Also comply with four spaces convention.
- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
