### PR TITLE
only call BeamParticleContainer::ReadParameters() once per Beam

### DIFF
--- a/src/particles/BoxSort.cpp
+++ b/src/particles/BoxSort.cpp
@@ -38,7 +38,7 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
 
     amrex::Gpu::exclusive_scan(m_box_counts.begin(), m_box_counts.end(), m_box_offsets.begin());
 
-    BeamParticleContainer tmp(a_beam.get_name());
+    amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0> tmp{};
     tmp.resize(np);
 
     auto p_box_offsets = m_box_offsets.dataPtr();
@@ -49,7 +49,8 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
         p_dst_indices[i] += p_box_offsets[dst_box];
     });
 
-    amrex::scatterParticles(tmp, a_beam, np, dst_indices.dataPtr());
+    amrex::scatterParticles<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>>(tmp, a_beam, np,
+                                                                             dst_indices.dataPtr());
 
     a_beam.swap(tmp);
 }


### PR DESCRIPTION
Previously, in every timestep `BoxSort.cpp` would make a temporary `BeamParticleContainer` that would call `ReadParameters()`. Now `BoxSort.cpp` uses the Base class `amrex::ParticleTile` instead.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
