### PR TITLE
Automatically use small DST for large Resolutions

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -94,7 +94,7 @@ Modeling ion motion is not yet supported by the explicit solver
 
 * ``hipace.use_small_dst`` (`bool`) optional (default `0` or `1`)
     Whether to use a large R2C or a small C2R fft in the dst of the Poisson solver.
-    The small dst can be much quicker for high resolutions :math:`\geq 511`.
+    The small dst is quicker for simulations with :math:`\geq 511` transverse grid points.
     The default is set accordingly.
 
 Predictor-corrector loop parameters

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -92,9 +92,10 @@ Modeling ion motion is not yet supported by the explicit solver
     Which solver to use.
     Possible values: ``predictor-corrector`` and ``explicit``.
 
-* ``hipace.use_small_dst`` (`bool`) optional (default `0`)
+* ``hipace.use_small_dst`` (`bool`) optional (default `0` or `1`)
     Whether to use a large R2C or a small C2R fft in the dst of the Poisson solver.
-    The small dst can be much quicker for high resolutions.
+    The small dst can be much quicker for high resolutions :math:`\geq 511`.
+    The default is set accordingly.
 
 Predictor-corrector loop parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -232,7 +232,7 @@ namespace AnyDST
         DSTplan dst_plan;
 
         amrex::ParmParse pp("hipace");
-        dst_plan.use_small_dst = false;
+        dst_plan.use_small_dst = (std::max(real_size[0], real_size[1]) >= 511);
         pp.query("use_small_dst", dst_plan.use_small_dst);
 
         if(!dst_plan.use_small_dst) {


### PR DESCRIPTION
Running multiple tests, I found 511 to be a good point to start using the (new) small DST.

Each point is an average of three runs, except for 2047 and 4095 Cells.

In fp32 and 511 Cells there is outlier causing the average to be slower, however the other results are still 1,5% faster with the small DST.

All times are total runtimes of one Iteration with a beam. `hipace.do_device_synchronize = 1` to just measure `AnyDST::Execute()` was not used as it causes significant overhead, especially to the small DST.

![perf_test_dst_3](https://user-images.githubusercontent.com/64009254/124141692-e60e3e80-da89-11eb-8ca4-085d367ab061.png)

The user can still use a particular DST by specifying `hipace.use_small_dst = 0 or 1`.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
