### PR TITLE
[mini] use _rt in GetDomainLev

### DIFF
--- a/src/particles/pusher/GetDomainLev.H
+++ b/src/particles/pusher/GetDomainLev.H
@@ -8,6 +8,7 @@ namespace
     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> GetDomainLev (
         const amrex::Geometry& gm, const amrex::Box& box, bool is_lo, int lev)
     {
+        using namespace amrex::literals;
         if (lev == 0) {
             return is_lo ? gm.ProbLoArray() : gm.ProbHiArray();
         } else {
@@ -16,13 +17,13 @@ namespace
             const amrex::IntVect& big = box.bigEnd();
             const auto plo = gm.ProbLoArray();
             if (is_lo) {
-                return {{AMREX_D_DECL(plo[0]+(small[0]+0.5)*dx[0],
-                                      plo[1]+(small[1]+0.5)*dx[1],
-                                      plo[2]+(small[2]+0.5)*dx[2])}};
+                return {{AMREX_D_DECL(plo[0]+(small[0]+0.5_rt)*dx[0],
+                                      plo[1]+(small[1]+0.5_rt)*dx[1],
+                                      plo[2]+(small[2]+0.5_rt)*dx[2])}};
             } else {
-                return {{AMREX_D_DECL(plo[0]+(big[0]+0.5)*dx[0],
-                                      plo[1]+(big[1]+0.5)*dx[1],
-                                      plo[2]+(big[2]+0.5)*dx[2])}};
+                return {{AMREX_D_DECL(plo[0]+(big[0]+0.5_rt)*dx[0],
+                                      plo[1]+(big[1]+0.5_rt)*dx[1],
+                                      plo[2]+(big[2]+0.5_rt)*dx[2])}};
             }
         }
     }


### PR DESCRIPTION
This PR fixes a float to double conversion issue in GetDomainLev and removes a warning if compiled on GPU and single precision


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
