### PR TITLE
linking openPMD-viewer and VisualPIC in documentation

### DIFF
--- a/docs/source/visualize/visualization.rst
+++ b/docs/source/visualize/visualization.rst
@@ -3,4 +3,19 @@
 Visualize the results
 =====================
 
-See python analysis scripts in examples.
+HiPACE++ complies with the openPMD standard, therefore we recommend visualization tools utilizing
+openPMD.
+
+2D visualization
+----------------
+
+For 2D visualization, we recommend the
+`openPMD-viewer <https://github.com/openPMD/openPMD-viewer>`__. Please visit their website for an
+installation guide and tutorials.
+
+3D visualization
+----------------
+
+For 3D rendering, we recommend `VisualPIC <https://github.com/AngelFP/VisualPIC>`__.
+The latest redesign of VisualPIC is required to visualize openPMD data. Please visit the website
+for an installation guide.


### PR DESCRIPTION
This PR links the two libraries we typically use for visualization (openPMD-viewer and VisualPIC) in the documentation.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
