### PR TITLE
Field Interpolation

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -281,7 +281,7 @@ Hipace::MakeNewLevelFromScratch (
     DefineSliceGDB(lev, ba, dm);
     // Note: we pass ba[0] as a dummy box, it will be resized properly in the loop over boxes in Evolve
     m_diags.AllocData(lev, ba[0], Comps[WhichSlice::This]["N"], Geom(lev));
-    m_fields.AllocData(lev, Geom(), m_slice_ba[lev], m_slice_dm[lev]);
+    m_fields.AllocData(lev, Geom(), m_slice_ba[lev], m_slice_dm[lev], ref_ratio);
 }
 
 void

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -77,6 +77,7 @@ public:
      * \param[in] geom Geometry
      * \param[in] slice_ba BoxArray for the slice
      * \param[in] slice_dm DistributionMapping for the slice
+     * \param[in] ref_ratio mesh refinement ratio
      */
     void AllocData (
         int lev, amrex::Vector<amrex::Geometry> const& geom, const amrex::BoxArray& slice_ba,
@@ -146,13 +147,14 @@ public:
                                  const int sc1omp=0, const int s2comp=0, const int dcomp=0);
 
     /** \brief Interpolate values at boundaries from coarse grid to the fine grid
-     * ExmBy and EypBx are solved in the same function because both rely on Psi.
      *
      * \param[in] geom Geometry
-     * \param[in] component which can be Psi, Ez, By,Bx ...
+     * \param[in] component which can be Psi, Ez, By, Bx ...
      * \param[in] lev current level
      */
-    void InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom,const int lev, std::string component);
+    void InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom,const int lev,
+                                std::string component);
+
     /** \brief Compute ExmBy and EypBx on the slice container from J by solving a Poisson equation
      * ExmBy and EypBx are solved in the same function because both rely on Psi.
      *

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -144,8 +144,8 @@ public:
                                  const amrex::Real mult_coeff=1.,
                                  const SliceOperatorType slice_operator=SliceOperatorType::Assign,
                                  const int sc1omp=0, const int s2comp=0, const int dcomp=0);
-    
-    /** \brief Interpolate values at boundaries from coarse grid to the fine grid 
+
+    /** \brief Interpolate values at boundaries from coarse grid to the fine grid
      * ExmBy and EypBx are solved in the same function because both rely on Psi.
      *
      * \param[in] geom Geometry

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -80,7 +80,7 @@ public:
      */
     void AllocData (
         int lev, amrex::Vector<amrex::Geometry> const& geom, const amrex::BoxArray& slice_ba,
-        const amrex::DistributionMapping& slice_dm);
+        const amrex::DistributionMapping& slice_dm, amrex::Vector<amrex::IntVect> const& ref_ratio);
 
     /** Class to handle transverse FFT Poisson solver on 1 slice */
     amrex::Vector<std::unique_ptr<FFTPoissonSolver>> m_poisson_solver;
@@ -247,6 +247,7 @@ private:
     amrex::IntVect m_slices_nguards {-1, -1, -1};
     /** Whether to use Dirichlet BC for the Poisson solver. Otherwise, periodic */
     bool m_do_dirichlet_poisson = true;
+    amrex::IntVect m_ref_ratio;
 };
 
 #endif

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -144,7 +144,15 @@ public:
                                  const amrex::Real mult_coeff=1.,
                                  const SliceOperatorType slice_operator=SliceOperatorType::Assign,
                                  const int sc1omp=0, const int s2comp=0, const int dcomp=0);
-
+    
+    /** \brief Interpolate values at boundaries from coarse grid to the fine grid 
+     * ExmBy and EypBx are solved in the same function because both rely on Psi.
+     *
+     * \param[in] geom Geometry
+     * \param[in] component which can be Psi, Ez, By,Bx ...
+     * \param[in] lev current level
+     */
+    void InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom,const int lev, std::string component);
     /** \brief Compute ExmBy and EypBx on the slice container from J by solving a Poisson equation
      * ExmBy and EypBx are solved in the same function because both rely on Psi.
      *

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -149,10 +149,10 @@ public:
     /** \brief Interpolate values at boundaries from coarse grid to the fine grid
      *
      * \param[in] geom Geometry
-     * \param[in] component which can be Psi, Ez, By, Bx ...
      * \param[in] lev current level
+     * \param[in] component which can be Psi, Ez, By, Bx ...
      */
