### PR TITLE
Update RNG

### DIFF
--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -164,8 +164,8 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
 
         PhysConst phys_const = get_phys_const();
 
-        amrex::ParallelFor(domain_box,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        amrex::ParallelForRNG(domain_box,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, const amrex::RandomEngine& engine) noexcept
         {
             int ix = i - lo.x;
             int iy = j - lo.y;
@@ -197,7 +197,7 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                 if (density < a_min_density) continue;
 
                 amrex::Real u[3] = {0.,0.,0.};
-                get_momentum(u[0],u[1],u[2]);
+                get_momentum(u[0],u[1],u[2], engine);
 
                 const amrex::Real weight = density * scale_fac;
                 AddOneBeamParticle(pstruct, arrdata, x, y, z, u[0], u[1], u[2], weight,
@@ -243,15 +243,15 @@ InitBeamFixedWeight (int num_to_add,
         ParticleType::NextID(pid + num_to_add);
 
         const amrex::Real duz_per_uz0_dzeta = m_duz_per_uz0_dzeta;
-        amrex::ParallelFor(
+        amrex::ParallelForRNG(
             num_to_add,
-            [=] AMREX_GPU_DEVICE (int i) noexcept
+            [=] AMREX_GPU_DEVICE (int i, const amrex::RandomEngine& engine) noexcept
             {
-                const amrex::Real x = amrex::RandomNormal(0, pos_std[0]);
-                const amrex::Real y = amrex::RandomNormal(0, pos_std[1]);
-                const amrex::Real z = amrex::RandomNormal(0, pos_std[2]);
+                const amrex::Real x = amrex::RandomNormal(0, pos_std[0], engine);
+                const amrex::Real y = amrex::RandomNormal(0, pos_std[1], engine);
+                const amrex::Real z = amrex::RandomNormal(0, pos_std[2], engine);
                 amrex::Real u[3] = {0.,0.,0.};
-                get_momentum(u[0],u[1],u[2], z, duz_per_uz0_dzeta);
+                get_momentum(u[0],u[1],u[2], engine, z, duz_per_uz0_dzeta);
 
                 const amrex::Real cental_x_pos = pos_mean[0] + z*dx_per_dzeta;
                 const amrex::Real cental_y_pos = pos_mean[1] + z*dy_per_dzeta;

--- a/src/particles/ParticleUtil.H
+++ b/src/particles/ParticleUtil.H
@@ -5,6 +5,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_RealVect.H>
+#include <AMReX_Random.H>
 
 /** \brief Basic helper functions that can be used for both plasma and beam species */
 namespace ParticleUtil
@@ -39,13 +40,16 @@ namespace ParticleUtil
      * \param[in,out] u 3D momentum of 1 particle, modified by this function
      * \param[in] u_mean Mean value of the random distribution in each dimension
      * \param[in] u_std standard deviation of the random distribution in each dimension
+     * \param[in] engine random number engine
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void get_gaussian_random_momentum (amrex::Real* u, const amrex::RealVect u_mean, const amrex::RealVect u_std)
+    void get_gaussian_random_momentum (amrex::Real* u, const amrex::RealVect u_mean,
+                                       const amrex::RealVect u_std,
+                                       const amrex::RandomEngine& engine)
     {
-        amrex::Real ux_th = amrex::RandomNormal(0.0, u_std[0]);
-        amrex::Real uy_th = amrex::RandomNormal(0.0, u_std[1]);
-        amrex::Real uz_th = amrex::RandomNormal(0.0, u_std[2]);
+        amrex::Real ux_th = amrex::RandomNormal(0.0, u_std[0], engine);
+        amrex::Real uy_th = amrex::RandomNormal(0.0, u_std[1], engine);
+        amrex::Real uz_th = amrex::RandomNormal(0.0, u_std[2], engine);
 
         u[0] = u_mean[0] + ux_th;
         u[1] = u_mean[1] + uy_th;

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -194,8 +194,8 @@ IonizationModule (const int lev,
 
         long num_ions = ptile_ion.numParticles();
 
-        amrex::ParallelFor(num_ions,
-            [=] AMREX_GPU_DEVICE (long ip) {
+        amrex::ParallelForRNG(num_ions,
+            [=] AMREX_GPU_DEVICE (long ip, const amrex::RandomEngine& engine) {
 
             amrex::ParticleReal xp, yp, zp;
             int pid;
@@ -229,7 +229,7 @@ IonizationModule (const int lev,
                 std::exp( adk_exp_prefactor[ion_lev_loc]/Ep );
             amrex::Real p = 1._rt - std::exp( - w_dtau );
 
-            amrex::Real random_draw = amrex::Random();
+            amrex::Real random_draw = amrex::Random(engine);
             if (random_draw < p)
             {
                 ion_lev[ip] += 1;

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -102,8 +102,8 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
 
         const int init_ion_lev = m_init_ion_lev;
 
-        amrex::ParallelFor(tile_box,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        amrex::ParallelForRNG(tile_box,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, const amrex::RandomEngine& engine) noexcept
         {
             int ix = i - lo.x;
             int iy = j - lo.y;
@@ -137,7 +137,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 const amrex::Real rp = std::sqrt(x*x + y*y);
 
                 amrex::Real u[3] = {0.,0.,0.};
-                ParticleUtil::get_gaussian_random_momentum(u, a_u_mean, a_u_std);
+                ParticleUtil::get_gaussian_random_momentum(u, a_u_mean, a_u_std, engine);
 
                 ParticleType& p = pstruct[pidx];
                 p.id()   = pid + pidx;

--- a/src/particles/profiles/GetInitialMomentum.H
+++ b/src/particles/profiles/GetInitialMomentum.H
@@ -21,15 +21,18 @@ struct GetInitialMomentum
      * \param[in,out] ux momentum in x, modified by this function
      * \param[in,out] uy momentum in y, modified by this function
      * \param[in,out] uz momentum in z, modified by this function
+     * \param[in] engine random number engine
      * \param[in] z position in z
      * \param[in] duz_per_uz0_dzeta correlated energy spread
      */
-    void operator() (amrex::Real& ux, amrex::Real& uy, amrex::Real& uz, const amrex::Real z=0.,
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator() (amrex::Real& ux, amrex::Real& uy, amrex::Real& uz,
+                     const amrex::RandomEngine& engine, const amrex::Real z=0.,
                      const amrex::Real duz_per_uz0_dzeta=0.) const
     {
         amrex::Real u[3] = {ux,uy,uz};
         if (m_momentum_profile == BeamMomentumType::Gaussian){
-            ParticleUtil::get_gaussian_random_momentum(u, m_u_mean, m_u_std);
+            ParticleUtil::get_gaussian_random_momentum(u, m_u_mean, m_u_std, engine);
         }
         ux = u[0];
         uy = u[1];


### PR DESCRIPTION
AMReX has removed the CUDA only random number generator functions.  This
update fixes the compilation error with the latest AMReX, and prepares
Hipace for HIP and DPC++.  Note that this commit might change the results.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
