### PR TITLE
add proton element for convenience

### DIFF
--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -27,6 +27,9 @@ PlasmaParticleContainer::ReadParameters ()
     } else if (element == "positron") {
         m_charge = phys_const.q_e;
         m_mass = phys_const.m_e;
+    } else if (element == "proton") {
+        m_charge = phys_const.q_e;
+        m_mass = phys_const.m_p;
     }
 
     amrex::Real mass_Da;


### PR DESCRIPTION
This enables to specify the element `proton` for plasma species, it is more convenient than using Hydrogen at the first ionization level

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
