### PR TITLE
Add possibility to input multiple beams at once

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -255,6 +255,11 @@ Option: ``from_file``
     Name of the beam to be read in. If an openPMD file contains multiple beams, the name of the beam
     needs to be specified.
 
+* ``beams.all_from_file`` (`string`)
+    Name of the input file for all beams. This macro then passes it down to all individual beams
+    without a specified `injection_type`. Additionally the input parameters `beams.iteration`,
+    `beams.plasma_density` and `beams.file_coordinates_xyz` are passed down if applicable.
+
 Diagnostic parameters
 ---------------------
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -145,7 +145,7 @@ public:
      */
     int getNRealParticles (int ibeam) const {return m_n_real_particles[ibeam];};
 
-    /** \brief Allows beams.all_from_file <file> to specify the input file of all beams that have
+    /** \brief Allows beams.all_from_file to specify the input file of all beams that have
      * no injection_type. Also passes down beams.iteration, beams.plasma_density and
      * beams.file_coordinates_xyz to the individual beams if applicable.
      *

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -144,6 +144,14 @@ public:
      * \param[in] ibeam index of the beam
      */
     int getNRealParticles (int ibeam) const {return m_n_real_particles[ibeam];};
+
+    /** \brief Allows beams.all_from_file <file> to specify the input file of all beams that have
+     * no injection_type. Also passes down beams.iteration, beams.plasma_density and
+     * beams.file_coordinates_xyz to the individual beams if applicable.
+     *
+     * \param[in] beam_names names of all beams.
+     */
+    void MultiFromFileMacro (const amrex::Vector<std::string> beam_names);
 private:
 
     amrex::Vector<BeamParticleContainer> m_all_beams; /**< contains all beam containers */


### PR DESCRIPTION
This PR adds the possibility to input multiple beams from the same file with the same input parameter instead of specifying them one by one.
Old, but still possible:
```
beams.names = beam1 beam2
beam1.injection_type = from_file
beam1.input_file = beam_%T.h5
beam1.iteration = 0
beam2.injection_type = from_file
beam2.input_file = beam_%T.h5
beam2.iteration = 0
```
New:
```
beams.names = beam1 beam2
beams.all_from_file = beam_%T.h5
beams.iteration = 0
```
It's also supported to specify `iteration`, `plasma_density` and `file_coordinates_xyz` for all beams at once.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
