### PR TITLE
Add OpenMP for FFTW

### DIFF
--- a/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
@@ -21,13 +21,15 @@ namespace AnyDST
         const int ny = real_size[1];
 
 #if defined(AMREX_USE_OMP) && defined(HIPACE_FFTW_OMP)
+        if (nx > 32 && ny > 32) {
 #   ifdef AMREX_USE_FLOAT
-        fftwf_init_threads();
-        fftwf_plan_with_nthreads(omp_get_max_threads());
+            fftwf_init_threads();
+            fftwf_plan_with_nthreads(omp_get_max_threads());
 #   else
-        fftw_init_threads();
-        fftw_plan_with_nthreads(omp_get_max_threads());
+            fftw_init_threads();
+            fftw_plan_with_nthreads(omp_get_max_threads());
 #   endif
+        }
 #endif
 
         // Initialize fft_plan.m_plan with the vendor fft plan.

--- a/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
@@ -20,7 +20,7 @@ namespace AnyDST
         const int nx = real_size[0];
         const int ny = real_size[1];
 
-#ifdef AMREX_USE_OMP
+#if defined(AMREX_USE_OMP) && defined(HIPACE_FFTW_OMP)
 #   ifdef AMREX_USE_FLOAT
         fftwf_init_threads();
         fftwf_plan_with_nthreads(omp_get_max_threads());

--- a/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
@@ -1,6 +1,10 @@
 #include "AnyDST.H"
 #include "utils/HipaceProfilerWrapper.H"
 
