### PR TITLE
remove hardcoded lev calls

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -225,8 +225,8 @@ Hipace::InitData ()
 
     AmrCore::InitFromScratch(0.0); // function argument is time
     constexpr int lev = 0;
-    m_multi_beam.InitData(geom[0]);
-    m_multi_plasma.InitData(lev, m_slice_ba, m_slice_dm, m_slice_geom, geom[0]);
+    m_multi_beam.InitData(geom[lev]);
+    m_multi_plasma.InitData(lev, m_slice_ba, m_slice_dm, m_slice_geom, geom[lev]);
     m_adaptive_time_step.Calculate(m_dt, m_multi_beam, m_multi_plasma.maxDensity());
 #ifdef AMREX_USE_MPI
     m_adaptive_time_step.WaitTimeStep(m_dt, m_comm_z);
@@ -243,7 +243,7 @@ Hipace::MakeNewLevelFromScratch (
     // We are going to ignore the DistributionMapping argument and build our own.
     amrex::DistributionMapping dm;
     {
-        const amrex::IntVect ncells_global = Geom(0).Domain().length();
+        const amrex::IntVect ncells_global = Geom(lev).Domain().length();
         const amrex::IntVect box_size = ba[0].length();  // Uniform box size
         const int nboxes_x = m_numprocs_x;
         const int nboxes_y = m_numprocs_y;
@@ -278,7 +278,8 @@ Hipace::PostProcessBaseGrids (amrex::BoxArray& ba0) const
 {
     // This is called by AmrCore::InitFromScratch.
     // The BoxArray made by AmrCore is not what we want.  We will replace it with our own.
-    const amrex::IntVect ncells_global = Geom(0).Domain().length();
+    const int lev = 0;
+    const amrex::IntVect ncells_global = Geom(lev).Domain().length();
     amrex::IntVect box_size{ncells_global[0] / m_numprocs_x,
                             ncells_global[1] / m_numprocs_y,
                             m_grid_size_z};


### PR DESCRIPTION
In order to prepare for mesh refinement and the required multiple levels, some hardcoded `lev` calls are replaced.

Note: in some function calls we pass both `lev` and `Geom(lev) `. This should probably be replaced by passing the full `Geom`
and then calling it with the provided `lev`, which is already also passed.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
