### PR TITLE
Mesh refinement: Adding IO

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -290,6 +290,7 @@ public:
      */
     void CheckGhostSlice (int it);
 
+    static int m_nlev; /**< number of MR levels */
     amrex::RealVect patch_lo {0., 0., 0.}; /**< 3D array with lower ends of the refined grid */
     amrex::RealVect patch_hi {0., 0., 0.}; /**< 3D array with upper ends of the refined grid */
 private:
@@ -313,7 +314,7 @@ private:
     Diagnostic m_diags;
 
     void ResizeFDiagFAB (const amrex::Box box, const int lev) { m_diags.ResizeFDiagFAB(box, lev); };
-    void FillDiagnostics (int lev, int i_slice);
+    void FillDiagnostics (int i_slice);
     /** \brief get diagnostics Component names of Fields to output */
     amrex::Vector<std::string>& getDiagComps () { return m_diags.getComps(); };
     /** \brief get diagnostics Component names of Fields to output */

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -290,7 +290,6 @@ public:
      */
     void CheckGhostSlice (int it);
 
-    static int m_nlev; /**< number of MR levels */
     amrex::RealVect patch_lo {0., 0., 0.}; /**< 3D array with lower ends of the refined grid */
     amrex::RealVect patch_hi {0., 0., 0.}; /**< 3D array with upper ends of the refined grid */
 private:

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -391,7 +391,8 @@ Hipace::Evolve ()
 
             const amrex::Box& bx = boxArray(lev)[it];
 
-            // FIXME: dirty workaround to not touch the box in general but only for IO.
+            // FIXME: dirty workaround to not touch the box in general
+            // but resize the boxes on all levels for IO.
             for (int lev_loc = 0; lev_loc < m_nlev; ++lev_loc) {
                 const amrex::Box& bx_loc = boxArray(lev_loc)[it];
                 ResizeFDiagFAB(bx_loc, lev_loc);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -246,7 +246,7 @@ void
 Hipace::MakeNewLevelFromScratch (
     int lev, amrex::Real /*time*/, const amrex::BoxArray& ba, const amrex::DistributionMapping&)
 {
-    AMREX_ALWAYS_ASSERT(lev == 0);
+    // AMREX_ALWAYS_ASSERT(lev == 0);
 
     // We are going to ignore the DistributionMapping argument and build our own.
     amrex::DistributionMapping dm;
@@ -256,6 +256,16 @@ Hipace::MakeNewLevelFromScratch (
         const int nboxes_x = m_numprocs_x;
         const int nboxes_y = m_numprocs_y;
         const int nboxes_z = (m_boxes_in_z == 1) ? ncells_global[2] / box_size[2] : m_boxes_in_z;
+
+        amrex::Print() << " level " << lev << "\n";
+                amrex::Print() << " box array " << ba << "\n";
+                        amrex::Print() <<  " dm " << dm << "\n";
+        amrex::Print() << "ncells_global[0] " <<  ncells_global[0] << " ncells_global[1] " <<  ncells_global[1] << " ncells_global[2] " <<  ncells_global[2] << "\n";
+        amrex::Print() << " box_size[0] " << box_size[0] << " box_size[1] " << box_size[1] << " box_size[2] " << box_size[2] << "\n";
+        amrex::Print() << " nboxes_x " << nboxes_x << " nboxes_y " << nboxes_y << " nboxes_z " << nboxes_z << " ba.size() " << ba.size() << "\n";
+
+
+
         AMREX_ALWAYS_ASSERT(static_cast<long>(nboxes_x) *
                             static_cast<long>(nboxes_y) *
                             static_cast<long>(nboxes_z) == ba.size());

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -440,7 +440,7 @@ Hipace::Evolve ()
     }
 
 #ifdef HIPACE_USE_OPENPMD
-    if (m_output_period > 0) m_openpmd_writer.reset(m_nlev);
+    if (m_output_period > 0) m_openpmd_writer.reset();
 #endif
 }
 

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -67,12 +67,13 @@ private:
      * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
      * \param[in] geom Geometry of the simulation, to get the cell size etc.
      * \param[in] beamnames list of the names of the beam to be written to file
+     * \param[in] lev MR level
      */
     void WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration iteration,
                                 const int output_step, const int it,
                                 const amrex::Vector<BoxSorter>& a_box_sorter_vec,
                                 const amrex::Geometry& geom,
-                                const amrex::Vector< std::string > beamnames);
+                                const amrex::Vector< std::string > beamnames, const int lev);
 
     /** \brief writing openPMD field data
      *
@@ -82,24 +83,25 @@ private:
      * \param[in] varnames list of variable names for the fields (ExmBy, EypBx, Ey, ...)
      * \param[in,out] iteration openPMD iteration to which the data is written
      * \param[in] output_step current time step to dump
+     * \param[in] lev MR level
      */
