### PR TITLE
Set verbose level of MG solver

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -161,6 +161,9 @@ Explicit solver parameters
 * ``hipace.MG_tolerance_abs`` (`float`) optional (default `0.`)
     Absolute error tolerance of the AMReX multigrid solver.
 
+* ``hipace.MG_verbose`` (`int`) optional (default `1`)
+    Level of verbosity of the AMReX multigrid solver.
+
 Plasma parameters
 -----------------
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -161,7 +161,7 @@ Explicit solver parameters
 * ``hipace.MG_tolerance_abs`` (`float`) optional (default `0.`)
     Absolute error tolerance of the AMReX multigrid solver.
 
-* ``hipace.MG_verbose`` (`int`) optional (default `1`)
+* ``hipace.MG_verbose`` (`int`) optional (default `0`)
     Level of verbosity of the AMReX multigrid solver.
 
 Plasma parameters

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -268,6 +268,8 @@ public:
     static amrex::Real m_MG_tolerance_rel;
     /** Absolute tolerance for the multigrid solver, when using the explicit solver */
     static amrex::Real m_MG_tolerance_abs;
+    /** Level of verbosity for the MG solver */
+    static int m_MG_verbose;
     /** Adaptive time step instance */
     AdaptiveTimeStep m_adaptive_time_step;
     /** GridCurrent instance */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -45,6 +45,7 @@ amrex::Real Hipace::m_external_Ez_slope = 0.;
 amrex::Real Hipace::m_external_Ez_uniform = 0.;
 amrex::Real Hipace::m_MG_tolerance_rel = 1.e-4;
 amrex::Real Hipace::m_MG_tolerance_abs = 0.;
+int Hipace::m_MG_verbose = 1;
 #ifdef AMREX_USE_GPU
 bool Hipace::m_do_tiling = false;
 #else
@@ -130,6 +131,7 @@ Hipace::Hipace () :
 
     queryWithParser(pph, "MG_tolerance_rel", m_MG_tolerance_rel);
     queryWithParser(pph, "MG_tolerance_abs", m_MG_tolerance_abs);
+    queryWithParser(pph, "MG_verbose", m_MG_verbose);
     queryWithParser(pph, "do_tiling", m_do_tiling);
 #ifdef AMREX_USE_GPU
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_tiling==0, "Tiling must be turned off to run on GPU.");
@@ -802,6 +804,7 @@ Hipace::ExplicitSolveBxBy (const int lev)
                           amrex::LinOpBCType::Dirichlet)});
 
         m_mlmg = std::make_unique<amrex::MLMG>(*m_mlalaplacian);
+        m_mlmg->setVerbose(m_MG_verbose);
     }
 
     // BxBy is assumed to have at least one ghost cell in x and y.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -45,7 +45,7 @@ amrex::Real Hipace::m_external_Ez_slope = 0.;
 amrex::Real Hipace::m_external_Ez_uniform = 0.;
 amrex::Real Hipace::m_MG_tolerance_rel = 1.e-4;
 amrex::Real Hipace::m_MG_tolerance_abs = 0.;
-int Hipace::m_MG_verbose = 1;
+int Hipace::m_MG_verbose = 0;
 #ifdef AMREX_USE_GPU
 bool Hipace::m_do_tiling = false;
 #else


### PR DESCRIPTION
```
hipace.MG_verbose = 0
```
0: (default) for no output
1: same output as before
2: print residuum for all MG iterations
3: same as 2
4: print information for each smoothing stepp

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
