### PR TITLE
Initialize m_phys_const earlier

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -190,6 +190,15 @@ public:
     /** status of the physical time send request */
     MPI_Request m_tsend_request = MPI_REQUEST_NULL;
 
+private:
+    /** Pointer to current (and only) instance of class Hipace */
+    static Hipace* m_instance;
+public:
+    /** Whether to use normalized units */
+    static bool m_normalized_units;
+    /** Struct containing physical constants (which values depends on the unit system, determined
+     * at runtime): SI or normalized units. */
+    PhysConst m_phys_const;
     /** All field data (3D array, slices) and field methods */
     Fields m_fields;
     /** Contains all beam species */
@@ -208,11 +217,6 @@ public:
     static amrex::Real m_physical_time;
     /** Level of verbosity */
     static int m_verbose;
-    /** Whether to use normalized units */
-    static bool m_normalized_units;
-    /** Struct containing physical constants (which values depends on the unit system, determined
-     * at runtime): SI or normalized units. */
-    PhysConst m_phys_const;
     /** Order of the field gather and current deposition shape factor in the transverse directions
      */
     static int m_depos_order_xy;
@@ -292,9 +296,6 @@ public:
     amrex::RealVect patch_lo {0., 0., 0.}; /**< 3D array with lower ends of the refined grid */
     amrex::RealVect patch_hi {0., 0., 0.}; /**< 3D array with upper ends of the refined grid */
 private:
-    /** Pointer to current (and only) instance of class Hipace */
-    static Hipace* m_instance;
-
     amrex::Vector<amrex::Geometry> m_slice_geom;
     amrex::Vector<amrex::DistributionMapping> m_slice_dm;
     amrex::Vector<amrex::BoxArray> m_slice_ba;
@@ -347,8 +348,6 @@ private:
      */
     void PredictorCorrectorLoopToSolveBxBy (const int islice_local, const int lev,
                         const amrex::Box bx, amrex::Vector<BeamBins> bins, const int ibox);
-
-    void Ionisation (const int lev);
 
     /** \brief define Geometry, DistributionMapping and BoxArray for the slice.
      * The slice MultiFAB and the plasma particles are defined on this GDB.

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -7,13 +7,7 @@ namespace
 {
     void QueryElementSetChargeMass (amrex::ParmParse& pp, amrex::Real& charge, amrex::Real& mass)
     {
-        // normalized_units is directly queried here so we can defined the appropriate PhysConst
-        // locally. We cannot use Hipace::m_phys_const as it has not been initialized when the
-        // PlasmaParticleContainer constructor is called.
-        amrex::ParmParse pph("hipace");
-        bool normalized_units = false;
-        pph.query("normalized_units", normalized_units);
-        PhysConst phys_const = normalized_units ? make_constants_normalized() : make_constants_SI();
+        PhysConst phys_const = get_phys_const();
 
         std::string element = "electron";
         pp.query("element", element);

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -11,13 +11,7 @@
 void
 PlasmaParticleContainer::ReadParameters ()
 {
-    // normalized_units is directly queried here so we can defined the appropriate PhysConst
-    // locally. We cannot use Hipace::m_phys_const as it has not been initialized when the
-    // PlasmaParticleContainer constructor is called.
-    amrex::ParmParse pph("hipace");
-    bool normalized_units = false;
-    pph.query("normalized_units", normalized_units);
-    PhysConst phys_const = normalized_units ? make_constants_normalized() : make_constants_SI();
+    PhysConst phys_const = get_phys_const();
 
     amrex::ParmParse pp(m_name);
     std::string element = "";
@@ -51,7 +45,7 @@ PlasmaParticleContainer::ReadParameters ()
     pp.query("can_ionize", m_can_ionize);
     if(m_can_ionize) {
         m_neutralize_background = false; // change default
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!normalized_units,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!Hipace::GetInstance().m_normalized_units,
             "Cannot use Ionization Module in normalized units");
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_init_ion_lev >= 0,
             "The initial Ion level must be specified");


### PR DESCRIPTION
Previously ` get_phys_const()` wasn’t available in the constructors of `Fields`, `MultiBeam` and `MultiPlasma`, in which a lot of initialization and reading of input parameters is done.
Now these functions can call ` get_phys_const()`. 

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
