### PR TITLE
fix includes for compiling without openPMD

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -10,6 +10,7 @@
 #include "utils/GridCurrent.H"
 #include "utils/Constants.H"
 #include "diagnostics/Diagnostic.H"
+#include "diagnostics/OpenPMDWriter.H"
 
 #include <AMReX_AmrCore.H>
 #ifdef AMREX_USE_LINEAR_SOLVERS
@@ -18,8 +19,7 @@
 #endif
 
 #ifdef HIPACE_USE_OPENPMD
-#include <openPMD/openPMD.hpp>
-#include "diagnostics/OpenPMDWriter.H"
+#   include <openPMD/openPMD.hpp>
 #endif
 
 #include <memory>

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1263,6 +1263,7 @@ Hipace::WriteDiagnostics (int output_step, const int it, const OpenPMDWriterCall
                         m_physical_time, output_step, finestLevel()+1, getDiagSliceDir(), varnames, beamnames,
                         it, m_box_sorters, geom, call_type);
 #else
+    amrex::ignore_unused(it, call_type);
     amrex::Print()<<"WARNING: HiPACE++ compiled without openPMD support, the simulation has no I/O.\n";
 #endif
 }

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -14,11 +14,13 @@
 #include <vector>
 
 #ifdef HIPACE_USE_OPENPMD
-#include <openPMD/openPMD.hpp>
+#   include <openPMD/openPMD.hpp>
+#endif
 
 /** \brief Whether the beam, the field data is written, or if it is just flushing the stored data */
 enum struct OpenPMDWriterCallType { beams, fields };
 
+#ifdef HIPACE_USE_OPENPMD
 /** \brief class handling the IO with openPMD */
 class OpenPMDWriter
 {


### PR DESCRIPTION
This PR resolves #532. 

The inclusion of `OpenPMDWriter.H` was within a conditional block, but required nonetheless.
This PR moves the inclusion out of that conditional block and fixes the conditions in `OpenPMDWriter.H` itself.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
