### PR TITLE
initialize m_adaptive_density

### DIFF
--- a/src/particles/MultiPlasma.H
+++ b/src/particles/MultiPlasma.H
@@ -99,7 +99,7 @@ private:
     amrex::Vector<std::string> m_names; /**< names of all plasma containers */
     int m_nplasmas; /**< number of plasma containers */
     /** Background (hypothetical) density, used to compute the adaptive time step */
-    amrex::Real m_adaptive_density;
+    amrex::Real m_adaptive_density = 0.;
 };
 
 #endif // MULTIPLASMA_H_

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -150,7 +150,7 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
         {
             const amrex::Real omega_p = std::sqrt(plasma_density * phys_const.q_e*phys_const.q_e
                                           / ( phys_const.ep0*phys_const.m_e ));
-            new_dt = sqrt(2.*chosen_min_uz)/omega_p * m_nt_per_omega_betatron;
+            new_dt = std::sqrt(2.*chosen_min_uz)/omega_p * m_nt_per_omega_betatron;
         }
 
         /* set the new time step */


### PR DESCRIPTION
`m_adaptive_density` is called, but never initialized, if not defined in the input script. This caused random behaviour sometimes. 
In this PR, the `m_adaptive_density` is initialized to 0, preventing this bug to appear.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
