### PR TITLE
Mesh refinement: fix boxarray

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -296,9 +296,9 @@ private:
     /** Pointer to current (and only) instance of class Hipace */
     static Hipace* m_instance;
 
-    amrex::Geometry m_slice_geom;
-    amrex::DistributionMapping m_slice_dm;
-    amrex::BoxArray m_slice_ba;
+    amrex::Vector<amrex::Geometry> m_slice_geom;
+    amrex::Vector<amrex::DistributionMapping> m_slice_dm;
+    amrex::Vector<amrex::BoxArray> m_slice_ba;
 
 #ifdef AMREX_USE_LINEAR_SOLVERS
     /** Linear operator for the explicit Bx and By solver */
@@ -351,10 +351,12 @@ private:
     /** \brief define Geometry, DistributionMapping and BoxArray for the slice.
      * The slice MultiFAB and the plasma particles are defined on this GDB.
      *
+     * \param[in] lev level of mesh refinement
      * \param[in] ba BoxArray of the whole domain
      * \param[in] dm DistributionMappint of the whole domain
      */
-    void DefineSliceGDB (const amrex::BoxArray& ba, const amrex::DistributionMapping& dm);
+    void DefineSliceGDB (const int lev, const amrex::BoxArray& ba,
+                         const amrex::DistributionMapping& dm);
 
     int leftmostBoxWithParticles () const;
 };

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -260,6 +260,8 @@ Hipace::MakeNewLevelFromScratch (
             ba[i].setBig  (1, a_ba[1].bigEnd  (Direction::y));
         }
         SetBoxArray(lev, ba); // Let AmrCore know
+    } else {
+        amrex::Abort("Only lev <= 1 implemented");
     }
 
     // We are going to ignore the DistributionMapping argument and build our own.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -149,7 +149,7 @@ Hipace::~Hipace ()
 }
 
 void
-Hipace::DefineSliceGDB (const amrex::BoxArray& ba, const amrex::DistributionMapping& dm)
+Hipace::DefineSliceGDB (const int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm)
 {
     std::map<int,amrex::Vector<amrex::Box> > boxes;
     for (int i = 0; i < ba.size(); ++i) {
@@ -190,13 +190,12 @@ Hipace::DefineSliceGDB (const amrex::BoxArray& ba, const amrex::DistributionMapp
     }
 
     // Slice BoxArray
-    m_slice_ba = amrex::BoxArray(std::move(bl));
+    m_slice_ba.push_back(amrex::BoxArray(std::move(bl)));
 
     // Slice DistributionMapping
-    m_slice_dm = amrex::DistributionMapping(std::move(procmap));
+    m_slice_dm.push_back(amrex::DistributionMapping(std::move(procmap)));
 
     // Slice Geometry
-    constexpr int lev = 0;
     // Set the lo and hi of domain and probdomain in the z direction
     amrex::RealBox tmp_probdom = Geom(lev).ProbDomain();
     amrex::Box tmp_dom = Geom(lev).Domain();
@@ -207,8 +206,8 @@ Hipace::DefineSliceGDB (const amrex::BoxArray& ba, const amrex::DistributionMapp
     tmp_probdom.setHi(Direction::z, hi);
     tmp_dom.setSmall(Direction::z, 0);
     tmp_dom.setBig(Direction::z, 0);
-    m_slice_geom = amrex::Geometry(
-        tmp_dom, tmp_probdom, Geom(lev).Coord(), Geom(lev).isPeriodic());
+    m_slice_geom.push_back(amrex::Geometry(
+        tmp_dom, tmp_probdom, Geom(lev).Coord(), Geom(lev).isPeriodic()));
 }
 
 bool
@@ -234,7 +233,7 @@ Hipace::InitData ()
     AmrCore::InitFromScratch(0.0); // function argument is time
     constexpr int lev = 0;
     m_multi_beam.InitData(geom[lev]);
-    m_multi_plasma.InitData(lev, m_slice_ba, m_slice_dm, m_slice_geom, geom[lev]);
+    m_multi_plasma.InitData(lev, m_slice_ba[lev], m_slice_dm[lev], m_slice_geom[lev], geom[lev]);
     m_adaptive_time_step.Calculate(m_dt, m_multi_beam, m_multi_plasma.maxDensity());
 #ifdef AMREX_USE_MPI
     m_adaptive_time_step.WaitTimeStep(m_dt, m_comm_z);
@@ -244,8 +243,24 @@ Hipace::InitData ()
 
 void
 Hipace::MakeNewLevelFromScratch (
-    int lev, amrex::Real /*time*/, const amrex::BoxArray& ba, const amrex::DistributionMapping&)
+    int lev, amrex::Real /*time*/, const amrex::BoxArray& a_ba, const amrex::DistributionMapping&)
 {
+    amrex::BoxArray ba;
+    if (lev == 0) {
+        ba = a_ba;
+    } else if (lev == 1) {
+        // for lev == 1, we have to create the box array by hand: it is correct transversely,
+        // but not longitudinally. We use the box array from level 0 longitudinally and use the
+        // transverse dimensions from level 1.
+        ba = boxArray(0);
+        for (int i = 0; i<ba.size(); i++) {
+            ba[i].setSmall(0, a_ba[0].smallEnd(Direction::x));
+            ba[i].setSmall(1, a_ba[1].smallEnd(Direction::y));
+            ba[i].setBig  (0, a_ba[0].bigEnd  (Direction::x));
+            ba[i].setBig  (1, a_ba[1].bigEnd  (Direction::y));
+        }
+        SetBoxArray(lev, ba); // Let AmrCore know
+    }
 
     // We are going to ignore the DistributionMapping argument and build our own.
     amrex::DistributionMapping dm;
@@ -276,10 +291,10 @@ Hipace::MakeNewLevelFromScratch (
         dm.define(std::move(procmap));
     }
     SetDistributionMap(lev, dm); // Let AmrCore know
-    DefineSliceGDB(ba, dm);
+    DefineSliceGDB(lev, ba, dm);
     // Note: we pass ba[0] as a dummy box, it will be resized properly in the loop over boxes in Evolve
     m_diags.AllocData(lev, ba[0], Comps[WhichSlice::This]["N"], Geom(lev));
-    m_fields.AllocData(lev, Geom(), m_slice_ba, m_slice_dm);
+    m_fields.AllocData(lev, Geom(), m_slice_ba[lev], m_slice_dm[lev]);
 }
 
 void


### PR DESCRIPTION
This PR fixes a few things:

the BoxArray on level 1 is now correct. It was already correct transversely, but not longitudinally. Here, we construct it from the correct transverse part and the longitudinal part from level 0. `DefineSliceGDB` is now called per level and adapted correctly.

This PR does not fix that the plasma etc, which use some of the variables touched here are initialized per level. They are still just initialized on level 0, this will be fixed in an upcoming PR.

Majority of this PR was authored by @MaxThevenet.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
