### PR TITLE
[mini] remove unused parameters

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -252,8 +252,6 @@ Hipace::MakeNewLevelFromScratch (
     // We are going to ignore the DistributionMapping argument and build our own.
     amrex::DistributionMapping dm;
     {
-        const amrex::IntVect ncells_global = Geom(lev).Domain().length();
-        const amrex::IntVect box_size = ba[0].length();  // Uniform box size
         const int nboxes_x = m_numprocs_x;
         const int nboxes_y = m_numprocs_y;
         const int nboxes_z = (m_boxes_in_z == 1) ? m_numprocs_z : m_boxes_in_z;


### PR DESCRIPTION
Follow up to #546. Two unused parameters are removed. This fixes a compiler warning.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
