### PR TITLE
CMake: FFTW Search w/ CMake Install

### DIFF
--- a/cmake/dependencies/FFT.cmake
+++ b/cmake/dependencies/FFT.cmake
@@ -15,17 +15,15 @@ function(fftw_add_define HAS_FFTW_OMP_LIB)
     endif()
 endfunction()
 
-# Check if the PkgConfig target location has an _omp library, e.g.,
-# libfftw3(f)_omp.a shipped and if yes, set the HIPACE_FFTW_OMP=1 define.
+# Check if the found FFTW install location has an _omp library, e.g.,
+# libfftw3(f)_omp.(a|so) shipped and if yes, set the HIPACE_FFTW_OMP=1 define.
 #
 function(fftw_check_omp library_paths fftw_precision_suffix)
-    if(HiPACE_FFTW_IGNORE_OMP)
-        fftw_add_define(FALSE)
-        return()
-    endif()
-
     find_library(HAS_FFTW_OMP_LIB fftw3${fftw_precision_suffix}_omp
         PATHS ${library_paths}
+        # this is intentional, so we don't mix different FFTW installs
+        # and only check what is in the location hinted by the
+        # "library_paths" variable
         NO_DEFAULT_PATH
         NO_PACKAGE_ROOT_PATH
         NO_CMAKE_PATH
@@ -87,9 +85,17 @@ elseif(NOT HiPACE_COMPUTE STREQUAL CUDA)
 
     if(HiPACE_FFTW_SEARCH STREQUAL CMAKE)
         find_package(FFTW3${HFFTWp} CONFIG REQUIRED)
+        set(HiPACE_FFTW_LIBRARY_DIRS "${FFTW3${HFFTWp}_LIBRARY_DIRS}")
+        message(STATUS "Found FFTW: ${FFTW3${HFFTWp}_DIR} (found version \"${FFTW3${HFFTWp}_VERSION}\")")
     else()
         find_package(PkgConfig REQUIRED QUIET)
         pkg_check_modules(fftw3${HFFTWp} REQUIRED IMPORTED_TARGET fftw3${HFFTWp})
+        message(STATUS "Found FFTW: ${fftw3${HFFTWp}_PREFIX}")
+        if(fftw3${HFFTWp}_LIBRARY_DIRS)
+            set(HiPACE_FFTW_LIBRARY_DIRS "${fftw3${HFFTWp}_LIBRARY_DIRS}")
+        else()
+            set(HiPACE_FFTW_LIBRARY_DIRS "${fftw3${HFFTWp}_LIBDIR}")
+        endif()
     endif()
 endif()
 
@@ -100,24 +106,18 @@ if(HiPACE_COMPUTE STREQUAL CUDA)
 elseif(HiPACE_COMPUTE STREQUAL HIP)
     make_third_party_includes_system(roc::rocfft FFT)
 else()
-    if(FFTW3_FOUND)
-        # subtargets: fftw3(p), fftw3(p)_threads, fftw3(p)_omp
-        if(HiPACE_COMPUTE STREQUAL OMP AND
-           TARGET FFTW3::fftw3${HFFTWp}_omp AND
-           NOT HiPACE_FFTW_IGNORE_OMP)
-            make_third_party_includes_system(FFTW3::fftw3${HFFTWp}_omp FFT)
-            fftw_add_define(TRUE)
-        else()
-            make_third_party_includes_system(FFTW3::fftw3${HFFTWp} FFT)
-            fftw_add_define(FALSE)
-        endif()
+    if(HiPACE_FFTW_SEARCH STREQUAL CMAKE)
+        make_third_party_includes_system(FFTW3::fftw3${HFFTWp} FFT)
     else()
         make_third_party_includes_system(PkgConfig::fftw3${HFFTWp} FFT)
-        if(HiPACE_COMPUTE STREQUAL OMP AND
-           NOT HiPACE_FFTW_IGNORE_OMP)
-            fftw_check_omp("${fftw3${HFFTWp}_LIBRARY_DIRS}" "${HFFTWp}")
+    endif()
+    if(HiPACE_COMPUTE STREQUAL OMP)
+        if(HiPACE_FFTW_IGNORE_OMP)
+            message(STATUS "FFTW: Requested to IGNORE OpenMP support")
         else()
-            fftw_add_define(FALSE)
+            fftw_check_omp("${HiPACE_FFTW_LIBRARY_DIRS}" "${HFFTWp}")
         endif()
+    else()
+        message(STATUS "FFTW: Did NOT search for OpenMP support (HiPACE_COMPUTE!=OMP)")
     endif()
 endif()


### PR DESCRIPTION
This adds support for FFTW search with OpenMP support if FFTW was installed with CMake. This is, for instance, the case with EasyBuild based installs on Juelich's JUWELS Booster cluster.

Fixes:
- the FFTW install does NOT define CMake targets for their sub-targets, so we need to manually find and link the `_omp` lib
- the library dir hint with CMake was empty because of a differing spelling (upper vs lowercase of FFTW from pkg-config check module)

Tested:
- installed with pkg-config, SP and DP, picked up with `*.pc`
- installed with CMake, SP and DP, picked up with `*config.cmake`
- installed with CMake, SP and DP, picked up with `*.pc`

System check:
- [x] still need to figure our why the `pkg-config` module set `fftw3${HFFTWp}_LIBRARY_DIRS` is unset on JUWELS (but `fftw3${HFFTWp}_PREFIX` is set

Follow-up to #541

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