-    void WriteFieldData (amrex::FArrayBox const& fab, amrex::Geometry const& geom,
+    void WriteFieldData (amrex::FArrayBox & fab, amrex::Geometry const& geom,
                          const int slice_dir, const amrex::Vector< std::string > varnames,
-                         openPMD::Iteration iteration, const int output_step);
+                         openPMD::Iteration iteration, const int output_step, const int lev);
 
     /** Named Beam SoA attributes per particle as defined in BeamIdx
      */
     amrex::Vector<std::string> m_real_names {"weighting", "momentum_x", "momentum_y", "momentum_z"};
 
-    /** Parallel openPMD-api Series object for output */
-    std::unique_ptr< openPMD::Series > m_outputSeries;
+    /** vector over levels of openPMD-api Series object for output */
+    amrex::Vector<std::unique_ptr< openPMD::Series >> m_outputSeries;
 
     /** openPMD backend: h5, bp, or json. Default depends on what is available */
     std::string m_openpmd_backend = "default";
 
     /** Last iteration that was written to file.
      * This is stored to make sure we don't write the last iteration multiple times. */
-    int m_last_output_dumped = -1;
+    amrex::Vector<int> m_last_output_dumped;
 
     /** vector of length nbeams with the numbers of particles already written to file */
     amrex::Vector<uint64_t> m_offset;
@@ -114,8 +116,10 @@ public:
      * \param[in] output_step current iteration
      * \param[in] output_period output period
      * \param[in] max_step maximum time step of the simulation
+     * \param[in] nlev number of mesh refinement levels
      */
-    void InitDiagnostics (const int output_step, const int output_period, const int max_step);
+    void InitDiagnostics (const int output_step, const int output_period, const int max_step,
+                          const int nlev);
 
     /** \brief writing openPMD data
      *
@@ -124,7 +128,7 @@ public:
      * \param[in] geom Geometry of the simulation, to get the cell size etc.
      * \param[in] physical_time Physical time of the currenerationt it.
      * \param[in] output_step current iteration to be written to file
-     * \param[in] lev MR level
+     * \param[in] nlev number of MR levels
      * \param[in] slice_dir direction of slicing. 0=x, 1=y, -1=no slicing (3D array)
      * \param[in] varnames list of variable names for the fields (ExmBy, EypBx, Ey, ...)
      * \param[in] beamnames list of the names of the beam to be written to file
@@ -134,15 +138,19 @@ public:
      * \param[in] call_type whether the beams or the fields should be written to file
      */
     void WriteDiagnostics(
-        amrex::Vector<amrex::FArrayBox> const& a_mf, MultiBeam& a_multi_beam,
+        amrex::Vector<amrex::FArrayBox> & a_mf, MultiBeam& a_multi_beam,
         amrex::Vector<amrex::Geometry> const& geom,
-        const amrex::Real physical_time, const int output_step, const int lev,
+        const amrex::Real physical_time, const int output_step, const int nlev,
         const int slice_dir, const amrex::Vector< std::string > varnames,
         const amrex::Vector< std::string > beamnames, const int it,
-        const amrex::Vector<BoxSorter>& a_box_sorter_vec, const amrex::Geometry& geom3D,
+        const amrex::Vector<BoxSorter>& a_box_sorter_vec, amrex::Vector<amrex::Geometry> const& geom3D,
         const OpenPMDWriterCallType call_type);
 
-    void reset () {m_outputSeries.reset();};
+    /** \brief Resets the openPMD series of all levels
+     *
+     * \param[in] nlev number of mesh refinement levels
+     */
+    void reset (const int nlev);
 
     /** Prefix/path for the output files */
     std::string m_file_prefix = "diags/hdf5";

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -146,11 +146,8 @@ public:
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, amrex::Vector<amrex::Geometry> const& geom3D,
         const OpenPMDWriterCallType call_type);
 
-    /** \brief Resets the openPMD series of all levels
-     *
-     * \param[in] nlev number of mesh refinement levels
-     */
-    void reset (const int nlev);
+    /** \brief Resets the openPMD series of all levels */
+    void reset ();
 
     /** Prefix/path for the output files */
     std::string m_file_prefix = "diags/hdf5";

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -85,7 +85,7 @@ private:
      * \param[in] output_step current time step to dump
      * \param[in] lev MR level
      */
