### PR TITLE
[mini] Fix a few style warnings on AMD

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -124,7 +124,7 @@ public:
     void WriteDiagnostics (int output_step, const int it, const OpenPMDWriterCallType call_type);
 
     /** \brief Return a copy of member struct for physical constants */
-    PhysConst get_phys_const () {return m_phys_const;};
+    PhysConst get_phys_const () {return m_phys_const;}
 
     /** \brief Full evolve on 1 slice
      *
@@ -315,15 +315,15 @@ private:
     void ResizeFDiagFAB (const int it);
     void FillDiagnostics (const int lev, int i_slice);
     /** \brief get diagnostics Component names of Fields to output */
-    amrex::Vector<std::string>& getDiagComps () { return m_diags.getComps(); };
+    amrex::Vector<std::string>& getDiagComps () { return m_diags.getComps(); }
     /** \brief get diagnostics Component names of Fields to output */
-    amrex::Vector<std::string>& getDiagBeamNames () { return m_diags.getBeamNames(); };
+    amrex::Vector<std::string>& getDiagBeamNames () { return m_diags.getBeamNames(); }
     /** \brief get diagnostics multifab */
-    amrex::Vector<amrex::FArrayBox>& getDiagF () { return m_diags.getF(); };
+    amrex::Vector<amrex::FArrayBox>& getDiagF () { return m_diags.getF(); }
     /** \brief get diagnostics geometry */
-    amrex::Vector<amrex::Geometry>& getDiagGeom () { return m_diags.getGeom(); };
+    amrex::Vector<amrex::Geometry>& getDiagGeom () { return m_diags.getGeom(); }
     /** \brief get slicing direction of the diagnostics */
-    int getDiagSliceDir () { return m_diags.sliceDir(); };
+    int getDiagSliceDir () { return m_diags.sliceDir(); }
 
     /** \brief Predictor-corrector loop to calculate Bx and By.
      * 1. an initial Bx and By value is guessed.

--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -26,25 +26,25 @@ public:
     void AllocData (int lev, const amrex::Box& bx, int nfields, amrex::Geometry const& geom);
 
     /** \brief return the main diagnostics multifab */
-    amrex::Vector<amrex::FArrayBox>& getF () { return m_F; };
+    amrex::Vector<amrex::FArrayBox>& getF () { return m_F; }
 
     /** \brief return the main diagnostics multifab
      *
      * \param[in] lev MR level
      */
-    amrex::FArrayBox& getF (int lev) {return m_F[lev];};
+    amrex::FArrayBox& getF (int lev) { return m_F[lev]; }
 
     /** \brief return Component names of Fields to output */
-    amrex::Vector<std::string>& getComps () { return m_comps_output; };
+    amrex::Vector<std::string>& getComps () { return m_comps_output; }
 
     /** \brief return names of the beams to output */
-    amrex::Vector<std::string>& getBeamNames () { return m_output_beam_names; };
+    amrex::Vector<std::string>& getBeamNames () { return m_output_beam_names; }
 
     /** return the diagnostics geometry */
-    amrex::Vector<amrex::Geometry>& getGeom () { return m_geom_io; };
+    amrex::Vector<amrex::Geometry>& getGeom () { return m_geom_io; }
 
     /** return slice direction of the diagnostics */
-    int sliceDir () {return m_slice_dir;};
+    int sliceDir () {return m_slice_dir;}
 
     /** \brief return box which possibly was trimmed in case of slice IO
      *

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -81,7 +81,7 @@ public:
                            const bool species_specified);
 #endif
 
-    std::string get_name () const {return m_name;};
+    std::string get_name () const {return m_name;}
     amrex::Real m_charge; /**< charge of each particle of this species */
     amrex::Real m_mass; /**< mass of each particle of this species */
     bool m_do_z_push {true}; /**< Pushing beam particles in z direction */
@@ -92,7 +92,7 @@ public:
 
     unsigned long long m_total_num_particles {0};
 
-    unsigned long long get_total_num_particles () const {return m_total_num_particles;};
+    unsigned long long get_total_num_particles () const {return m_total_num_particles;}
 
     amrex::Long TotalNumberOfParticles (bool only_valid=true, bool only_local=false) const;
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -83,21 +83,21 @@ public:
     /** Return 1 species
      * \param[in] i index of the beam
      */
-    BeamParticleContainer& getBeam (int i) {return m_all_beams[i];};
+    BeamParticleContainer& getBeam (int i) {return m_all_beams[i];}
 
     /** returns the number of beams */
-    int get_nbeams () const {return m_nbeams;};
+    int get_nbeams () const {return m_nbeams;}
 
     /** returns the name of a beam */
-    std::string get_name (int i) const {return m_all_beams[i].get_name();};
+    std::string get_name (int i) const {return m_all_beams[i].get_name();}
 
     /** returns the local number of particles of a beam */
     unsigned long long get_local_n_part (int i) const
-        {return m_all_beams[i].TotalNumberOfParticles(1,1);};
+        {return m_all_beams[i].TotalNumberOfParticles(1,1);}
 
     /** returns the local number of particles of a beam */
     unsigned long long get_total_num_particles (int i) const
-        {return m_all_beams[i].get_total_num_particles();};
+        {return m_all_beams[i].get_total_num_particles();}
 
     /** \brief Check that all beams have the same number of Real components
      * and return this number */
@@ -126,7 +126,7 @@ public:
      *
      * \param[in] ibeam beam index
      */
-    int Npart (int ibeam) const {return m_all_beams[ibeam].numParticles();};
+    int Npart (int ibeam) const {return m_all_beams[ibeam].numParticles();}
 
     /** \brief copy particles in box it-1 in the ghost buffer at the end of the particle array.
      *
@@ -143,7 +143,7 @@ public:
      *
      * \param[in] ibeam index of the beam
      */
-    int getNRealParticles (int ibeam) const {return m_n_real_particles[ibeam];};
+    int getNRealParticles (int ibeam) const {return m_n_real_particles[ibeam];}
 
     /** \brief Allows beams.all_from_file to specify the input file of all beams that have
      * no injection_type. Also passes down beams.iteration, beams.plasma_density and


### PR DESCRIPTION
Remove a few unnecessary semicolons, giving compilation warnings on AMD.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
