### PR TITLE
first preparation to enable multiple levels

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -9,6 +9,16 @@ General parameters
 * ``amr.n_cell`` (3 `integer`)
     Number of cells in x, y and z.
 
+* ``amr.max_level`` (`integer`)
+    Maximum level of mesh-refinement. Mesh-refinement is not yet implemented, therefore only
+    level `0` is supported.
+
+* ``hipace.fine_tag_lo`` (3 `float`)
+    Lower end of the refined grid in x, y and z.
+
+* ``hipace.fine_tag_hi`` (3 `float`)
+    Upper end of the refined grid in x, y and z.
+
 * ``max_step`` (`integer`) optional (default `0`)
     Maximum number of time steps. `0` means that the 0th time step will be calculated, which are the
     fields of the initial beams.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -13,11 +13,14 @@ General parameters
     Maximum level of mesh refinement. Mesh refinement is not yet implemented, therefore only
     level `0` is supported.
 
-* ``hipace.fine_tag_lo`` (3 `float`)
+* ``hipace.patch_lo`` (3 `float`)
     Lower end of the refined grid in x, y and z.
 
-* ``hipace.fine_tag_hi`` (3 `float`)
+* ``hipace.patch_hi`` (3 `float`)
     Upper end of the refined grid in x, y and z.
+
+* ``amr.ref_ratio_vect`` (3 `int`)
+    Refinement ratio. Last one must be 1.
 
 * ``max_step`` (`integer`) optional (default `0`)
     Maximum number of time steps. `0` means that the 0th time step will be calculated, which are the

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -10,7 +10,7 @@ General parameters
     Number of cells in x, y and z.
 
 * ``amr.max_level`` (`integer`)
-    Maximum level of mesh-refinement. Mesh-refinement is not yet implemented, therefore only
+    Maximum level of mesh refinement. Mesh refinement is not yet implemented, therefore only
     level `0` is supported.
 
 * ``hipace.fine_tag_lo`` (3 `float`)

--- a/examples/beam_in_vacuum/inputs_normalized_transverse
+++ b/examples/beam_in_vacuum/inputs_normalized_transverse
@@ -5,7 +5,7 @@ hipace.verbose = 1
 hipace.output_period = 1
 random_seed = 4
 amr.blocking_factor = 2
-amr.max_level = 1
+amr.max_level = 0
 
 max_step = 9
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -290,8 +290,8 @@ public:
      */
     void CheckGhostSlice (int it);
 
-    amrex::RealVect fine_tag_lo {0., 0., 0.}; /**< 3D array with lower ends of the refined grid */
-    amrex::RealVect fine_tag_hi {0., 0., 0.}; /**< 3D array with upper ends of the refined grid */
+    amrex::RealVect patch_lo {0., 0., 0.}; /**< 3D array with lower ends of the refined grid */
+    amrex::RealVect patch_hi {0., 0., 0.}; /**< 3D array with upper ends of the refined grid */
 private:
     /** Pointer to current (and only) instance of class Hipace */
     static Hipace* m_instance;

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -44,9 +44,9 @@ public:
         const amrex::DistributionMapping& dm) override;
 
     /** Tag cells for refinement */
-    void ErrorEst (
+    virtual void ErrorEst (
                    int /*lev*/, amrex::TagBoxArray& /*tags*/,
-                   amrex::Real /*time*/, int /*ngrow*/) override {}
+                   amrex::Real /*time*/, int /*ngrow*/) final;
 
     /** Make a new level using provided BoxArray and DistributionMapping and
      * fill with interpolated coarse level data */
@@ -290,6 +290,8 @@ public:
      */
     void CheckGhostSlice (int it);
 
+    amrex::RealVect fine_tag_lo {0., 0., 0.}; /**< 3D array with lower ends of the refined grid */
+    amrex::RealVect fine_tag_hi {0., 0., 0.}; /**< 3D array with upper ends of the refined grid */
 private:
     /** Pointer to current (and only) instance of class Hipace */
     static Hipace* m_instance;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -119,6 +119,15 @@ Hipace::Hipace () :
     pph.query("MG_tolerance_rel", m_MG_tolerance_rel);
     pph.query("MG_tolerance_abs", m_MG_tolerance_abs);
 
