### PR TITLE
check that the density is >0

### DIFF
--- a/src/particles/MultiPlasma.cpp
+++ b/src/particles/MultiPlasma.cpp
@@ -43,10 +43,11 @@ MultiPlasma::InitData (int lev, amrex::BoxArray slice_ba,
 amrex::Real
 MultiPlasma::maxDensity ()
 {
-    amrex::Real max_density = 0;
+    amrex::Real max_density = 0.;
     for (auto& plasma : m_all_plasmas) {
         max_density = amrex::max(max_density, plasma.m_density);
     }
+    AMREX_ALWAYS_ASSERT(max_density>0.);
     return amrex::max(max_density, m_adaptive_density);
 }
 


### PR DESCRIPTION
When calculating time step etc. we take the max density. This PR just makes sure that the max density is >0. @SeverinDiederichs do you know what would happen in the max density is 0? This PR proposes to abort in this case.