### PR TITLE
[WIP] add the possiblity to fully symmetrize the beam.

### DIFF
--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -55,7 +55,7 @@ public:
                               const amrex::RealVect pos_std,
                               const amrex::Real total_charge,
                               const bool do_symmetrize,
-                              const bool do_super_symmetrize,
+                              const bool do_full_symmetrize,
                               const amrex::Real dx_per_dzeta,
                               const amrex::Real dy_per_dzeta);
 
@@ -114,7 +114,7 @@ private:
     amrex::Real m_density; /**< Peak density for fixed-weight Gaussian beam */
     amrex::Real m_min_density {0.}; /**< minimum density at which beam particles are generated */
     bool m_do_symmetrize {0}; /**< Option to symmetrize the beam */
-    bool m_do_super_symmetrize {0}; /**< Option to fully symmetrize the beam */
+    bool m_do_full_symmetrize {0}; /**< Option to fully symmetrize the beam */
     /** Density of plasma to convert from_file beam to normalized units */
     amrex::Real m_plasma_density;
     std::string m_input_file; /**< Path to bean input file */

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -55,6 +55,7 @@ public:
                               const amrex::RealVect pos_std,
                               const amrex::Real total_charge,
                               const bool do_symmetrize,
+                              const bool do_super_symmetrize,
                               const amrex::Real dx_per_dzeta,
                               const amrex::Real dy_per_dzeta);
 
@@ -113,6 +114,7 @@ private:
     amrex::Real m_density; /**< Peak density for fixed-weight Gaussian beam */
     amrex::Real m_min_density {0.}; /**< minimum density at which beam particles are generated */
     bool m_do_symmetrize {0}; /**< Option to symmetrize the beam */
+    bool m_do_super_symmetrize {0}; /**< Option to fully symmetrize the beam */
     /** Density of plasma to convert from_file beam to normalized units */
     amrex::Real m_plasma_density;
     std::string m_input_file; /**< Path to bean input file */

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -59,6 +59,14 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         pp.query("do_symmetrize", m_do_symmetrize);
         if (m_do_symmetrize) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_particles%4 == 0,
             "To symmetrize the beam, please specify a beam particle number divisible by 4.");
+        pp.query("do_full_symmetrize", m_do_full_symmetrize);
+        if (m_do_full_symmetrize) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_particles%16 == 0,
+            "To fully symmetrize the beam, please specify a beam particle number divisible by 16.");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_do_symmetrize == 0,
+            "You can either symmetrize the beam or super-symmetrize the beam, not both");
+        }
+
 
         if (peak_density_is_specified)
         {
@@ -76,8 +84,8 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 
         const GetInitialMomentum get_momentum(m_name);
         InitBeamFixedWeight(m_num_particles, get_momentum, m_position_mean,
-                            m_position_std, m_total_charge, m_do_symmetrize, m_dx_per_dzeta,
-                            m_dy_per_dzeta);
+                            m_position_std, m_total_charge, m_do_symmetrize, m_do_full_symmetrize,
+                            m_dx_per_dzeta, m_dy_per_dzeta);
 
     } else if (m_injection_type == "from_file") {
 #ifdef HIPACE_USE_OPENPMD

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -216,6 +216,7 @@ InitBeamFixedWeight (int num_to_add,
                      const amrex::RealVect pos_std,
                      const amrex::Real total_charge,
                      const bool do_symmetrize,
+                     const bool do_full_symmetrize,
                      const amrex::Real dx_per_dzeta,
                      const amrex::Real dy_per_dzeta)
 {
@@ -223,6 +224,7 @@ InitBeamFixedWeight (int num_to_add,
 
     if (num_to_add == 0) return;
     if (do_symmetrize) num_to_add /=4;
+    if (do_full_symmetrize) num_to_add /=16;
 
     PhysConst phys_const = get_phys_const();
 
@@ -231,6 +233,7 @@ InitBeamFixedWeight (int num_to_add,
         auto& particle_tile = *this;
         auto old_size = particle_tile.GetArrayOfStructs().size();
         auto new_size = do_symmetrize? old_size + 4*num_to_add : old_size + num_to_add;
+        if (do_full_symmetrize) new_size =  old_size + 16*num_to_add;
         particle_tile.resize(new_size);
 
         // Access particles' AoS and SoA
@@ -257,12 +260,12 @@ InitBeamFixedWeight (int num_to_add,
                 const amrex::Real cental_y_pos = pos_mean[1] + z*dy_per_dzeta;
 
                 amrex::Real weight = total_charge / num_to_add / phys_const.q_e;
-                if (!do_symmetrize)
+                if (!do_symmetrize && !do_full_symmetrize)
                 {
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
                                        pos_mean[2]+z, u[0], u[1], u[2], weight,
                                        pid, procID, i, phys_const.c);
-                } else {
+                } else if (do_symmetrize) {
                     weight /= 4;
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
                                        pos_mean[2]+z, u[0], u[1], u[2], weight,
@@ -276,6 +279,56 @@ InitBeamFixedWeight (int num_to_add,
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
                                        pos_mean[2]+z, -u[0], -u[1], u[2], weight,
                                        pid, procID, 4*i+3, phys_const.c);
+                } else {
+                    weight /= 16;
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
+                                       pos_mean[2]+z, u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
+                                       pos_mean[2]+z, u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+1, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
+                                       pos_mean[2]+z, -u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i+2, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
+                                       pos_mean[2]+z, -u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+3, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos-y,
+                                       pos_mean[2]+z, u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i+4, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos-y,
+                                       pos_mean[2]+z, u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+5, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos-y,
+                                       pos_mean[2]+z, -u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i+6, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos-y,
+                                       pos_mean[2]+z, -u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+7, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos+y,
+                                       pos_mean[2]+z, u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i+8, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos+y,
+                                       pos_mean[2]+z, u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+9, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos+y,
+                                       pos_mean[2]+z, -u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i+10, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos+y,
+                                       pos_mean[2]+z, -u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+11, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
+                                       pos_mean[2]+z, u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i+12, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
+                                       pos_mean[2]+z, u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+13, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
+                                       pos_mean[2]+z, -u[0], u[1], u[2], weight,
+                                       pid, procID, 16*i+14, phys_const.c);
+                    AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
+                                       pos_mean[2]+z, -u[0], -u[1], u[2], weight,
+                                       pid, procID, 16*i+15, phys_const.c);
                 }
             });
     }


### PR DESCRIPTION
This PR adds the possibility to fully symmetrize the beam.

The `do_symmetrize` option creates for each particle with (x, y, ux, uy) 3 more particles:
``` 
 x  y  ux  uy
-x  y -ux  uy
 x -y  ux -uy
-x -y -ux -uy
```
With this, the average of x, y, ux, uy is 0. However, their products, e.g. `x*ux` are not.
This is added by the new `do_full_symmetrize` option, which generates 15 additional particles (16 in total):
```
 x  y  ux  uy
 x  y  ux -uy
 x  y -ux  uy
 x  y -ux -uy
 x -y  ux  uy
 x -y  ux -uy
 x -y -ux  uy
 x -y -ux -uy
-x  y  ux  uy
-x  y  ux -uy
-x  y -ux  uy
-x  y -ux -uy
-x -y  ux  uy
-x -y  ux -uy
-x -y -ux  uy
-x -y -ux -uy
 ```

If this actually helps, needs to be tested in high-resolution runs.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
