### PR TITLE
move Diagnostic class from Fields to Hipace class

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -9,6 +9,7 @@
 #include "utils/AdaptiveTimeStep.H"
 #include "utils/GridCurrent.H"
 #include "utils/Constants.H"
+#include "diagnostics/Diagnostic.H"
 
 #include <AMReX_AmrCore.H>
 #ifdef AMREX_USE_LINEAR_SOLVERS
@@ -305,6 +306,20 @@ private:
 #endif
     /** Used to sort the beam particles into boxes for pipelining */
     amrex::Vector<BoxSorter> m_box_sorters;
+
+    /** Diagnostics */
+    Diagnostic m_diags;
+
+    void ResizeFDiagFAB (const amrex::Box box, const int lev) { m_diags.ResizeFDiagFAB(box, lev); };
+    void FillDiagnostics (int lev, int i_slice);
+    /** \brief get diagnostics Component names of Fields to output */
+    amrex::Vector<std::string>& getDiagComps () { return m_diags.getComps(); };
+    /** \brief get diagnostics multifab */
+    amrex::Vector<amrex::FArrayBox>& getDiagF () { return m_diags.getF(); };
+    /** \brief get diagnostics geometry */
+    amrex::Vector<amrex::Geometry>& getDiagGeom () { return m_diags.getGeom(); };
+    /** \brief get slicing direction of the diagnostics */
+    int getDiagSliceDir () { return m_diags.sliceDir(); };
 
     /** \brief Predictor-corrector loop to calculate Bx and By.
      * 1. an initial Bx and By value is guessed.

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(HiPACE
   PRIVATE
     OpenPMDWriter.cpp
-    FieldDiagnostic.cpp
+    Diagnostic.cpp
 )

--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -1,19 +1,20 @@
-#ifndef FIELDDIAGNOSTIC_H_
-#define FIELDDIAGNOSTIC_H_
+#ifndef DIAGNOSTIC_H_
+#define DIAGNOSTIC_H_
 
 #include <AMReX_MultiFab.H>
+#include <AMReX_Vector.H>
 
 /** type of diagnostics: full xyz array or xz slice or yz slice */
 enum struct DiagType{xyz, xz, yz};
 
 /** \brief This class holds data for 1 diagnostics (full or slice) */
-class FieldDiagnostic
+class Diagnostic
 {
 
 public:
 
     /** \brief Constructor */
-    explicit FieldDiagnostic (int nlev);
+    explicit Diagnostic (int nlev);
 
     /** \brief allocate arrays of this MF
      *
@@ -66,4 +67,4 @@ private:
     amrex::Vector<amrex::Geometry> m_geom_io; /**< Diagnostics geometry */
 };
 
-#endif // FIELDDIAGNOSTIC_H_
+#endif // DIAGNOSTIC_H_

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -1,9 +1,8 @@
-#include "FieldDiagnostic.H"
-#include "fields/Fields.H"
+#include "Diagnostic.H"
 #include "Hipace.H"
 #include <AMReX_ParmParse.H>
 
-FieldDiagnostic::FieldDiagnostic (int nlev)
+Diagnostic::Diagnostic (int nlev)
     : m_F(nlev),
       m_geom_io(nlev)
 {
@@ -50,7 +49,7 @@ FieldDiagnostic::FieldDiagnostic (int nlev)
 }
 
 void
