### PR TITLE
[mini] print precision in output

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -231,7 +231,12 @@ void
 Hipace::InitData ()
 {
     HIPACE_PROFILE("Hipace::InitData()");
-    amrex::Print() << "HiPACE++ (" << Hipace::Version() << ")\n";
+#ifdef AMREX_USE_FLOAT
+    amrex::Print() << "HiPACE++ (" << Hipace::Version() << ") running in single precision\n";
+#else
+    amrex::Print() << "HiPACE++ (" << Hipace::Version() << ") running in double precision\n";
+#endif
+
 
     amrex::Vector<amrex::IntVect> new_max_grid_size;
     for (int ilev = 0; ilev <= maxLevel(); ++ilev) {


### PR DESCRIPTION
This PR prints the precision in the output, so one knows, if the simulation was run in single or double precision:

```
Initializing CUDA...
CUDA initialized with 1 GPU per MPI rank; 1 GPU(s) used in total
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (21.07-55-gb87ec0a8fc08) initialized
HiPACE++ (f05da101a027) running in single precision
```

```
Initializing CUDA...
CUDA initialized with 1 GPU per MPI rank; 1 GPU(s) used in total
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (21.07-51-g5619ef246175) initialized
HiPACE++ (ec18bf7a9c74) running in double precision
```

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
