### PR TITLE
[mini] fix documentation on how to build the documentation

### DIFF
--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -42,7 +42,7 @@ Please see installation instructions below in the Developers section.
 Optional dependencies include:
 
 - `MPI 3.0+ <https://www.mpi-forum.org/docs/>`__: for multi-node and/or multi-GPU execution
-- `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution (currently not fully accelerated)
+- `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (needs 3.7.9+ for CUDA)
 
 Please choose **one** of the installation methods below to get started:
@@ -201,7 +201,7 @@ Documentation
 
 The documentation is written at the `RST <https://sphinx-tutorial.readthedocs.io/step-1/>`__ format, to compile the documentation locally use
 
-.. code-block::bash
+.. code-block:: bash
 
    cd docs
    pip install -r requirements.txt # only the first time


### PR DESCRIPTION
Due to a missing space, the code block on how to build the documentation did not appear.
This is fixed in this small PR.

Additionally, since all core functions are now OpenMP accelerated, I removed the deprecated statement that the code is not fully accelerated.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
