### PR TITLE
remove unused parameters

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -280,7 +280,7 @@ Hipace::MakeNewLevelFromScratch (
     DefineSliceGDB(ba, dm);
     // Note: we pass ba[0] as a dummy box, it will be resized properly in the loop over boxes in Evolve
     m_diags.AllocData(lev, ba[0], Comps[WhichSlice::This]["N"], Geom(lev));
-    m_fields.AllocData(lev, ba, dm, Geom(lev), m_slice_ba, m_slice_dm);
+    m_fields.AllocData(lev, Geom(lev), m_slice_ba, m_slice_dm);
 }
 
 void

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -74,15 +74,12 @@ public:
     /** Allocate MultiFabs for the 3D array and the 2D slices
      * and define the BoxArrays and DistributionMappings.
      * \param[in] lev MR level
-     * \param[in] ba BoxArray for the simulation
-     * \param[in] dm DistributionMapping for the whole simulation
      * \param[in] geom Geometry
      * \param[in] slice_ba BoxArray for the slice
      * \param[in] slice_dm DistributionMapping for the slice
      */
     void AllocData (
-        int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
-        amrex::Geometry const& geom, const amrex::BoxArray& slice_ba,
+        int lev, amrex::Geometry const& geom, const amrex::BoxArray& slice_ba,
         const amrex::DistributionMapping& slice_dm);
 
     /** Class to handle transverse FFT Poisson solver on 1 slice */

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -14,8 +14,8 @@ Fields::Fields (Hipace const* a_hipace)
 
 void
 Fields::AllocData (
-    int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
-    amrex::Geometry const& geom, const amrex::BoxArray& slice_ba, const amrex::DistributionMapping& slice_dm)
+    int lev, amrex::Geometry const& geom, const amrex::BoxArray& slice_ba,
+    const amrex::DistributionMapping& slice_dm)
 {
     HIPACE_PROFILE("Fields::AllocData()");
     // Need at least 1 guard cell transversally for transverse derivative


### PR DESCRIPTION
This PR removes some compiler warnings of unused parameters, which arose from #524. 

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
