### PR TITLE
Abort with useful message if users try to use an input parameters no longer supported

### DIFF
--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -2,6 +2,7 @@
 #include "PlasmaParticleContainer.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/AtomicWeightTable.H"
+#include "utils/DeprecatedInput.H"
 #include "pusher/PlasmaParticleAdvance.H"
 #include "pusher/BeamParticleAdvance.H"
 #include "pusher/FieldGather.H"
@@ -67,6 +68,8 @@ PlasmaParticleContainer::ReadParameters ()
     queryWithParser(pp, "ionization_product", m_product_name);
 
     std::string density_func_str = "0.";
+    DeprecatedInput(m_name, "density", "density(x,y,z)");
+
     bool density_func_specified = queryWithParser(pp, "density(x,y,z)", density_func_str);
     m_density_func = makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"});
 

--- a/src/utils/DeprecatedInput.H
+++ b/src/utils/DeprecatedInput.H
@@ -1,0 +1,24 @@
+#ifndef HIPACE_DeprecatedInput_H_
+#define HIPACE_DeprecatedInput_H_
+
+#include "Parser.H"
+#include <AMReX_ParmParse.H>
+#include <AMReX_Parser.H>
+
+inline void
+DeprecatedInput(std::string const& pp_name, char const * const str,
+                std::string const& replacement, std::string const& msg="")
+{
+    amrex::ParmParse pp(pp_name);
+    std::string tmp_str = "";
+    if (queryWithParser(pp, str, tmp_str)) {
+        amrex::Abort(
+            "DEPRECATED INPUT ERROR:\n"
+            "Input parameter " + pp_name + "." + str + " no longer supported.\n"
+            "See " + pp_name + "." + replacement + " instead (more info in the documentation). "
+            + msg
+            );
+    }
+}
+
+#endif // HIPACE_DeprecatedInput_H_


### PR DESCRIPTION
This PR proposes to explicitly check if the user specifies some old input parameters, and crash with a meaningful message if it is the case. This is not as stable as backward compatibility, but is also much less constraint in terms of development, and should help the user experience.
Test: using a deprecated input parameter Ade the code crash with proper error message:
```
amrex::Abort::0::DEPRECATED INPUT ERROR:
Input parameter plasma.density no longer supported.
See plasma.density(x,y,z) instead (more info in the documentation).  !!!
```

replaces #611.