### PR TITLE
Mesh refinement: enable level 1 to be longitudinally a different size than level 0

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1257,7 +1257,15 @@ void
 Hipace::ResizeFDiagFAB (const int it)
 {
     for (int lev = 0; lev <= finestLevel(); ++lev) {
-        const amrex::Box& bx = boxArray(lev)[it];
+        amrex::Box bx = boxArray(lev)[it];
+
+        if (lev == 1) {
+            const amrex::Box& bx_lev0 = boxArray(0)[it];
+            // Ensuring the IO boxes on level 1 are aligned with the boxes on level 0
+            bx.setSmall(Direction::z, bx_lev0.smallEnd(Direction::z));
+            bx.setBig  (Direction::z, bx_lev0.bigEnd(Direction::z));
+        }
+
         m_diags.ResizeFDiagFAB(bx, lev);
     }
 }

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -121,6 +121,8 @@ Hipace::Hipace () :
 
     if (maxLevel() > 0) {
         AMREX_ALWAYS_ASSERT(maxLevel() < 2);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_explicit, "Mesh refinement + explicit solver is not yet"
+                                " supported! Please use hipace.bxby_solver = predictor-corrector");
         amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
         pph.get("patch_lo", loc_array);
         for (int idim=0; idim<AMREX_SPACEDIM; ++idim) patch_lo[idim] = loc_array[idim];
@@ -254,7 +256,7 @@ Hipace::MakeNewLevelFromScratch (
         const amrex::IntVect box_size = ba[0].length();  // Uniform box size
         const int nboxes_x = m_numprocs_x;
         const int nboxes_y = m_numprocs_y;
-        const int nboxes_z = (m_boxes_in_z == 1) ? ncells_global[2] / box_size[2] : m_boxes_in_z;
+        const int nboxes_z = (m_boxes_in_z == 1) ? m_numprocs_z : m_boxes_in_z;
         AMREX_ALWAYS_ASSERT(static_cast<long>(nboxes_x) *
                             static_cast<long>(nboxes_y) *
                             static_cast<long>(nboxes_z) == ba.size());
@@ -444,11 +446,24 @@ Hipace::SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins
     HIPACE_PROFILE("Hipace::SolveOneSlice()");
 
     for (int lev = 0; lev <= finestLevel(); ++lev) {
+
+        if (lev == 1) { // skip all slices which are not existing on level 1
+            const amrex::Real* problo = Geom(lev).ProbLo();
+            const amrex::Real* dx = Geom(lev).CellSize();
+            amrex::Real pos = (islice+0.5)*dx[2]+problo[2];
+            if (pos < patch_lo[2] || pos > patch_hi[2]) continue;
+        }
+
         // Between this push and the corresponding pop at the end of this
         // for loop, the parallelcontext is the transverse communicator
         amrex::ParallelContext::push(m_comm_xy);
 
         const amrex::Box& bx = boxArray(lev)[ibox];
+
+        // Assumes '2' == 'z' == 'the long dimension'.
+        // fixme: boxArray(lev) is hardcoded to lev = 0, because we currently only bin the beam
+        // particles on level 0. This must be addressed if we want to have longitudinal refinement.
+        const int islice_local = islice - boxArray(0)[ibox].smallEnd(2);
 
         if (m_explicit) {
             // Set all quantities to 0 except Bx and By: the previous slice serves as initial guess.
@@ -471,17 +486,17 @@ Hipace::SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins
         m_multi_plasma.DepositCurrent(
             m_fields, WhichSlice::This, false, true, true, true, m_explicit, geom[lev], lev);
 
-            if (m_explicit){
-                amrex::MultiFab j_slice_next(m_fields.getSlices(lev, WhichSlice::Next),
-                                             amrex::make_alias, Comps[WhichSlice::Next]["jx"], 4);
-                j_slice_next.setVal(0.);
-                m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice, bx, bins,
-                                                 m_box_sorters, ibox, m_do_beam_jx_jy_deposition,
-                                                 WhichSlice::Next);
-                m_fields.AddBeamCurrents(lev, WhichSlice::Next);
-                // need to exchange jx jy jx_beam jy_beam
-                j_slice_next.FillBoundary(Geom(lev).periodicity());
-            }
+        if (m_explicit){
+            amrex::MultiFab j_slice_next(m_fields.getSlices(lev, WhichSlice::Next),
+                                         amrex::make_alias, Comps[WhichSlice::Next]["jx"], 4);
+            j_slice_next.setVal(0.);
+            m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice_local, bx, bins,
+                                             m_box_sorters, ibox, m_do_beam_jx_jy_deposition,
+                                             WhichSlice::Next);
+            m_fields.AddBeamCurrents(lev, WhichSlice::Next);
+            // need to exchange jx jy jx_beam jy_beam
+            j_slice_next.FillBoundary(Geom(lev).periodicity());
+        }
 
         m_fields.AddRhoIons(lev);
 
@@ -505,7 +520,7 @@ Hipace::SolveOneSlice (int islice, const int ibox, amrex::Vector<BeamBins>& bins
         m_fields.SolvePoissonExmByAndEypBx(Geom(), m_comm_xy, lev);
 
         m_grid_current.DepositCurrentSlice(m_fields, geom[lev], lev, islice);
-        m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice, bx, bins, m_box_sorters,
+        m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice_local, bx, bins, m_box_sorters,
                                          ibox, m_do_beam_jx_jy_deposition, WhichSlice::This);
         m_fields.AddBeamCurrents(lev, WhichSlice::This);
 
@@ -834,6 +849,11 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev, cons
     /* shift force terms, update force terms using guessed Bx and By */
     m_multi_plasma.AdvanceParticles( m_fields, geom[lev], false, false, true, true, lev);
 
+    // Assumes '2' == 'z' == 'the long dimension'.
+    // fixme: boxArray(lev) is hardcoded to lev = 0, because we currently only bin the beam
+    // particles on level 0. This must be addressed if we want to have longitudinal refinement.
+    const int islice_local = islice - boxArray(0)[ibox].smallEnd(2);
+
     /* Begin of predictor corrector loop  */
     int i_iter = 0;
     /* resetting the initial B-field error for mixing between iterations */
@@ -851,7 +871,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev, cons
         m_multi_plasma.DepositCurrent(
             m_fields, WhichSlice::Next, true, true, false, false, false, geom[lev], lev);
 
-        m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice, bx, bins, m_box_sorters,
+        m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice_local, bx, bins, m_box_sorters,
                                          ibox, m_do_beam_jx_jy_deposition, WhichSlice::Next);
         m_fields.AddBeamCurrents(lev, WhichSlice::Next);
 
