### PR TITLE
add OpenMP to CI tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=17
         make -j 2 VERBOSE=ON
         export OMP_NUM_THREADS=2
-        ctest --output-on-failure
+        ctest --verbose
 
 #  linux_gcc_cxx14:
 #    name: GNU@7.5 C++14 Serial

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,6 +41,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/tmp/my-hipace  \
             -DCMAKE_CXX_STANDARD=17
         make -j 2 VERBOSE=ON
+        export OMP_NUM_THREADS=2
         ctest --output-on-failure
 
 #  linux_gcc_cxx14:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=17
         make -j 2 VERBOSE=ON
         export OMP_NUM_THREADS=2
-        ctest --verbose
+        ctest --output-on-failure
 
 #  linux_gcc_cxx14:
 #    name: GNU@7.5 C++14 Serial

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir build
         cd build
         cmake ..                                   \
-            -DHiPACE_COMPUTE=OMP                   \   
+            -DHiPACE_COMPUTE=OMP                   \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-hipace  \
             -DCMAKE_CXX_STANDARD=17
         make -j 2 VERBOSE=ON

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,6 +37,7 @@ jobs:
         mkdir build
         cd build
         cmake ..                                   \
+            -DHiPACE_COMPUTE=OMP                   \   
             -DCMAKE_INSTALL_PREFIX=/tmp/my-hipace  \
             -DCMAKE_CXX_STANDARD=17
         make -j 2 VERBOSE=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,9 +237,6 @@ if(BUILD_TESTING)
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
 
-        # use OpenMP from here on
-        export OMP_NUM_THREADS=2
-
         add_test(NAME blowout_wake_explicit.2Rank
                  COMMAND ${HiPACE_SOURCE_DIR}/tests/blowout_wake_explicit.2Rank.sh
                          $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,9 @@ if(BUILD_TESTING)
                  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
         )
 
+        # use OpenMP from here on
+        export OMP_NUM_THREADS=2
+
         add_test(NAME blowout_wake_explicit.2Rank
                  COMMAND ${HiPACE_SOURCE_DIR}/tests/blowout_wake_explicit.2Rank.sh
                          $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}


### PR DESCRIPTION
This PR adds multi-threading with OpenMP and 2 threads in all CI tests.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
