### PR TITLE
Add seed to write_beam.py to fix from_file test

### DIFF
--- a/tools/write_beam.py
+++ b/tools/write_beam.py
@@ -17,6 +17,7 @@ kp_inv = constants.c / constants.e * math.sqrt(constants.epsilon_0 * constants.m
 single_charge = (beam_density * beam_position_std[0] * beam_position_std[1] *
                  beam_position_std[2] * np.sqrt(2. * math.pi)**3 / n)
 
+np.random.seed(0)
 data = np.zeros([6,n],dtype=np.float64)
 
 for i in [0,1,2]:


### PR DESCRIPTION
Previously it was possible for `write_beam.py` to generate a beam file that had a beam particle outside of the simulation box, causing the particle to be reset and the test to fail. This was a 5.7 sigma outlier, with a 10e-8 chance, but with 10e6 beam particles it occasionally happened.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