-    void WriteFieldData (amrex::FArrayBox & fab, amrex::Geometry const& geom,
+    void WriteFieldData (amrex::FArrayBox const& fab, amrex::Geometry const& geom,
                          const int slice_dir, const amrex::Vector< std::string > varnames,
                          openPMD::Iteration iteration, const int output_step, const int lev);
 
@@ -138,7 +138,7 @@ public:
      * \param[in] call_type whether the beams or the fields should be written to file
      */
     void WriteDiagnostics(
-        amrex::Vector<amrex::FArrayBox> & a_mf, MultiBeam& a_multi_beam,
+        amrex::Vector<amrex::FArrayBox> const& a_mf, MultiBeam& a_multi_beam,
         amrex::Vector<amrex::Geometry> const& geom,
         const amrex::Real physical_time, const int output_step, const int nlev,
         const int slice_dir, const amrex::Vector< std::string > varnames,

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -66,7 +66,7 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
 
 void
 OpenPMDWriter::WriteDiagnostics (
-    amrex::Vector<amrex::FArrayBox> & a_mf, MultiBeam& a_multi_beam,
+    amrex::Vector<amrex::FArrayBox> const& a_mf, MultiBeam& a_multi_beam,
     amrex::Vector<amrex::Geometry> const& geom,
     const amrex::Real physical_time, const int output_step, const int nlev,
     const int slice_dir, const amrex::Vector< std::string > varnames,
@@ -94,7 +94,7 @@ OpenPMDWriter::WriteDiagnostics (
 
 void
 OpenPMDWriter::WriteFieldData (
-    amrex::FArrayBox & fab, amrex::Geometry const& geom,
+    amrex::FArrayBox const& fab, amrex::Geometry const& geom,
     const int slice_dir, const amrex::Vector< std::string > varnames,
     openPMD::Iteration iteration, const int output_step, const int lev)
 {

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -40,7 +40,7 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
 #endif
     }
 
-    if (nlev > 0) {
+    if (nlev > 1) {
         for (int lev=0; lev<nlev; ++lev) {
             std::string filename = m_file_prefix + "/lev_" + std::to_string(lev) +  "/openpmd_%06T."
                                    + m_openpmd_backend;

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -382,9 +382,11 @@ OpenPMDWriter::SaveRealProperty (BeamParticleContainer& pc,
     }
 }
 
-void OpenPMDWriter::reset (const int nlev)
+void OpenPMDWriter::reset ()
 {
-    for (int lev = 0; lev<nlev; ++lev) m_outputSeries[lev].reset();
+    for (int lev = 0; lev<m_outputSeries.size(); ++lev) {
+        m_outputSeries[lev].reset();
+    }
 }
 
 #endif // HIPACE_USE_OPENPMD

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -43,11 +43,10 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
     if (nlev > 0) {
         for (int lev=0; lev<nlev; ++lev) {
             std::string filename = m_file_prefix + "/lev_" + std::to_string(lev) +  "/openpmd_%06T."
-                                 + m_openpmd_backend;
+                                   + m_openpmd_backend;
 
             m_outputSeries.push_back(std::make_unique< openPMD::Series >(
                 filename, openPMD::Access::CREATE) );
-
             m_last_output_dumped.push_back(-1);
         }
     } else {
@@ -55,7 +54,6 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
 
         m_outputSeries.push_back(std::make_unique< openPMD::Series >(
             filename, openPMD::Access::CREATE) );
-
         m_last_output_dumped.push_back(-1);
     }
 
@@ -388,6 +386,5 @@ void OpenPMDWriter::reset (const int nlev)
 {
     for (int lev = 0; lev<nlev; ++lev) m_outputSeries[lev].reset();
 }
-
 
 #endif // HIPACE_USE_OPENPMD

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -32,6 +32,8 @@ Fields::AllocData (
         m_slices[lev][islice].setVal(0.0);
     }
 
+    // construct PoissonSolver only for maingrid FIXME: add refined grids
+    if (lev>0) return;
     // The Poisson solver operates on transverse slices only.
     // The constructor takes the BoxArray and the DistributionMap of a slice,
     // so the FFTPlans are built on a slice.

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -32,7 +32,7 @@ Fields::AllocData (
         m_slices[lev][islice].setVal(0.0);
     }
 
-    // construct PoissonSolver only for maingrid FIXME: add refined grids
+    // FIXME the Poisson solver must be constructed per level, here it is only constructed for lev 0
     if (lev>0) return;
     // The Poisson solver operates on transverse slices only.
     // The constructor takes the BoxArray and the DistributionMap of a slice,


### PR DESCRIPTION
This PR adds a first working version of IO of the refined level.

In the `OpenPMDWriter` class, the series is now a vector over levels. Each level has its own series and writes to its own sub-folder in the IO path. If only the 0th level is used, no sub-folders will be generated.

Then, the IO is now a loop over levels. Additionally, the copying of the slice to the diagnostics is now a loop over levels.

The resizing of the diagnostic arrays is a loop over levels. To not yet touch the other functions, it is done with local variables.

To avoid complications with the Poisson solver (the staging area needs to exist per level), the Poisson solver is not even allocated for other levels than lev = 0. This is handled in #527.

Additionally, the boxarray for the first level is not set correctly.

In the current version, the code crashes if used with a beam in the binning. No beam can be used with MR at this point.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
