### PR TITLE
When odd number of cells, no need to average to get slice io

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1197,7 +1197,7 @@ void
 Hipace::FillDiagnostics (int lev, int i_slice)
 {
     m_fields.Copy(lev, i_slice, FieldCopyType::StoF, 0, 0, Comps[WhichSlice::This]["N"],
-         m_diags.getF(lev), m_diags.sliceDir());
+                  m_diags.getF(lev), m_diags.sliceDir(), Geom(lev));
 }
 
 void

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -114,9 +114,10 @@ public:
      * \param[in] ncomp number of components to copy
      * \param[in,out] fab full FArrayBox
      * \param[in] slice_dir slicing direction. 0=x, 1=y, -1=no slicing (full 3D)
+     * \param[in] geom main geometry
      */
     void Copy (int lev, int i_slice, FieldCopyType copy_type, int slice_comp, int full_comp,
-               int ncomp, amrex::FArrayBox& fab, int slice_dir);
+               int ncomp, amrex::FArrayBox& fab, int slice_dir, amrex::Geometry geom);
 
     /** \brief Shift slices by 1 element: slices (1,2) are then stored in (2,3).
      *


### PR DESCRIPTION
With e.g. 127 cells transversally, I think one cell is at the exact center of the domain. This PR proposes not to average then.