### PR TITLE
Mesh refinement: first working field solve on level 1

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -129,12 +129,10 @@ public:
     /** \brief Full evolve on 1 slice
      *
      * \param[in] islice slice number
-     * \param[in] lev MR level
      * \param[in] ibox index of the current box to be calculated
      * \param[in] bins an amrex::DenseBins object that orders particles by slice
      */
-    void SolveOneSlice (int islice, int lev, const int ibox,
-                        amrex::Vector<BeamBins>& bins);
+    void SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins);
 
     /** \brief Reset plasma and field slice quantities to initial value.
      *
@@ -313,7 +311,7 @@ private:
     Diagnostic m_diags;
 
     void ResizeFDiagFAB (const amrex::Box box, const int lev) { m_diags.ResizeFDiagFAB(box, lev); };
-    void FillDiagnostics (int i_slice);
+    void FillDiagnostics (const int lev, int i_slice);
     /** \brief get diagnostics Component names of Fields to output */
     amrex::Vector<std::string>& getDiagComps () { return m_diags.getComps(); };
     /** \brief get diagnostics Component names of Fields to output */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -289,7 +289,6 @@ Hipace::ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real /*time*/, int /
     const amrex::Real* problo = Geom(lev).ProbLo();
     const amrex::Real* dx = Geom(lev).CellSize();
 
-    // we need to tag all cells, because we will adjust the domain of level 1 by hand anyway
     for (amrex::MFIter mfi(tags); mfi.isValid(); ++mfi)
     {
         auto& fab = tags[mfi];

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -300,9 +300,9 @@ Hipace::ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real /*time*/, int /
             amrex::RealVect pos {AMREX_D_DECL((cell[0]+0.5_rt)*dx[0]+problo[0],
                                         (cell[1]+0.5_rt)*dx[1]+problo[1],
                                         (cell[2]+0.5_rt)*dx[2]+problo[2])};
-             if (pos > patch_lo && pos < patch_hi) {
-                 fab(cell) = amrex::TagBox::SET;
-             }
+            if (pos > patch_lo && pos < patch_hi) {
+                fab(cell) = amrex::TagBox::SET;
+            }
         }
     }
 }

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -86,6 +86,7 @@ public:
     amrex::Real m_mass; /**< mass of each particle of this species */
     bool m_do_z_push {true}; /**< Pushing beam particles in z direction */
     int m_n_subcycles {1}; /**< Number of sub-cycles in the beam pusher */
+    int m_finest_level {0}; /**< finest level of mesh refinement that the beam interacts with */
     /** Number of particles on upstream rank (required for IO) */
     int m_num_particles_on_upstream_ranks {0};
 

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -51,7 +51,7 @@ BeamParticleContainer::ReadParameters ()
     pp.query("dy_per_dzeta", m_dy_per_dzeta);
     pp.query("duz_per_uz0_dzeta", m_duz_per_uz0_dzeta);
     pp.query("do_z_push", m_do_z_push);
-    pp.query("n_subcycles", m_n_subcycles);
+    pp.query("finest_level", m_finest_level);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_n_subcycles >= 1, "n_subcycles must be >= 1");
     if (m_injection_type == "fixed_ppc" || m_injection_type == "from_file"){
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (m_dx_per_dzeta == 0.) && (m_dy_per_dzeta == 0.)

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -51,6 +51,7 @@ BeamParticleContainer::ReadParameters ()
     pp.query("dy_per_dzeta", m_dy_per_dzeta);
     pp.query("duz_per_uz0_dzeta", m_duz_per_uz0_dzeta);
     pp.query("do_z_push", m_do_z_push);
+    pp.query("n_subcycles", m_n_subcycles);
     pp.query("finest_level", m_finest_level);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_n_subcycles >= 1, "n_subcycles must be >= 1");
     if (m_injection_type == "fixed_ppc" || m_injection_type == "from_file"){

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -90,6 +90,7 @@ public:
                            Fields& fields);
 
     amrex::Real m_density {0}; /**< Density of the plasma */
+    int m_MR_level {0}; /**< mesh refinement level on which the plasma lives */
     /** maximum weighting factor gamma/(Psi +1) before particle is regarded as violating
      *  the quasi-static approximation and is removed */
     amrex::Real m_max_qsa_weighting_factor {35.};

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -70,6 +70,7 @@ PlasmaParticleContainer::ReadParameters ()
     }
     pp.query("ionization_product", m_product_name);
     pp.query("density", m_density);
+    pp.query("MR_level", m_MR_level);
     pp.query("radius", m_radius);
     pp.query("hollow_core_radius", m_hollow_core_radius);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_hollow_core_radius < m_radius,

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -18,6 +18,9 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometr
     // Extract properties associated with physical size of the box
     amrex::Real const * AMREX_RESTRICT dx = gm.CellSize();
 
