### PR TITLE
Mesh refinement: fix beam currents in normalized units

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -475,7 +475,7 @@ Hipace::SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins
                 amrex::MultiFab j_slice_next(m_fields.getSlices(lev, WhichSlice::Next),
                                              amrex::make_alias, Comps[WhichSlice::Next]["jx"], 4);
                 j_slice_next.setVal(0.);
-                m_multi_beam.DepositCurrentSlice(m_fields, geom[lev], lev, islice, bx, bins,
+                m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice, bx, bins,
                                                  m_box_sorters, ibox, m_do_beam_jx_jy_deposition,
                                                  WhichSlice::Next);
                 m_fields.AddBeamCurrents(lev, WhichSlice::Next);
@@ -505,7 +505,7 @@ Hipace::SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins
         m_fields.SolvePoissonExmByAndEypBx(Geom(), m_comm_xy, lev);
 
         m_grid_current.DepositCurrentSlice(m_fields, geom[lev], lev, islice);
-        m_multi_beam.DepositCurrentSlice(m_fields, geom[lev], lev, islice, bx, bins, m_box_sorters,
+        m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice, bx, bins, m_box_sorters,
                                          ibox, m_do_beam_jx_jy_deposition, WhichSlice::This);
         m_fields.AddBeamCurrents(lev, WhichSlice::This);
 
@@ -851,7 +851,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev, cons
         m_multi_plasma.DepositCurrent(
             m_fields, WhichSlice::Next, true, true, false, false, false, geom[lev], lev);
 
-        m_multi_beam.DepositCurrentSlice(m_fields, geom[lev], lev, islice, bx, bins, m_box_sorters,
+        m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice, bx, bins, m_box_sorters,
                                          ibox, m_do_beam_jx_jy_deposition, WhichSlice::Next);
         m_fields.AddBeamCurrents(lev, WhichSlice::Next);
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -22,7 +22,7 @@ public:
 
     /** Loop over all beam species and deposit their current on the 2D XY slice
      * \param[in] fields Field object, with 2D slice MultiFabs
-     * \param[in] geom Geometry object at level lev
+     * \param[in] geom Geometry vector for all levels
      * \param[in] lev MR level
      * \param[in] islice slice index in which the current is stored
      * \param[in] bx current box to calculate in loop over longutidinal boxes
@@ -33,8 +33,8 @@ public:
      * \param[in] which_slice defines if this or the next slice is handled
      */
     void DepositCurrentSlice (
-        Fields& fields, const amrex::Geometry& geom, const int lev, int islice, const amrex::Box bx,
-        amrex::Vector<BeamBins> bins,
+        Fields& fields, amrex::Vector<amrex::Geometry> const& geom, const int lev, int islice,
+        const amrex::Box bx, amrex::Vector<BeamBins> bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox,
         const bool do_beam_jx_jy_deposition, const int which_slice);
 

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -28,8 +28,8 @@ MultiBeam::InitData (const amrex::Geometry& geom)
 
 void
 MultiBeam::DepositCurrentSlice (
-    Fields& fields, const amrex::Geometry& geom, const int lev, int islice, const amrex::Box bx,
-    amrex::Vector<BeamBins> bins,
+    Fields& fields, amrex::Vector<amrex::Geometry> const& geom, const int lev, int islice,
+    const amrex::Box bx, amrex::Vector<BeamBins> bins,
     const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox,
     const bool do_beam_jx_jy_deposition, const int which_slice)
 

--- a/src/particles/deposition/BeamDepositCurrent.H
+++ b/src/particles/deposition/BeamDepositCurrent.H
@@ -22,9 +22,9 @@
  *            islice = 0.
  */
 void
-DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
-                     int const lev, const int islice, const amrex::Box bx, int const offset,
-                     BeamBins& bins,
+DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
+                     amrex::Vector<amrex::Geometry> const& gm, int const lev, const int islice,
+                     const amrex::Box bx, int const offset, BeamBins& bins,
                      const bool do_beam_jx_jy_deposition, const int which_slice,
                      int nghost=0);
 

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -9,14 +9,14 @@
 #include <AMReX_DenseBins.H>
 
 void
-DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
-                     int const lev ,const int islice, const amrex::Box bx, int const offset,
-                     BeamBins& bins,
+DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
+                     amrex::Vector<amrex::Geometry> const& gm, int const lev ,const int islice,
+                     const amrex::Box bx, int const offset, BeamBins& bins,
                      const bool do_beam_jx_jy_deposition, const int which_slice, int nghost)
 {
     HIPACE_PROFILE("DepositCurrentSlice_BeamParticleContainer()");
     // Extract properties associated with physical size of the box
-    amrex::Real const * AMREX_RESTRICT dx = gm.CellSize();
+    amrex::Real const * AMREX_RESTRICT dx = gm[lev].CellSize();
 
     // beam deposits only up to its finest level
     if (beam.m_finest_level < lev) return;
@@ -36,7 +36,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometr
     amrex::Box tilebox = bx;
     tilebox.grow({Hipace::m_depos_order_xy, Hipace::m_depos_order_xy, Hipace::m_depos_order_z});
 
-    amrex::RealBox const grid_box{tilebox, gm.CellSize(), gm.ProbLo()};
+    amrex::RealBox const grid_box{tilebox, gm[lev].CellSize(), gm[lev].ProbLo()};
     amrex::Real const * AMREX_RESTRICT xyzmin = grid_box.lo();
     amrex::Dim3 const lo = amrex::lbound(tilebox);
 
@@ -55,8 +55,16 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometr
     amrex::FArrayBox& jyb_fab = jy_beam[0];
     amrex::FArrayBox& jzb_fab = jz_beam[0];
 
+    amrex::Real lev_weight_fac = 1.;
+    if (lev == 1 && Hipace::m_normalized_units) {
+        // re-scaling the weight in normalized units to get the same charge density on lev 1
+        // Not necessary in SI units, there the weight is the actual charge and not the density
+        amrex::Real const * AMREX_RESTRICT dx_lev0 = gm[0].CellSize();
+        lev_weight_fac = dx_lev0[0] * dx_lev0[1] * dx_lev0[2] / (dx[0] * dx[1] * dx[2]);
+    }
+
     // For now: fix the value of the charge
-    const amrex::Real q = beam.m_charge;
+    const amrex::Real q = beam.m_charge * lev_weight_fac;
 
     // Call deposition function in each box
     if        (Hipace::m_depos_order_xy == 0){


### PR DESCRIPTION
This is a follow-up to #530.

Previously, the beam current in normalized units was not set correctly. The reason is that the beam and its weight is defined on grid level 0. In normalized units, the beam weight represents a charge density, which depends on the grid dimension.
Therefore, this must be re-scaled for level 1. In SI units, this problem does not occur, because the weight represents an actual charge.

Before this PR, the space charge field in vacuum was (for both levels):
![image](https://user-images.githubusercontent.com/65728274/123518099-b4b9fb00-d6a4-11eb-8b98-766eb93c6a1d.png)

Now, it is:
![image](https://user-images.githubusercontent.com/65728274/123518124-c3081700-d6a4-11eb-8e2b-817f311ede96.png)




- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
