### PR TITLE
Abort with useful message if users try to use an input parameters no longer supported

### DIFF
--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -35,7 +35,7 @@ beam.position_std = 0.3 0.3 1.41
 beam.ppc = 1 1 1
 
 plasmas.names = plasma
-plasma.density(x,y,z) = 1.
+plasma.density = 1. # plasma.density(x,y,z) = 1.
 plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron

--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -35,7 +35,7 @@ beam.position_std = 0.3 0.3 1.41
 beam.ppc = 1 1 1
 
 plasmas.names = plasma
-plasma.density = 1. # plasma.density(x,y,z) = 1.
+plasma.density(x,y,z) = 1.
 plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -369,6 +369,9 @@ private:
                          const amrex::DistributionMapping& dm);
 
     int leftmostBoxWithParticles () const;
+
+    /** Crash with error message if old input parameters are used. */
+    void BackwardCompatibility () const;
 };
 
 #endif

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -154,6 +154,8 @@ Hipace::Hipace () :
     MPI_Comm_rank(m_comm_xy, &m_rank_xy);
     MPI_Comm_split(amrex::ParallelDescriptor::Communicator(), m_rank_xy, myproc, &m_comm_z);
 #endif
+
+    BackwardCompatibility();
 }
 
 Hipace::~Hipace ()
@@ -1402,4 +1404,10 @@ Hipace::CheckGhostSlice (int it)
             }
             );
     }
+}
+
+void
+Hipace::BackwardCompatibility () const
+{
+    m_multi_plasma.BackwardCompatibility();
 }

--- a/src/particles/MultiPlasma.H
+++ b/src/particles/MultiPlasma.H
@@ -103,6 +103,9 @@ public:
      */
     void TileSort (amrex::Box bx, amrex::Geometry geom);
 
+    /** Crash with error message if old input parameters are used. */
+    void BackwardCompatibility () const;
+
     int m_sort_bin_size {32}; /**< Tile size to sort plasma particles */
 
 private:

--- a/src/particles/MultiPlasma.cpp
+++ b/src/particles/MultiPlasma.cpp
@@ -144,3 +144,11 @@ MultiPlasma::TileSort (amrex::Box bx, amrex::Geometry geom)
             findParticlesInEachTile(lev, bx, m_sort_bin_size, plasma, geom));
     }
 }
+
+void
+MultiPlasma::BackwardCompatibility () const
+{
+    for (auto& plasma : m_all_plasmas) {
+        plasma.BackwardCompatibility();
+    }
+}

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -92,6 +92,9 @@ public:
      */
     void UpdateDensityFunction ();
 
+    /** Crash with error message if old input parameters are used. */
+    void BackwardCompatibility () const;
+
     amrex::Parser m_parser; /**< owns data for m_density_func */
     amrex::ParserExecutor<3> m_density_func; /**< Density function for the plasma */
     bool m_use_density_table; /**< if a density value table was specified */

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -359,3 +359,16 @@ IonizationModule (const int lev,
         amrex::Gpu::synchronize();
     }
 }
+
+void
+PlasmaParticleContainer::BackwardCompatibility () const
+{
+    amrex::ParmParse pp(m_name);
+    std::string tmp_str = "0.";
+    if (queryWithParser(pp, "density", tmp_str)) {
+        amrex::Abort(
+            "DEPRECATED INPUT ERROR:\n"
+            "Input parameter <plasma species>.density is no longer supported.\n"
+            "Use <plasma species>.density(x,y,z) instead. See documentation for more information.");
+    }
+}


### PR DESCRIPTION
This PR proposes to explicitly check if the user specifies some old input parameters, and crash with a meaningful message if it is the case. This is not as stable as backward compatibility, but is also much less constraint in terms of development, and should help the user experience.
Test: using a deprecated input parameter Ade the code crash with proper error message:
```
amrex::Abort::1::DEPRECATED INPUT ERROR:
Input parameter <plasma species>.density is no longer supported.
Use <plasma species>.density(x,y,z) instead. See documentation for more information. !!!
```