### PR TITLE
openPMD-api: 0.14.2

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -118,7 +118,7 @@ macro(find_amrex)
         mark_as_advanced(AMReX_FPE)
         mark_as_advanced(AMReX_FORTRAN)
         mark_as_advanced(AMReX_FORTRAN_INTERFACES)
-        mark_as_advanced(AMReX_HDF5)  # we will do HDF5 I/O (and more) via openPMD-api
+        mark_as_advanced(AMReX_HDF5)  # we do HDF5 I/O (and more) via openPMD-api
         mark_as_advanced(AMReX_LINEAR_SOLVERS)
         mark_as_advanced(AMReX_MEM_PROFILE)
         mark_as_advanced(AMReX_MPI)

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -10,7 +10,7 @@ function(find_openpmd)
     if(HiPACE_openpmd_internal OR HiPACE_openpmd_src)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-        # see https://openpmd-api.readthedocs.io/en/0.13.1-alpha/dev/buildoptions.html
+        # see https://openpmd-api.readthedocs.io/en/0.14.2/dev/buildoptions.html
         set(openPMD_USE_MPI         ${HiPACE_MPI} CACHE INTERNAL "")
         set(openPMD_USE_PYTHON      OFF           CACHE INTERNAL "")
         set(openPMD_BUILD_CLI_TOOLS OFF           CACHE INTERNAL "")
@@ -65,7 +65,7 @@ function(find_openpmd)
         else()
             set(COMPONENT_WMPI NOMPI)
         endif()
-        find_package(openPMD 0.13.0 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
+        find_package(openPMD 0.14.2 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
         message(STATUS "openPMD-api: Found version '${openPMD_VERSION}'")
     endif()
 endfunction()
@@ -81,7 +81,7 @@ if(HiPACE_OPENPMD)
     set(HiPACE_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(HiPACE_openpmd_internal)")
-    set(HiPACE_openpmd_branch "ac083025ee662469b8cad1adf93eef48cde35f58"
+    set(HiPACE_openpmd_branch "0.14.2"
         CACHE STRING
         "Repository branch for HiPACE_openpmd_repo if(HiPACE_openpmd_internal)")
 

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -32,10 +32,10 @@ Please see installation instructions below in the Developers section.
 - a mature `C++14 <https://en.wikipedia.org/wiki/C%2B%2B14>`__ compiler: e.g. GCC 5, Clang 3.6 or newer
 - `CMake 3.15.0+ <https://cmake.org/>`__
 - `AMReX development <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
-- `openPMD-api dev <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api
+- `openPMD-api 0.14.2+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api
 
   - `HDF5 <https://support.hdfgroup.org/HDF5>`__ 1.8.13+ (optional; for ``.h5`` file support)
-  - `ADIOS2 <https://github.com/ornladios/ADIOS2>`__ 2.6.0+ (optional; for ``.bp`` file support)
+  - `ADIOS2 <https://github.com/ornladios/ADIOS2>`__ 2.7.0+ (optional; for ``.bp`` file support)
 - Nvidia GPU support: `CUDA Toolkit 9.0+ <https://developer.nvidia.com/cuda-downloads>`__ (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`__)
 - CPU-only: `FFTW3 <http://www.fftw.org/>`__ (only used serially; *not* needed for Nvidia GPUs)
 
@@ -171,19 +171,19 @@ HiPACE++ can be configured in further detail with options from AMReX, which are 
 **Developers** might be interested in additional options that control dependencies of HiPACE++.
 By default, the most important dependencies of HiPACE++ are automatically downloaded for convenience:
 
-===========================  =============================================  ============================================================
-CMake Option                 Default & Values                               Description
----------------------------  ---------------------------------------------  ------------------------------------------------------------
-``HiPACE_amrex_src``         *None*                                         Path to AMReX source directory (preferred if set)
-``HiPACE_amrex_repo``        `https://github.com/AMReX-Codes/amrex.git`     Repository URI to pull and build AMReX from
-``HiPACE_amrex_branch``      ``development``                                Repository branch for ``HiPACE_amrex_repo``
-``HiPACE_amrex_internal``    **ON**/OFF                                     Needs a pre-installed AMReX library if set to ``OFF``
-``HiPACE_openpmd_src``       *None*                                         Path to openPMD-api source directory (preferred if set)
-``HiPACE_openpmd_repo``      `https://github.com/openPMD/openPMD-api.git`   Repository URI to pull and build openPMD-api from
-``HiPACE_openpmd_branch``    `0.13.2`                                       Repository branch for ``HiPACE_openpmd_repo``
-``HiPACE_openpmd_internal``  **ON**/OFF                                     Needs a pre-installed openPMD-api library if set to ``OFF``
-``AMReX_LINEAR_SOLVERS``     **ON**/OFF                                     Compile AMReX multigrid solver. Required for explicit solver
-===========================  =============================================  ============================================================
+===========================  ==============================================  ============================================================
+CMake Option                 Default & Values                                Description
+---------------------------  ----------------------------------------------  ------------------------------------------------------------
+``HiPACE_amrex_src``         *None*                                          Path to AMReX source directory (preferred if set)
+``HiPACE_amrex_repo``        ``https://github.com/AMReX-Codes/amrex.git``    Repository URI to pull and build AMReX from
+``HiPACE_amrex_branch``      ``development``                                 Repository branch for ``HiPACE_amrex_repo``
+``HiPACE_amrex_internal``    **ON**/OFF                                      Needs a pre-installed AMReX library if set to ``OFF``
+``HiPACE_openpmd_src``       *None*                                          Path to openPMD-api source directory (preferred if set)
+``HiPACE_openpmd_repo``      ``https://github.com/openPMD/openPMD-api.git``  Repository URI to pull and build openPMD-api from
+``HiPACE_openpmd_branch``    ``0.14.2``                                      Repository branch for ``HiPACE_openpmd_repo``
+``HiPACE_openpmd_internal``  **ON**/OFF                                      Needs a pre-installed openPMD-api library if set to ``OFF``
+``AMReX_LINEAR_SOLVERS``     **ON**/OFF                                      Compile AMReX multigrid solver. Required for explicit solver
+===========================  ==============================================  ============================================================
 
 For example, one can also build against a local AMReX copy.
 Assuming AMReX' source is located in ``$HOME/src/amrex``, add the ``cmake`` argument ``-DHiPACE_amrex_src=$HOME/src/amrex``.


### PR DESCRIPTION
Update to the next major release of openPMD-api.

> **Resize, Dask, openpmd-pipe and new ADIOS2 Iteration Encoding**
>
> This release adds support for resizable data sets. For data-processing, support for Dask (parallel) and Pandas (serial) are added and lazy reader parsing of iterations is now supported. ADIOS2 adds an experimental variable-based iteration encoding. An openPMD Series can now be flushed from non-Series objects and write buffers can be requested upfront to avoid unnecessary data copies in some situations.

Changelog:
  https://openpmd-api.readthedocs.io/en/0.14.2/install/changelog.html

Upgrade Guide:
  https://openpmd-api.readthedocs.io/en/0.14.2/install/upgrade.html

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
