### PR TITLE
Mesh refinement: pass the correct ProbLoArray to enforcePeriodic

### DIFF
--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -66,7 +66,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
 
     const auto getPosition = GetParticlePosition<BeamParticleContainer>(beam, offset);
     const auto setPosition = SetParticlePosition<BeamParticleContainer>(beam, offset);
-    const auto enforceBC = EnforceBC<BeamParticleContainer>(beam, lev, offset);
+    const auto enforceBC = EnforceBC<BeamParticleContainer>(beam, lev, box, offset);
 
     const amrex::Real zmin = xyzmin[2];
 
@@ -113,7 +113,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
                 yp += dt * 0.5_rt * uyp[ip] / gammap;
 
                 setPosition(ip, xp, yp, zp);
-                if (enforceBC(ip)) return;
+                if (enforceBC(ip, lev)) return;
 
                 // define field at particle position reals
                 amrex::ParticleReal ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
@@ -165,7 +165,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::G
                 yp += dt * 0.5_rt * uy_next  / gamma_next;
                 if (do_z_push) zp += dt * ( uz_next  / gamma_next - phys_const.c );
                 setPosition(ip, xp, yp, zp);
-                if (enforceBC(ip)) return;
+                if (enforceBC(ip, lev)) return;
                 uxp[ip] = ux_next;
                 uyp[ip] = uy_next;
                 uzp[ip] = uz_next;

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -166,7 +166,6 @@ struct EnforceBC
             const amrex::IntVect& big = box.bigEnd();
 
             const auto plo = m_plo;
-            const auto phi = m_phi;
             m_plo_lev1 = {{AMREX_D_DECL(plo[0]+(small[0]+0.5)*dx[0], plo[1]+(small[1]+0.5)*dx[1],
                                         plo[2]+(small[2]+0.5)*dx[2])}};
             m_phi_lev1 =  {{AMREX_D_DECL(plo[0]+(big[0]+0.5)*dx[0], plo[1]+(big[1]+0.5)*dx[1],

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -170,7 +170,6 @@ struct EnforceBC
                                         plo[2]+(small[2]+0.5)*dx[2])}};
             m_phi_lev1 =  {{AMREX_D_DECL(plo[0]+(big[0]+0.5)*dx[0], plo[1]+(big[1]+0.5)*dx[1],
                                          plo[2]+(big[2]+0.5)*dx[2])}};
-        // amrex::Print() << " m_plo_lev1 " << m_plo_lev1[0] << " " << m_plo_lev1[1] << " " << m_plo_lev1[2]  << " m_phi_lev1 " << m_phi_lev1[0] << " " << m_phi_lev1[1] << " "<< m_phi_lev1[2] << "\n";
         } else {
             amrex::ignore_unused(box);
         }

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -141,21 +141,40 @@ struct EnforceBC
 
     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_plo;
     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_phi;
+    amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_plo_lev1;
+    amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> m_phi_lev1;
     amrex::GpuArray<int,AMREX_SPACEDIM> m_is_per;
     amrex::GpuArray<int,AMREX_SPACEDIM> m_periodicity;
 
     /** Constructor.
      * \param a_ptile tile containing the macroparticles
      * \param lev level of MR
+     * \param box box to get the correct physical boundaries
      * \param a_offset offset to apply to the particle indices
      */