@@ -919,7 +939,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int lev, cons
 
     // adding relative B field error for diagnostic
     m_predcorr_avg_B_error += relative_Bfield_error;
-    if (m_verbose >= 2) amrex::Print()<<"islice: " << islice << " n_iter: "<<i_iter<<
+    if (m_verbose >= 2) amrex::Print()<<"level: " << lev << " islice: " << islice << " n_iter: "<<i_iter<<
                             " relative B field error: "<<relative_Bfield_error<< "\n";
 }
 

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -29,9 +29,6 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Hipace::m_depos_order_z == 0,
         "Only order 0 deposition is allowed for beam per-slice deposition");
 
-    // Assumes '2' == 'z' == 'the long dimension'.
-    int islice_local = islice - bx.smallEnd(2);
-
     // Extract properties associated with the extent of the current box
     amrex::Box tilebox = bx;
     tilebox.grow({Hipace::m_depos_order_xy, Hipace::m_depos_order_xy, Hipace::m_depos_order_z});
@@ -68,16 +65,16 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
 
     // Call deposition function in each box
     if        (Hipace::m_depos_order_xy == 0){
-        doDepositionShapeN<0, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice_local,
+        doDepositionShapeN<0, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice,
                                   bins, offset, do_beam_jx_jy_deposition, which_slice, nghost);
     } else if (Hipace::m_depos_order_xy == 1){
-        doDepositionShapeN<1, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice_local,
+        doDepositionShapeN<1, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice,
                                   bins, offset, do_beam_jx_jy_deposition, which_slice, nghost);
     } else if (Hipace::m_depos_order_xy == 2){
-        doDepositionShapeN<2, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice_local,
+        doDepositionShapeN<2, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice,
                                   bins, offset, do_beam_jx_jy_deposition, which_slice, nghost);
     } else if (Hipace::m_depos_order_xy == 3){
-        doDepositionShapeN<3, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice_local,
+        doDepositionShapeN<3, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, xyzmin, lo, q, islice,
                                   bins, offset, do_beam_jx_jy_deposition, which_slice, nghost);
     } else {
         amrex::Abort("unknown deposition order");


### PR DESCRIPTION
This PR allows to have the patch have a different dimension than level 0.
The refinement ratio longitudinally must still be 1.

The mesh refinement is implemented as a loop over levels at each slice. With this implementation, level 1 is skipped at each slice which is outside of the patch.

Because the binning of the beam currently only happens on level 0, the `islice_local` definition had to be moved to `Hipace.cpp`, instead of doing it in the beam deposition itself.
This will be different, as soon as we allow longitudinal refinement, which will involve a sub-loop per level 0 slice and binning of the beam per level. 

When the patch has a different size than level 0 longitudinally, the boxArray is not correct. The boxArray of level 1 is only used for IO, so it is adapted in the `ResizeFDiagFAB` to have the correct longitudinal size of level 0. Otherwise, this leads to problems in parallelized runs.

Note: Currently, we always push the beam particles on the most refined grid. This can cause crashes, when level 1 is longitudinally smaller than level 0, because the beam is binned by level 0 and then we run into out of memory accesses.
This will be fixed, as soon as we bin the beams per level.

Using a refined patch only from -2 to 0 longitudinally and 4 ranks, I got the following refined space charge field of the beam:

![image](https://user-images.githubusercontent.com/65728274/124035164-77cf6a80-d9fc-11eb-9bbd-53819da37c16.png)



- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
