### PR TITLE
[mini] call pip with python3 -m

### DIFF
--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -204,7 +204,8 @@ The documentation is written at the `RST <https://sphinx-tutorial.readthedocs.io
 .. code-block:: bash
 
    cd docs
-   pip install -r requirements.txt # only the first time
+   # optional:                                 --user
+   python3 -m pip install -r requirements.txt          # only the first time
    make html
    open build/html/index.html
 


### PR DESCRIPTION
This small PR improves the description how to install the requirements with pip, which should be called with `python3 -m ...`, because it allows for controlling the python version.
Additionally, the hint to the option `--user` was added.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