-    void InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom,const int lev,
+    void InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                                 std::string component);
 
     /** \brief Compute ExmBy and EypBx on the slice container from J by solving a Poisson equation

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -249,7 +249,7 @@ private:
     amrex::IntVect m_slices_nguards {-1, -1, -1};
     /** Whether to use Dirichlet BC for the Poisson solver. Otherwise, periodic */
     bool m_do_dirichlet_poisson = true;
-    amrex::IntVect m_ref_ratio;
+    amrex::IntVect m_ref_ratio; /**< refinement ratio in {x, y, z} */
 };
 
 #endif

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -248,7 +248,7 @@ Fields::InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom, const
 {
     // To solve a Poisson equation with non-zero Dirichlet boundary conditions, the source term
     // must be corrected at the outmost grid points in x by -field_value_at_boundary / dx^2 and
-    // in y by -field_value_at_boundary / dy^2
+    // in y by -field_value_at_boundary / dy^2, where dx and dy are those of the fine grid
     HIPACE_PROFILE("Fields::InterpolateBoundaries()");
     if (lev == 0) return; // only interpolate boundaries to lev 1
     using namespace amrex::literals;

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -244,8 +244,8 @@ Fields::AddBeamCurrents (const int lev, const int which_slice)
 
 
 void
-Fields::InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom,
-                                    const int lev, std::string component)
+Fields::InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom, const int lev,
+                               std::string component)
 {
     // To solve a Poisson equation with non-zero Dirichlet boundary conditions, the source term
     // must be corrected at the outmost grid points in x by -field_value_at_boundary / dx^2 and

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -242,7 +242,6 @@ Fields::AddBeamCurrents (const int lev, const int which_slice)
     }
 }
 
-
 void
 Fields::InterpolateBoundaries (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                                std::string component)


### PR DESCRIPTION
Edit by Severin:

Solving a Poisson equation with non-zero boundary conditions requires that the source term is corrected at the outmost grid points in x by `- alpha/dx^2` and in y by `- alpha/dy^2` . 

This PR adds the function to interpolate the field values of the coarse grid (`lev = 0`) to the source term on the fine grid (`lev = 1`) in the Poisson solver via bilinear interpolation.

The bilinear interpolation is done via:
![Screenshot from 2021-07-09 12-55-06](https://user-images.githubusercontent.com/65728274/125067821-07d47a80-e0b5-11eb-8d54-6ffc06387411.png)
with 
![Screenshot from 2021-07-09 12-55-12](https://user-images.githubusercontent.com/65728274/125067839-0dca5b80-e0b5-11eb-9039-4b658d6369a3.png)
![Screenshot from 2021-07-09 12-55-21](https://user-images.githubusercontent.com/65728274/125067845-0f941f00-e0b5-11eb-9d6f-52664f523bdb.png)
![Screenshot from 2021-07-09 12-55-26](https://user-images.githubusercontent.com/65728274/125067852-11f67900-e0b5-11eb-80b3-e8692d1186e9.png)
![Screenshot from 2021-07-09 12-55-32](https://user-images.githubusercontent.com/65728274/125067866-158a0000-e0b5-11eb-96f5-ae3d4042971f.png)
(equations from https://fr.wikipedia.org/wiki/Interpolation_bilin%C3%A9aire)

This PR is tested by a beam in vacuum example. A full fine grid is used (`256 x 256 x 50` cells) and compared against a coarse grid (`64 x 64 x 50` cells) + a refined grid (refinement ratio `4 x 4 x 1`). 

As it can be seen, the refined grid shows good agreement with the full fine grid. Differences can be attributed to the fact that the field on the coarse grid is not the same as the full fine grid at the boundary.

![image](https://user-images.githubusercontent.com/65728274/125068435-c395aa00-e0b5-11eb-8a03-cc4d0c7349dc.png)

The speedup of the MR run is 2.5x, however this strongly depends on the setting and will increase up to orders of magnitude for other examples.

Known issues:
- MR currently does not work on GPU, which is not related to this PR, but to the field solver itself
- The transverse derivative gives some problems, which can be seen in this refined grid in a full blowout:
![image](https://user-images.githubusercontent.com/65728274/125069362-eeccc900-e0b6-11eb-915d-0acf6b345c19.png)
There are two issues: 1. the transverse derivative must take into account the edge of the fine box properly. This could be done by filling the guard cell of the fine grid by interpolation from the coarse grid. 2. at second deposition order, there are contributions missing in the next-to-last grid point of the current arrays, which is reflected in an incorrect Psi at this.
The handling of the boundary on the fine grid needs some improvement.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
