### PR TITLE
Mesh refinement: pass vector of geometries to field solve functions

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -502,7 +502,7 @@ Hipace::SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins
                                 amrex::make_alias, Comps[WhichSlice::This]["jx"], 7);
         j_slice.FillBoundary(Geom(lev).periodicity());
 
-        m_fields.SolvePoissonExmByAndEypBx(Geom(lev), m_comm_xy, lev);
+        m_fields.SolvePoissonExmByAndEypBx(Geom(), m_comm_xy, lev);
 
         m_grid_current.DepositCurrentSlice(m_fields, geom[lev], lev, islice);
         m_multi_beam.DepositCurrentSlice(m_fields, geom[lev], lev, islice, bx, bins, m_box_sorters,
@@ -511,8 +511,8 @@ Hipace::SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins
 
         j_slice.FillBoundary(Geom(lev).periodicity());
 
-        m_fields.SolvePoissonEz(Geom(lev), lev);
-        m_fields.SolvePoissonBz(Geom(lev), lev);
+        m_fields.SolvePoissonEz(Geom(), lev);
+        m_fields.SolvePoissonBz(Geom(), lev);
 
         // Modifies Bx and By in the current slice and the force terms of the plasma particles
         if (m_explicit){
@@ -863,8 +863,8 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev, cons
         amrex::ParallelContext::pop();
 
         /* Calculate Bx and By */
-        m_fields.SolvePoissonBx(Bx_iter, Geom(lev), lev);
-        m_fields.SolvePoissonBy(By_iter, Geom(lev), lev);
+        m_fields.SolvePoissonBx(Bx_iter, Geom(), lev);
+        m_fields.SolvePoissonBy(By_iter, Geom(), lev);
 
         relative_Bfield_error = m_fields.ComputeRelBFieldError(
             m_fields.getSlices(lev, WhichSlice::This),

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -152,34 +152,36 @@ public:
      * \param[in] m_comm_xy transverse communicator on the slice
      * \param[in] lev current level
      */
-    void SolvePoissonExmByAndEypBx (amrex::Geometry const& geom, const MPI_Comm& m_comm_xy,
-                                    const int lev);
+    void SolvePoissonExmByAndEypBx (amrex::Vector<amrex::Geometry> const& geom,
+                                    const MPI_Comm& m_comm_xy, const int lev);
     /** \brief Compute Ez on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
      */
-    void SolvePoissonEz (amrex::Geometry const& geom, const int lev);
+    void SolvePoissonEz (amrex::Vector<amrex::Geometry> const& geom, const int lev);
     /** \brief Compute Bx on the slice container from J by solving a Poisson equation
      *
      * \param[in,out] Bx_iter Bx field during current iteration of the predictor-corrector loop
      * \param[in] geom Geometry
      * \param[in] lev current level
      */
-    void SolvePoissonBx (amrex::MultiFab& Bx_iter, amrex::Geometry const& geom, const int lev);
+    void SolvePoissonBx (amrex::MultiFab& Bx_iter, amrex::Vector<amrex::Geometry> const& geom,
+                         const int lev);
     /** \brief Compute By on the slice container from J by solving a Poisson equation
      *
      * \param[in,out] By_iter By field during current iteration of the predictor-corrector loop
      * \param[in] geom Geometry
      * \param[in] lev current level
      */
-    void SolvePoissonBy (amrex::MultiFab& By_iter,amrex::Geometry const& geom, const int lev);
+    void SolvePoissonBy (amrex::MultiFab& By_iter, amrex::Vector<amrex::Geometry> const& geom,
+                         const int lev);
     /** \brief Compute Bz on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
      */
-    void SolvePoissonBz (amrex::Geometry const& geom, const int lev);
+    void SolvePoissonBz (amrex::Vector<amrex::Geometry> const& geom, const int lev);
     /** \brief Sets the initial guess of the B field from the two previous slices
      *
      * This modifies component Bx or By of slice 1 in m_fields.m_slices


### PR DESCRIPTION
This PR prepares the field interpolation from the coarse to the fine level.

Instead of passing just the geometry of the level, which is currently solved, now a vector of all geometries is passed and the appropriate geometry is used in the field solvers.

Now, the geometry of both levels can be accessed within the field solver functions

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
