### PR TITLE
Fix: CUDA Host-Side -O3 with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,8 @@ endif()
 
 option(HiPACE_amrex_internal "Download & build AMReX" ON)
 
-# change the default build type to RelWithDebInfo (or Release) instead of Debug
-set_default_build_type("RelWithDebInfo")
+# change the default build type to Release (or RelWithDebInfo) instead of Debug
+set_default_build_type("Release")
 
 # this defined the variable BUILD_TESTING which is ON by default
 include(CTest)

--- a/cmake/HiPACEFunctions.cmake
+++ b/cmake/HiPACEFunctions.cmake
@@ -72,13 +72,6 @@ macro(set_default_build_type default_build_type)
             set_property(CACHE CMAKE_BUILD_TYPE
                     PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES})
         endif()
-
-        # RelWithDebInfo uses -O2 which is sub-ideal for how it is intended to be used
-        #   https://gitlab.kitware.com/cmake/cmake/-/merge_requests/591
-        list(TRANSFORM CMAKE_C_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
-        list(TRANSFORM CMAKE_CXX_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
-        # FIXME: due to the "AMReX inits CUDA first" logic we will first see this with -O2 in output
-        list(TRANSFORM CMAKE_CUDA_FLAGS_RELWITHDEBINFO REPLACE "-O2" "-O3")
     endif()
 endmacro()
 

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -156,7 +156,7 @@ or by providing arguments to the CMake call
 =============================  ========================================  =====================================================
  CMake Option                  Default & Values                          Description
 -----------------------------  ----------------------------------------  -----------------------------------------------------
- ``CMAKE_BUILD_TYPE``          **RelWithDebInfo**/Release/Debug          Type of build, symbols & optimizations
+ ``CMAKE_BUILD_TYPE``          RelWithDebInfo/**Release**/Debug          Type of build, symbols & optimizations
  ``HiPACE_COMPUTE``            **NOACC**/CUDA/SYCL/HIP/OMP               On-node, accelerated computing backend
  ``HiPACE_MPI``                **ON**/OFF                                Multi-node support (message-passing)
  ``HiPACE_PRECISION``          SINGLE/**DOUBLE**                         Floating point precision (single/double)


### PR DESCRIPTION
`-O3` was only set for CUDA if we ran CMake at least twice. This was
an intialization logic bug and should be set from the beginning, but
we initialized CUDA too late / applied the transform too early.

We now change the default build type to `Release` to avoid changing
defaults and avoid further surprises.

We will add optional `-g` for optimized builds again on a later PR.

Same as: https://github.com/ECP-WarpX/WarpX/pull/2078 and similar implications as in #71. With the herein fixed issue for CUDA builds, the host-side default optimization was taken (GCC: `-O0` but NVCC device-side is still defaulting to `-O3`). We saw ~30% performance regressions for GPU runs with WarpX with this unoptimized host code path for CUDA translation units.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
