### PR TITLE
use correct CUDA version on maxwell

### DIFF
--- a/docs/source/building/platforms/maxwell_desy.rst
+++ b/docs/source/building/platforms/maxwell_desy.rst
@@ -12,7 +12,7 @@ HiPACE++:
 
    module purge
    module load maxwell gcc/9.3 openmpi/4
-   module load maxwell cuda/11.1 # cuda/11.0
+   module load maxwell cuda/11.3
    module load hdf5/1.10.6
    # pick correct GPU setting (this may differ for V100 nodes)
    export GPUS_PER_SOCKET=2


### PR DESCRIPTION
CUDA 11.1 introduced a bug, which leads to an empty result for FFTs > 1024x1024 grid points. 
This bug is not prevalent in CUDA 11.3 (I think it got fixed in CUDA 11.2).

This PR updates the documentation on installing on maxwell, to save users from running into this nasty bug.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
