### PR TITLE
[mini] add missing/errorenous CMake in build description

### DIFF
--- a/docs/source/building/platforms/booster_jsc.rst
+++ b/docs/source/building/platforms/booster_jsc.rst
@@ -13,6 +13,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    # please set your project account
    export proj=<your project id>
    # required dependencies
+   module load CMake
    module load GCC
    module load OpenMPI
    module load CUDA

--- a/docs/source/building/platforms/maxwell_desy.rst
+++ b/docs/source/building/platforms/maxwell_desy.rst
@@ -23,7 +23,7 @@ Install HiPACE++ (the first time, and whenever you want the latest version):
    rm -rf build
    mkdir build
    cd build
-   cmake .. -DHiPACE_COMPUTE=CUDA
+   cmake3 .. -DHiPACE_COMPUTE=CUDA
    make -j 16
 
 You can get familiar with the HiPACE++ input file format in our :doc:`../../run/get_started` section, to prepare an input file that suits your needs.


### PR DESCRIPTION
In the description to install HiPACE++ on JUWELS, the CMake module was missing.
On Maxwell, it should be `cmake3` instead of `cmake`.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
