### PR TITLE
Mesh refinement: fix slice IO

### DIFF
--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -110,8 +110,9 @@ Diagnostic::TrimIOBox (const amrex::Box box_3d)
     amrex::Box slice_bx = box_3d;
     if (m_slice_dir >= 0){
             // Flatten the box down to 1 cell in the approprate direction.
-            slice_bx.setSmall(m_slice_dir, box_3d.length(m_slice_dir)/2);
-            slice_bx.setBig  (m_slice_dir, box_3d.length(m_slice_dir)/2);
+            const int idx = box_3d.smallEnd(m_slice_dir) + box_3d.length(m_slice_dir)/2;
+            slice_bx.setSmall(m_slice_dir, idx);
+            slice_bx.setBig  (m_slice_dir, idx);
     }
     // m_F is defined on F_bx, the full or the slice Box
     amrex::Box F_bx = m_slice_dir >= 0 ? slice_bx : box_3d;


### PR DESCRIPTION
Slice IO was broken for the refined mesh.
The reason was that the slice box was created by setting the index to the length of the box divided by 2.
For the refined mesh an offset was required, which is added in this PR.

Using this PR, the slice IO works flawlessly for the refined grid.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
