### PR TITLE
CMake: More Robust git STRIP

### DIFF
--- a/cmake/HiPACEFunctions.cmake
+++ b/cmake/HiPACEFunctions.cmake
@@ -189,7 +189,7 @@ function(get_source_version NAME SOURCE_DIR)
         execute_process(COMMAND git describe --abbrev=12 --dirty --always --tags
                 WORKING_DIRECTORY ${SOURCE_DIR}
                 OUTPUT_VARIABLE _tmp)
-        string( STRIP ${_tmp} _tmp)
+        string( STRIP "${_tmp}" _tmp)
     endif()
 
     # Is there a CMake project version?


### PR DESCRIPTION
Sometimes a `git` executable can be found but is unusable.
Quoting the result for empty strings makes the build logic more robust in such scenarios.

Mitigates:
```
CMake Error at cmake/HiPACEFunctions.cmake:192 (string):
  string sub-command STRIP requires two arguments.
Call Stack (most recent call first):
  CMakeLists.txt:256 (get_source_version)
```

Provoked via: Mixing of brew and Spack (git from brew + Spack env with `export DYLD_LIBRARY_PATH=/Users/axel/src/spack/var/spack/environments/warpx-dev/.spack-env/view/lib`)

Same as https://github.com/ECP-WarpX/WarpX/pull/2358

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
