### PR TITLE
add Adios2 support

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -60,7 +60,7 @@ General parameters
     This option is only available in serial runs, in parallel runs, please use more GPU to achieve
     the same effect.
 
-* ``hipace.openpmd_backend`` (`string`) optional
+* ``hipace.openpmd_backend`` (`string`) optional (default `h5`)
     OpenPMD backend. This can either be `h5, bp`, or `json`. The default is chosen by what is
     available. If both Adios2 and HDF5 are available, `h5` is used. Note that `json` is extremely
     slow and is not recommended for production runs.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -60,6 +60,11 @@ General parameters
     This option is only available in serial runs, in parallel runs, please use more GPU to achieve
     the same effect.
 
+* ``hipace.openpmd_backend`` (`string`) optional
+    OpenPMD backend. This can either be `h5, bp`, or `json`. The default is chosen by what is
+    available. If both Adios2 and HDF5 are available, `h5` is used. Note that `json` is extremely
+    slow and is not recommended for production runs.
+
 Field solver parameters
 -----------------------
 

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -92,6 +92,9 @@ private:
     /** Parallel openPMD-api Series object for output */
     std::unique_ptr< openPMD::Series > m_outputSeries;
 
+    /** openPMD backend: h5, bp, or json. Default depends on what is available */
+    std::string m_openpmd_backend = "default";
+
     /** Last iteration that was written to file.
      * This is stored to make sure we don't write the last iteration multiple times. */
     int m_last_output_dumped = -1;


### PR DESCRIPTION
This PR adds Adios2 support. This is also a preparation for mesh refinement. The openPMD backend is chosen by what is available. If both Adios2 and HDF5 are available, HDF5 is chosen for now. If Adios2 shows performance improvements, we should consider to switch. In some simple, local tests, `h5` was faster.

Additionally, `json` was also added, but it is very slow and may only be used for debugging.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