+    if (maxLevel() > 0) {
+        AMREX_ALWAYS_ASSERT(maxLevel() < 2);
+        amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
+        pph.get("fine_tag_lo", loc_array);
+        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) fine_tag_lo[idim] = loc_array[idim];
+        pph.get("fine_tag_hi", loc_array);
+        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) fine_tag_hi[idim] = loc_array[idim];
+    }
+
 #ifdef AMREX_USE_MPI
     pph.query("skip_empty_comms", m_skip_empty_comms);
     int myproc = amrex::ParallelDescriptor::MyProc();
@@ -272,6 +281,30 @@ Hipace::MakeNewLevelFromScratch (
     // Note: we pass ba[0] as a dummy box, it will be resized properly in the loop over boxes in Evolve
     m_diags.AllocData(lev, ba[0], Comps[WhichSlice::This]["N"], Geom(lev));
     m_fields.AllocData(lev, ba, dm, Geom(lev), m_slice_ba, m_slice_dm);
+}
+
+void
+Hipace::ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real /*time*/, int /*ngrow*/)
+{
+    using namespace amrex::literals;
+    const amrex::Real* problo = Geom(lev).ProbLo();
+    const amrex::Real* dx = Geom(lev).CellSize();
+
+    for (amrex::MFIter mfi(tags); mfi.isValid(); ++mfi)
+    {
+        auto& fab = tags[mfi];
+        const amrex::Box& bx = fab.box();
+        for (amrex::BoxIterator bi(bx); bi.ok(); ++bi)
+        {
+            const amrex::IntVect& cell = bi();
+            amrex::RealVect pos {AMREX_D_DECL((cell[0]+0.5_rt)*dx[0]+problo[0],
+                                       (cell[1]+0.5_rt)*dx[1]+problo[1],
+                                       (cell[2]+0.5_rt)*dx[2]+problo[2])};
+            if (pos > fine_tag_lo && pos < fine_tag_hi) {
+                fab(cell) = amrex::TagBox::SET;
+            }
+        }
+    }
 }
 
 void

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -122,10 +122,10 @@ Hipace::Hipace () :
     if (maxLevel() > 0) {
         AMREX_ALWAYS_ASSERT(maxLevel() < 2);
         amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
-        pph.get("fine_tag_lo", loc_array);
-        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) fine_tag_lo[idim] = loc_array[idim];
-        pph.get("fine_tag_hi", loc_array);
-        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) fine_tag_hi[idim] = loc_array[idim];
+        pph.get("patch_lo", loc_array);
+        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) patch_lo[idim] = loc_array[idim];
+        pph.get("patch_hi", loc_array);
+        for (int idim=0; idim<AMREX_SPACEDIM; ++idim) patch_hi[idim] = loc_array[idim];
     }
 
 #ifdef AMREX_USE_MPI
@@ -300,7 +300,7 @@ Hipace::ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real /*time*/, int /
             amrex::RealVect pos {AMREX_D_DECL((cell[0]+0.5_rt)*dx[0]+problo[0],
                                        (cell[1]+0.5_rt)*dx[1]+problo[1],
                                        (cell[2]+0.5_rt)*dx[2]+problo[2])};
-            if (pos > fine_tag_lo && pos < fine_tag_hi) {
+            if (pos > patch_lo && pos < patch_hi) {
                 fab(cell) = amrex::TagBox::SET;
             }
         }


### PR DESCRIPTION
This PR is a preparation for the upcoming implementation of mesh refinement.

It adds the `ErrorEst` function to tag the cells where the refinement is supported.
The lower and upper boundaries of the refined level can be read in via `hipace.fine_tag_lo` and `hipace.fine_tag_hi`.

The assert for `lev = 0` is still in place and will be triggered if a simulation with `max_level > 0` is started.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
