### PR TITLE
Docs: Tagfile (Doxygen)

### DIFF
--- a/.github/workflows/source/buildDoxygen
+++ b/.github/workflows/source/buildDoxygen
@@ -6,14 +6,12 @@
 #
 # License: BSD-3-Clause-LBNL
 
-# search recursive inside a folder if a file contains tabs
-#
-# @result 0 if no files are found, else 1
-#
-
 set -eu -o pipefail
 
 cd docs
+
+curl -L -o amrex-doxygen-web.tag.xml \
+  https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml
 
 # treat all warnings as errors
 echo "WARN_AS_ERROR = YES" >> Doxyfile

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ spack-build*
 build/
 debug/
 __pycache__
+
+# Sphinx
+docs/amrex-doxygen-web.tag.xml
+docs/hipace-doxygen-web.tag.xml
+docs/doxyhtml/
+docs/doxyxml/
+docs/source/_static/

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -322,7 +322,8 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+# TAGFILES += "cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.
@@ -2087,13 +2088,13 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = amrex-doxygen-web.tag.xml=https://amrex-codes.github.io/amrex/doxygen/
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = hipace-doxygen-web.tag.xml
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1042,13 +1042,6 @@ VERBATIM_HEADERS       = YES
 
 ALPHABETICAL_INDEX     = YES
 
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
-
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
 # can be used to specify a prefix (or a list of prefixes) that should be ignored

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os, sys, subprocess
+import os, sys, urllib.request, subprocess
 sys.path.insert(0, os.path.abspath('../../src/'))
 
 
@@ -62,4 +62,9 @@ primary_domain = 'cpp'
 # Tell sphinx what the pygments highlight language should be.
 highlight_language = 'cpp'
 
+# Download AMReX Doxygen Tagfile to interlink Doxygen docs
+url = 'https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml'
+urllib.request.urlretrieve(url, '../amrex-doxygen-web.tag.xml')
+
+# Build Doxygen
 subprocess.call('cd ../; doxygen; mkdir -p source/_static; cp -r doxyhtml source/_static/', shell=True)


### PR DESCRIPTION
Interlink the HiPACE++ Doxygen with the AMReX Doxygen pages.

Also generate a HiPACE++ tagfile. Used as an anchor in external projects.

Same as https://github.com/ECP-WarpX/WarpX/pull/2463

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable

## Before (Dead Ends for AMReX Types)
![Screenshot from 2021-10-22 09-51-50](https://user-images.githubusercontent.com/1353258/138493663-84fc0c89-151b-4fec-8f8a-a4a1f9fa5f23.png)

## After (Interlinked)
![Screenshot from 2021-10-22 10-12-15](https://user-images.githubusercontent.com/1353258/138496163-f27e5f26-158e-4bcc-af1b-cab93d01f7e2.png)