### PR TITLE
add fix for docutils in requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,8 @@
 sphinx_rtd_theme>=0.4.0
 recommonmark
 sphinx>=3.0
+# docutils 0.17 breaks HTML tags & RTD theme
+# https://github.com/sphinx-doc/sphinx/issues/9001
+docutils<=0.16
 pygments
 breathe


### PR DESCRIPTION
Same as https://github.com/ECP-WarpX/WarpX/pull/1884/files

(thanks to @ax3l)

This fixes an issue in our documentation were the logos appeared much larger than they used to do.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
