### PR TITLE
Mesh refinement: clean loop over levels

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -137,10 +137,8 @@ public:
     /** \brief Reset plasma and field slice quantities to initial value.
      *
      * Typically done at the beginning of each iteration.
-     *
-     * \param[in] lev MR level
      */
-    void ResetAllQuantities (int lev);
+    void ResetAllQuantities ();
 
     /**
        \brief Returns true on the head rank, otherwise false.
@@ -310,7 +308,11 @@ private:
     /** Diagnostics */
     Diagnostic m_diags;
 
-    void ResizeFDiagFAB (const amrex::Box box, const int lev) { m_diags.ResizeFDiagFAB(box, lev); };
+    /** \brief resizes the diagnostic fab to the correct box in a loop over boxes
+     *
+     * \param[in] it index of box to be resized to
+     */
+    void ResizeFDiagFAB (const int it);
     void FillDiagnostics (const int lev, int i_slice);
     /** \brief get diagnostics Component names of Fields to output */
     amrex::Vector<std::string>& getDiagComps () { return m_diags.getComps(); };

--- a/src/particles/MultiPlasma.H
+++ b/src/particles/MultiPlasma.H
@@ -78,10 +78,10 @@ public:
      * \param[in,out] fields the general field class, modified by this function
      * \param[in] which_slice slice in which the densities are deposited
      * \param[in] gm Geometry of the simulation, to get the cell size etc.
-     * \param[in] lev MR level
+     * \param[in] nlev number of MR levels
      */
     void DepositNeutralizingBackground (
-        Fields & fields, int which_slice, amrex::Geometry const& gm, int const lev);
+        Fields & fields, int which_slice, amrex::Geometry const& gm, int const nlev);
 
     /** Calculates Ionization Probability and makes new Plasma Particles
      *

--- a/src/particles/MultiPlasma.cpp
+++ b/src/particles/MultiPlasma.cpp
@@ -81,13 +81,15 @@ MultiPlasma::ResetParticles (int lev, bool initial)
 
 void
 MultiPlasma::DepositNeutralizingBackground (
-    Fields & fields, int which_slice, amrex::Geometry const& gm, int const lev)
+    Fields & fields, int which_slice, amrex::Geometry const& gm, int const nlev)
 {
-    for (auto& plasma : m_all_plasmas) {
-        if (plasma.m_neutralize_background){
-            // current of ions is zero, so they are not deposited.
-            ::DepositCurrent(plasma, fields, which_slice, false,
-                             false, false, true, false, gm, lev);
+    for (int lev = 0; lev < nlev; ++lev) {
+        for (auto& plasma : m_all_plasmas) {
+            if (plasma.m_neutralize_background){
+                // current of ions is zero, so they are not deposited.
+                ::DepositCurrent(plasma, fields, which_slice, false,
+                                 false, false, true, false, gm, lev);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR does some cleaning after #530. 

The loop over levels in the `Evolve` are moved to the functions themselves.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