-    EnforceBC (T_ParTile& a_ptile, const int lev, int a_offset = 0) noexcept
+    EnforceBC (T_ParTile& a_ptile, const int lev, const amrex::Box box, int a_offset = 0) noexcept
     {
 
         m_plo    = Hipace::GetInstance().Geom(lev).ProbLoArray();
         m_phi    = Hipace::GetInstance().Geom(lev).ProbHiArray();
         m_is_per = Hipace::GetInstance().Geom(lev).isPeriodicArray();
         AMREX_ALWAYS_ASSERT(m_is_per[0] == m_is_per[1]);
+
+        if (lev == 1) {
+            const auto dx = Hipace::GetInstance().Geom(lev).CellSizeArray();
+            const amrex::IntVect& small = box.smallEnd();
+            const amrex::IntVect& big = box.bigEnd();
+
+            const auto plo = m_plo;
+            const auto phi = m_phi;
+            m_plo_lev1 = {{AMREX_D_DECL(plo[0]+(small[0]+0.5)*dx[0], plo[1]+(small[1]+0.5)*dx[1],
+                                        plo[2]+(small[2]+0.5)*dx[2])}};
+            m_phi_lev1 =  {{AMREX_D_DECL(plo[0]+(big[0]+0.5)*dx[0], plo[1]+(big[1]+0.5)*dx[1],
+                                         plo[2]+(big[2]+0.5)*dx[2])}};
+        // amrex::Print() << " m_plo_lev1 " << m_plo_lev1[0] << " " << m_plo_lev1[1] << " " << m_plo_lev1[2]  << " m_phi_lev1 " << m_phi_lev1[0] << " " << m_phi_lev1[1] << " "<< m_phi_lev1[2] << "\n";
+        } else {
+            amrex::ignore_unused(box);
+        }
 
         m_periodicity = {true, true, false};
 
@@ -168,13 +187,20 @@ struct EnforceBC
     /** \brief enforces the boundary condition to the particle at index `i + a_offset`
      * and returns if the particle is invalid
      * \param[in] ip index of the particle
+     * \param[in] lev level of mesh refinement
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator() (const int ip) const noexcept
+    bool operator() (const int ip, const int lev) const noexcept
     {
         using namespace amrex::literals;
 
-        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_periodicity);
+        bool shifted;
+        if (lev == 0) {
+            shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_periodicity);
+        } else {
+            shifted = enforcePeriodic(m_structs[ip], m_plo_lev1, m_phi_lev1, m_periodicity);
+        }
+
         const bool invalid = (shifted && !m_is_per[0]);
         if (invalid) {
             m_weights[ip] = 0.0_rt;

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -109,7 +109,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
         using PTileType = PlasmaParticleContainer::ParticleTileType;
         const auto getPosition = GetParticlePosition<PTileType>(pti.GetParticleTile());
         const auto SetPosition = SetParticlePosition<PTileType>(pti.GetParticleTile());
-        const auto enforceBC = EnforceBC<PTileType>(pti.GetParticleTile(), lev);
+        const auto enforceBC = EnforceBC<PTileType>(pti.GetParticleTile(), lev, pti.tilebox());
         const amrex::Real zmin = xyzmin[2];
         const amrex::Real dz = dx[2];
 
@@ -162,7 +162,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
                                        Fx3[ip], Fy3[ip], Fux3[ip], Fuy3[ip], Fpsi3[ip],
                                        Fx4[ip], Fy4[ip], Fux4[ip], Fuy4[ip], Fpsi4[ip],
                                        Fx5[ip], Fy5[ip], Fux5[ip], Fuy5[ip], Fpsi5[ip],
-                                       dz, temp_slice, ip, SetPosition, enforceBC );
+                                       dz, temp_slice, ip, SetPosition, enforceBC, lev );
                 }
                 return;
           }

--- a/src/particles/pusher/PushPlasmaParticles.H
+++ b/src/particles/pusher/PushPlasmaParticles.H
@@ -51,6 +51,7 @@
  * \param[in] ip index of the plasma particle
  * \param[in] SetPosition Functor for setting the particle position
  * \param[in] enforceBC Functor for applying the boundary conditions to a single plasma particle
+ * \param[in] lev level of mesh refinement
  */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void PlasmaParticlePush (
@@ -87,7 +88,8 @@ void PlasmaParticlePush (
     const bool temp_slice,
     const long ip,
     const SetParticlePosition<PlasmaParticleContainer::ParticleTileType>& SetPosition,
-    const EnforceBC<PlasmaParticleContainer::ParticleTileType>& enforceBC )
+    const EnforceBC<PlasmaParticleContainer::ParticleTileType>& enforceBC,
+    const int lev)
 
 {
     using namespace amrex::literals;
@@ -106,7 +108,7 @@ void PlasmaParticlePush (
             + a4_times_dz * Fy4 + a5_times_dz * Fy5;
 
         SetPosition(ip, xp, yp, zp);
-        if (enforceBC(ip)) return;
+        if (enforceBC(ip, lev)) return;
 
         x_prev = xp;
         y_prev = yp;
@@ -125,7 +127,7 @@ void PlasmaParticlePush (
                  + a4_times_dz * Fy4 + a5_times_dz * Fy5 );
 
         SetPosition(ip, xp, yp, zp);
-        if (enforceBC(ip)) return;
+        if (enforceBC(ip, lev)) return;
         ux_temp = uxp - ( a1_times_dz * Fux1 + a2_times_dz * Fux2 + a3_times_dz * Fux3
                   + a4_times_dz * Fux4 + a5_times_dz * Fux5 );
         uy_temp = uyp - ( a1_times_dz * Fuy1 + a2_times_dz * Fuy2 + a3_times_dz * Fuy3


### PR DESCRIPTION
Previously, we used the `enforceBC` to ensure that (beam or plasma) particles, which left the domain, were handled correctly. 

In our current implementation, plasma particles are not allowed to move between levels. This caused the problem, that when a plasma particle left level 1 (but was still on level 0), it was not "out of the domain" from the view of `enforceBC`, but it would try to access grid points outside of the domain of level 1 in the current deposition, causing segfaults.

This PR proposes to save the `ProbLoArray` in `EnforceBC` per level and then use it accordingly. It solves the problem.
In the current implementation, level 0 and level 1 are hardcoded as member variables. This should become a vector over levels.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