+    // beam deposits only up to its finest level
+    if (beam.m_finest_level < lev) return;
+
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
     which_slice == WhichSlice::This || which_slice == WhichSlice::Next,
     "Current deposition can only be done in this slice (WhichSlice::This), or the next slice "

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -21,6 +21,9 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
     "Current deposition can only be done in this slice (WhichSlice::This), the next slice "
     " (WhichSlice::Next) or for the ion charge deposition (WhichSLice::RhoIons)");
 
+    // only deposit plasma currents on their according MR level
+    if (plasma.m_MR_level != lev) return;
+
     // Extract properties associated with physical size of the box
     amrex::Real const * AMREX_RESTRICT dx = gm.CellSize();
 

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -13,6 +13,9 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
     HIPACE_PROFILE("AdvanceBeamParticlesSlice()");
     using namespace amrex::literals;
 
+    // only finest MR level pushes the beam
+    if (beam.m_finest_level != lev) return;
+
     // Extract properties associated with physical size of the box
     amrex::Real const * AMREX_RESTRICT dx = gm.CellSize();
     const PhysConst phys_const = get_phys_const();

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -18,6 +18,9 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
     HIPACE_PROFILE("UpdateForcePushParticles_PlasmaParticleContainer()");
     using namespace amrex::literals;
 
+    // only push plasma particles on their according MR level
+    if (plasma.m_MR_level != lev) return;
+
     // Extract properties associated with physical size of the box
     amrex::Real const * AMREX_RESTRICT dx = gm.CellSize();
     const PhysConst phys_const = get_phys_const();

--- a/src/utils/GridCurrent.H
+++ b/src/utils/GridCurrent.H
@@ -16,6 +16,7 @@ private:
     /** Width of the Gaussian grid current. */
     amrex::RealVect m_position_std {0., 0., 0.};
     amrex::Real m_peak_current_density {0.}; /**< peak density for the grid current */
+    int m_finest_level {0}; /**< finest level of mesh refinement that the beam interacts with */
 
 public:
     /** Constructor */

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -14,6 +14,7 @@ GridCurrent::GridCurrent ()
         for (int idim=0; idim < AMREX_SPACEDIM; ++idim) m_position_mean[idim] = loc_array[idim];
         pp.get("position_std", loc_array);
         for (int idim=0; idim < AMREX_SPACEDIM; ++idim) m_position_std[idim] = loc_array[idim];
+        pp.query("finest_level", m_finest_level);
     }
 }
 
@@ -25,6 +26,9 @@ GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, i
     using namespace amrex::literals;
 
     if (m_use_grid_current == 0) return;
+    
+    // grid current deposits only up to its finest level
+    if (m_finest_level < lev) return;
 
     const auto plo = geom.ProbLoArray();
     amrex::Real const * AMREX_RESTRICT dx = geom.CellSize();

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -26,7 +26,7 @@ GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, i
     using namespace amrex::literals;
 
     if (m_use_grid_current == 0) return;
-    
+
     // grid current deposits only up to its finest level
     if (m_finest_level < lev) return;
 


### PR DESCRIPTION
This PR provides the first working version of a field solve on level 1.
This included some changes in the designing of the box:

+ the `BoxArray` of level 1 is generated automatically, using `SetMaxGridSize`, this gives the right size transversely and longitudinally.
+ the initial reset and the setting of the plasma neutralizing background  at the beginning of each time step is now in a loop over levels.
+ the `SolveOneSlice` does not take the level as an input parameter, but intrinsically loops over all levels (each slice needs to loop over all levels before the next slice can be calculated). This change looks bad in git compare, because the indentation changed.
+ the `FillDiagnostic` is again per level, as the solve per slice is a loop over levels.

In the first implementation, both beam and plasma particle container get a flag for a level:

A beam gets a finest level. It deposits to each level above and to the finest level. It is pushed on the finest level.
A plasma gets an assigned level. It only deposits currents on this level and it will be pushed on this level, too. It does not contribute to other levels.

Currently, beams are not working on level 1 (to be fixed). However, the `GridCurrent` option is.
Parallel runs are currently crashing with division by 0 error.
Using a plasma has not been tested extensively.

Using a grid current, this PR enables the first field solve on the refined level.

For a beam current in vacuum, the space charge field is shown in the following plot:
![image](https://user-images.githubusercontent.com/65728274/122021851-5cdae480-cdc6-11eb-8d52-a8d0a05af557.png)


As it can be seen, the refined grid resolves the space charge field of the beam in the center properly. However, because the box is too small, the Dirichlet boundary condition of 0 forces the field to decay way too quickly. This will be solved by using the value of level 0 at the boundary of level 1 in the near future. We currently print more to file than we would actually need, therefore the edges to the left and right on level 1

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
