### PR TITLE
add OpenMP support for transverse and longitudinal derivative

### DIFF
--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -55,6 +55,9 @@ Fields::TransverseDerivative (const amrex::MultiFab& src, amrex::MultiFab& dst, 
     using namespace amrex::literals;
 
     AMREX_ALWAYS_ASSERT((direction == Direction::x) || (direction == Direction::y));
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
     for ( amrex::MFIter mfi(dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
         const amrex::Box& bx = mfi.tilebox();
         amrex::Array4<amrex::Real const> const & src_array = src.array(mfi);
@@ -102,6 +105,10 @@ Fields::LongitudinalDerivative (const amrex::MultiFab& src1, const amrex::MultiF
 {
     HIPACE_PROFILE("Fields::LongitudinalDerivative()");
     using namespace amrex::literals;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
     for ( amrex::MFIter mfi(dst, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
         const amrex::Box& bx = mfi.tilebox();
         amrex::Array4<amrex::Real const> const & src1_array = src1.array(mfi);


### PR DESCRIPTION
This PR adds OpenMP support for the transverse and longitudinal derivative.

We currently anticipate that the field functions may become significant, if particle pusher + deposition + field solver use OpenMP.

This small PR takes the trivial functions of the derivatives and adds OpenMP support.

The `ComputeBFieldError` will be taken on in a separate PR, as it involves reduces and is not as trivial as the other functions.

The measured speed up was roughly what was expected.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
