### PR TITLE
use correct inputs in NotifyFinish

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -153,7 +153,7 @@ Hipace::~Hipace ()
 {
 #ifdef AMREX_USE_MPI
     NotifyFinish();
-    NotifyFinish(true);
+    NotifyFinish(0, true);
     MPI_Comm_free(&m_comm_xy);
     MPI_Comm_free(&m_comm_z);
 #endif


### PR DESCRIPTION
We noticed incomplete communication calls on JUWELS by the following error:
```
[1630593559.537108] [jwb0097:21399:0]          mpool.c:43   UCX  WARN  object 0x1a214d00 was not returned to mpool ucp_requests
[1630593559.537689] [jwb0097:21396:0]          mpool.c:43   UCX  WARN  object 0x19786d00 was not returned to mpool ucp_requests
[1630593559.539651] [jwb0097:21398:0]          mpool.c:43   UCX  WARN  object 0x19d59980 was not returned to mpool ucp_requests
[1630593559.538533] [jwb0097:21397:0]          mpool.c:43   UCX  WARN  object 0x194ddd00 was not returned to mpool ucp_requests
```

This was caused by incorrect inputs into `NotifyFinish`, which was called via `    NotifyFinish(true);`, but should have been `    NotifyFinish(0 ,true);`, because the finishing of the ghost particle send must be on box 0. (The box parameter was simply missing).

This PR fixes the problem and removes the error.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