+#ifdef AMREX_USE_OMP
+#   include <omp.h>
+#endif
+
 namespace AnyDST
 {
 #ifdef AMREX_USE_FLOAT
@@ -15,6 +19,16 @@ namespace AnyDST
         DSTplan dst_plan;
         const int nx = real_size[0];
         const int ny = real_size[1];
+
+#ifdef AMREX_USE_OMP
+#   ifdef AMREX_USE_FLOAT
+        fftwf_init_threads();
+        fftwf_plan_with_nthreads(omp_get_max_threads());
+#   else
+        fftw_init_threads();
+        fftw_plan_with_nthreads(omp_get_max_threads());
+#   endif
+#endif
 
         // Initialize fft_plan.m_plan with the vendor fft plan.
         // Swap dimensions: AMReX FAB are Fortran-order but FFTW is C-order


### PR DESCRIPTION
Add a heuristics that also works with PkgConfig to query OpenMP support in FFTW. Enable by default if we build with the OpenMP compute backend unless explicitly disabled.

Add a macro to control the source-code, since FFTW does not offer a public define for this.

Thanks to @ax3l FFTW with OpenMP now works:
On my laptop, using the beam in vacuum example without I/O and without beam at `amr.n_cell = 1024 1024 50`
I get the following run times:
```
OMP_NUM_THREADS=1
AnyDST::Execute()                                     500      29.68      29.68      29.68  80.17%
OMP_NUM_THREADS=2
AnyDST::Execute()                                     500      14.86      14.86      14.86  68.45%
OMP_NUM_THREADS=3
AnyDST::Execute()                                     500      10.05      10.05      10.05  59.75%
OMP_NUM_THREADS=4
AnyDST::Execute()                                     500      7.707      7.707      7.707  53.07%
OMP_NUM_THREADS=5
AnyDST::Execute()                                     500       6.23       6.23       6.23  47.70%
OMP_NUM_THREADS=6
AnyDST::Execute()                                     500      6.097      6.097      6.097  46.36%
```

This implementation seems to give the correct results. Using 2 threads, all tests pass locally:
```
      Start  1: blowout_wake.2Rank
 1/20 Test  #1: blowout_wake.2Rank ......................   Passed    6.49 sec
      Start  2: ionization.2Rank
 2/20 Test  #2: ionization.2Rank ........................   Passed    2.40 sec
      Start  3: from_file.normalized.1Rank
 3/20 Test  #3: from_file.normalized.1Rank ..............   Passed    3.12 sec
      Start  4: from_file.SI.1Rank
 4/20 Test  #4: from_file.SI.1Rank ......................   Passed    3.00 sec
      Start  5: restart.normalized.1Rank
 5/20 Test  #5: restart.normalized.1Rank ................   Passed    0.88 sec
      Start  6: blowout_wake_explicit.2Rank
 6/20 Test  #6: blowout_wake_explicit.2Rank .............   Passed    2.52 sec
      Start  7: beam_evolution.1Rank
 7/20 Test  #7: beam_evolution.1Rank ....................   Passed    3.04 sec
      Start  8: adaptive_time_step.1Rank
 8/20 Test  #8: adaptive_time_step.1Rank ................   Passed    5.32 sec
      Start  9: grid_current.1Rank
 9/20 Test  #9: grid_current.1Rank ......................   Passed    1.82 sec
      Start 10: linear_wake.normalized.1Rank
10/20 Test #10: linear_wake.normalized.1Rank ............   Passed    2.92 sec
      Start 11: linear_wake.SI.1Rank
11/20 Test #11: linear_wake.SI.1Rank ....................   Passed    2.91 sec
      Start 12: gaussian_linear_wake.normalized.1Rank
12/20 Test #12: gaussian_linear_wake.normalized.1Rank ...   Passed    3.00 sec
      Start 13: gaussian_linear_wake.SI.1Rank
13/20 Test #13: gaussian_linear_wake.SI.1Rank ...........   Passed    3.12 sec
      Start 14: reset.2Rank
14/20 Test #14: reset.2Rank .............................   Passed    3.08 sec
      Start 15: beam_in_vacuum.SI.1Rank
15/20 Test #15: beam_in_vacuum.SI.1Rank .................   Passed    5.50 sec
      Start 16: beam_in_vacuum.normalized.1Rank
16/20 Test #16: beam_in_vacuum.normalized.1Rank .........   Passed    4.94 sec
      Start 17: next_deposition_beam.2Rank
17/20 Test #17: next_deposition_beam.2Rank ..............   Passed   27.33 sec
      Start 18: slice_IO.1Rank
18/20 Test #18: slice_IO.1Rank ..........................   Passed    3.15 sec
      Start 19: gaussian_weight.1Rank
19/20 Test #19: gaussian_weight.1Rank ...................   Passed    5.00 sec
      Start 20: beam_in_vacuum.normalized.2Rank
20/20 Test #20: beam_in_vacuum.normalized.2Rank .........   Passed    5.35 sec

100% tests passed, 0 tests failed out of 20
```
 As a comparison, here the run time on development on my laptop:
 ```
       Start  1: blowout_wake.2Rank
 1/20 Test  #1: blowout_wake.2Rank ......................   Passed    6.95 sec
      Start  2: ionization.2Rank
 2/20 Test  #2: ionization.2Rank ........................   Passed    2.61 sec
      Start  3: from_file.normalized.1Rank
 3/20 Test  #3: from_file.normalized.1Rank ..............   Passed    4.15 sec
      Start  4: from_file.SI.1Rank
 4/20 Test  #4: from_file.SI.1Rank ......................   Passed    3.65 sec
      Start  5: restart.normalized.1Rank
 5/20 Test  #5: restart.normalized.1Rank ................   Passed    1.28 sec
      Start  6: blowout_wake_explicit.2Rank
 6/20 Test  #6: blowout_wake_explicit.2Rank .............   Passed    2.71 sec
      Start  7: beam_evolution.1Rank
 7/20 Test  #7: beam_evolution.1Rank ....................   Passed    2.88 sec
      Start  8: adaptive_time_step.1Rank
 8/20 Test  #8: adaptive_time_step.1Rank ................   Passed    5.30 sec
      Start  9: grid_current.1Rank
 9/20 Test  #9: grid_current.1Rank ......................   Passed    1.95 sec
      Start 10: linear_wake.normalized.1Rank
10/20 Test #10: linear_wake.normalized.1Rank ............   Passed    3.10 sec
      Start 11: linear_wake.SI.1Rank
11/20 Test #11: linear_wake.SI.1Rank ....................   Passed    4.18 sec
      Start 12: gaussian_linear_wake.normalized.1Rank
12/20 Test #12: gaussian_linear_wake.normalized.1Rank ...   Passed    3.83 sec
      Start 13: gaussian_linear_wake.SI.1Rank
13/20 Test #13: gaussian_linear_wake.SI.1Rank ...........   Passed    3.03 sec
      Start 14: reset.2Rank
14/20 Test #14: reset.2Rank .............................   Passed    3.12 sec
      Start 15: beam_in_vacuum.SI.1Rank
15/20 Test #15: beam_in_vacuum.SI.1Rank .................   Passed    6.73 sec
      Start 16: beam_in_vacuum.normalized.1Rank
16/20 Test #16: beam_in_vacuum.normalized.1Rank .........   Passed    5.32 sec
      Start 17: next_deposition_beam.2Rank
17/20 Test #17: next_deposition_beam.2Rank ..............   Passed    6.73 sec
      Start 18: slice_IO.1Rank
18/20 Test #18: slice_IO.1Rank ..........................   Passed    3.58 sec
      Start 19: gaussian_weight.1Rank
19/20 Test #19: gaussian_weight.1Rank ...................   Passed    6.52 sec
      Start 20: beam_in_vacuum.normalized.2Rank
20/20 Test #20: beam_in_vacuum.normalized.2Rank .........   Passed   10.55 sec
```

`next_deposition_beam.2Rank` test takes so much longer than running in serial. The reason lies in its extremely low resolution of 16 transverse grid points. Obviously, it does not make any sense to use more than 1 CPU for the FFT there. Using 32 grid points is slightly slower with 2 threads. Increasing the number of grid points to 64 yields in a speed up with more threads again. Therefore, a threshold of `nx > 32 && ny > 32` was added. If it is not met, the FFT is executed with a single thread.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
