### PR TITLE
Mesh refinement: fix parallel runs

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -226,6 +226,7 @@ Hipace::InitData ()
     for (int ilev = 0; ilev <= maxLevel(); ++ilev) {
         amrex::IntVect mgs = maxGridSize(ilev);
         mgs[0] = mgs[1] = 1024000000; // disable domain decomposition in x and y directions
+        mgs[2] = Geom(ilev).Domain().length()[2]/m_numprocs_z; // make 1 box per rank longitudinally
         new_max_grid_size.push_back(mgs);
     }
     SetMaxGridSize(new_max_grid_size);
@@ -245,7 +246,7 @@ void
 Hipace::MakeNewLevelFromScratch (
     int lev, amrex::Real /*time*/, const amrex::BoxArray& ba, const amrex::DistributionMapping&)
 {
-    SetMaxGridSize(1048576); // 2^20, this ensures that level 1 uses only 1 box longitudinally.
+    // SetMaxGridSize(1048576); // 2^20, this ensures that level 1 uses only 1 box longitudinally.
 
     // We are going to ignore the DistributionMapping argument and build our own.
     amrex::DistributionMapping dm;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -246,7 +246,6 @@ void
 Hipace::MakeNewLevelFromScratch (
     int lev, amrex::Real /*time*/, const amrex::BoxArray& ba, const amrex::DistributionMapping&)
 {
-    // SetMaxGridSize(1048576); // 2^20, this ensures that level 1 uses only 1 box longitudinally.
 
     // We are going to ignore the DistributionMapping argument and build our own.
     amrex::DistributionMapping dm;


### PR DESCRIPTION
Previously, parallel runs with mesh refinement failed due to a division-by-zero error.

The reason was that only 1 box was created longitudinally on level 1, even if many ranks were used.
This resulted in a `1/n_rank = 0` which was used in a division later.

This PR solves this issue by setting the `maxgridsize` in the longitudinal direction to `n_z / n_ranks_z`.

This way, the number of longitudinal boxes is set correctly on level 1 and no division by 0 occurs.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
