### PR TITLE
[mini] remove deprecated comment

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -599,7 +599,6 @@ Hipace::ExplicitSolveBxBy (const int lev)
                 // NOTE: a few -1 factors are added here, due to discrepancy in definitions between
                 // WAND-PIC and hipace++:
                 //   n* and j are defined from ne in WAND-PIC and from rho in hipace++.
-                //   psi in hipace++ has the wrong sign, it is actually -psi.
                 const amrex::Real cne     = - rho(i,j,k);
                 const amrex::Real cjzp    = - (jz(i,j,k) - jzb(i,j,k));
                 const amrex::Real cjxp    = - (jx(i,j,k) - jxb(i,j,k));


### PR DESCRIPTION
This comment is deprecated, the sign of psi was fixed in #455.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
