### PR TITLE
switch assert to >0 density in adaptive time step

### DIFF
--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -57,7 +57,7 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
 
     if (m_do_adaptive_time_step == 0) return;
     if (!Hipace::HeadRank() && initial) return;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( plasma_density != 0.,
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( plasma_density > 0.,
         "A >0 plasma density must be specified to use an adaptive time step.");
 
     // Extract properties associated with physical size of the box


### PR DESCRIPTION
After a quick discussion under #517, this is a safer assert of the density in the adaptive time step.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
