### PR TITLE
add missing AMREX_GPU_HOST_DEVICE

### DIFF
--- a/src/particles/profiles/GetInitialMomentum.H
+++ b/src/particles/profiles/GetInitialMomentum.H
@@ -24,6 +24,7 @@ struct GetInitialMomentum
      * \param[in] z position in z
      * \param[in] duz_per_uz0_dzeta correlated energy spread
      */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (amrex::Real& ux, amrex::Real& uy, amrex::Real& uz, const amrex::Real z=0.,
                      const amrex::Real duz_per_uz0_dzeta=0.) const
     {


### PR DESCRIPTION
There was a `AMREX_GPU_HOST_DEVICE` missing in `GetInitialMomentum()`.
Using CUDA 11.3, this threw a compilation error. This PR fixes this problem.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