-FieldDiagnostic::AllocData (int lev, const amrex::Box& bx, int nfields, amrex::Geometry const& geom)
+Diagnostic::AllocData (int lev, const amrex::Box& bx, int nfields, amrex::Geometry const& geom)
 {
     m_nfields = nfields;
 
@@ -72,14 +71,14 @@ FieldDiagnostic::AllocData (int lev, const amrex::Box& bx, int nfields, amrex::G
 }
 
 void
-FieldDiagnostic::ResizeFDiagFAB (const amrex::Box box, const int lev)
+Diagnostic::ResizeFDiagFAB (const amrex::Box box, const int lev)
 {
     amrex::Box io_box = TrimIOBox(box);
     m_F[lev].resize(io_box, m_nfields);
  }
 
 amrex::Box
-FieldDiagnostic::TrimIOBox (const amrex::Box box_3d)
+Diagnostic::TrimIOBox (const amrex::Box box_3d)
 {
     // Create a xz slice Box
     amrex::Box slice_bx = box_3d;

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -2,7 +2,7 @@
 #define FIELDS_H_
 
 #include "fft_poisson_solver/FFTPoissonSolver.H"
-#include "diagnostics/FieldDiagnostic.H"
+#include "diagnostics/Diagnostic.H"
 
 #include <AMReX_MultiFab.H>
 #include <AMReX_Vector.H>
@@ -85,8 +85,6 @@ public:
         amrex::Geometry const& geom, const amrex::BoxArray& slice_ba,
         const amrex::DistributionMapping& slice_dm);
 
-    void ResizeFDiagFAB (const amrex::Box box, const int lev) { m_diags.ResizeFDiagFAB(box, lev); };
-
     /** Class to handle transverse FFT Poisson solver on 1 slice */
     std::unique_ptr<FFTPoissonSolver> m_poisson_solver;
     /** get function for the main 3D array F */
@@ -105,20 +103,7 @@ public:
      * \param[in] islice slice index
      */
     amrex::MultiFab& getSlices (int lev, int islice) {return m_slices[lev][islice]; }
-    /** \brief get diagnostics Component names of Fields to output */
-    amrex::Vector<std::string>& getDiagComps () { return m_diags.getComps(); };
-    /** \brief get diagnostics multifab */
-    amrex::Vector<amrex::FArrayBox>& getDiagF () { return m_diags.getF(); };
-    /** \brief get diagnostics geometry */
-    amrex::Vector<amrex::Geometry>& getDiagGeom () { return m_diags.getGeom(); };
-    /** \brief get slicing direction of the diagnostics */
-    int getDiagSliceDir () { return m_diags.sliceDir(); };
-    /** \brief Copy the data from xy slices to the field diagnostics.
-     *
-     * \param[in] lev MR leve
-     * \param[in] i_slice z slice in which to write the data
-     */
-    void FillDiagnostics(int lev, int i_slice);
+
     /** \brief Copy between the full FArrayBox and slice MultiFab.
      *
      * \param[in] lev MR level
@@ -261,8 +246,6 @@ private:
     amrex::IntVect m_slices_nguards {-1, -1, -1};
     /** Whether to use Dirichlet BC for the Poisson solver. Otherwise, periodic */
     bool m_do_dirichlet_poisson = true;
-    /** Diagnostics */
-    FieldDiagnostic m_diags;
 };
 
 #endif

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -7,8 +7,7 @@
 
 Fields::Fields (Hipace const* a_hipace)
     : m_F(a_hipace->maxLevel()+1),
-      m_slices(a_hipace->maxLevel()+1),
-      m_diags(a_hipace->maxLevel()+1)
+      m_slices(a_hipace->maxLevel()+1)
 {
     amrex::ParmParse ppf("fields");
     ppf.query("do_dirichlet_poisson", m_do_dirichlet_poisson);
@@ -29,8 +28,6 @@ Fields::AllocData (
 
     // The Arena uses pinned memory.
     m_F[lev].define(ba, dm, Comps[WhichSlice::This]["N"], nguards_F, amrex::MFInfo().SetAlloc(false));
-    // Note: we pass ba[0] as a dummy box, it will be resized properly in the loop over boxes in Evolve
-    m_diags.AllocData(lev, ba[0], Comps[WhichSlice::This]["N"], geom);
 
     for (int islice=0; islice<WhichSlice::N; islice++) {
         m_slices[lev][islice].define(
@@ -185,13 +182,6 @@ Fields::Copy (int lev, int i_slice, FieldCopyType copy_type, int slice_comp, int
             });
         }
     }
-}
-
-void
-Fields::FillDiagnostics (int lev, int i_slice)
-{
-    Copy(lev, i_slice, FieldCopyType::StoF, 0, 0, Comps[WhichSlice::This]["N"],
-         m_diags.getF(lev), m_diags.sliceDir());
 }
 
 void


### PR DESCRIPTION
In preparation to make the diagnostics more general, the `FieldDiagnostic` class is moved from `Fields` to `Hipace` and renamed to `Diagnostic`.

This does not change anything for the user.

Further PRs will include more flexibility on the beam IO and moving functions and input parameters (`FillDiagnostic`, `output_period`) to this class.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
