### PR TITLE
control adaptive time step with hipace.dt

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -104,7 +104,7 @@ General parameters
 * ``hipace.nt_per_betatron`` (`Real`) optional (default `40.`)
     Only used when using adaptive time step (see ``hipace.dt`` above).
     Number of time steps per betatron period (of the full blowout regime).
-    The time step is given by :math:`\omega_{\beta}\Delta t = 2 \pi /` ``nt_per_betatron`` where :math:`\omega_{\beta}=\omega_p/\sqrt{2\gamma}` with :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz factors of the slowest particles in all beams.
+    The time step is given by :math:`\omega_{\beta}\Delta t = 2 \pi/N` (:math:`N` is ``nt_per_betatron``) where :math:`\omega_{\beta}=\omega_p/\sqrt{2\gamma}` with :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz factors of the slowest particles in all beams.
 
 Field solver parameters
 -----------------------

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -44,8 +44,8 @@ General parameters
     Maximum number of time steps. `0` means that the 0th time step will be calculated, which are the
     fields of the initial beams.
 
-* ``hipace.dt`` (`float`) optional (default `0.`)
-    Time step to advance the particle beam.
+* ``hipace.dt`` (`float` or `string`) optional (default `0.`)
+    Time step to advance the particle beam. For adaptive time step, use ``"adaptive"``.
 
 * ``hipace.normalized_units`` (`bool`) optional (default `0`)
     Using normalized units in the simulation.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -101,6 +101,11 @@ General parameters
     Currently, this option only affects plasma operations (gather, push and deposition).
     The tile size can be set with ``plasmas.sort_bin_size``.
 
+* ``hipace.nt_per_omega_betatron`` (`Real`) optional (default `0.07`)
+    Only used when using adaptive time step (see ``hipace.dt`` above).
+    Time step, normalized to the betatron angular frequency (of the full blowout regime).
+    The time step is given by :math:`\omega_{\beta}\Delta t =` ``nt_per_omega_betatron`` where :math:`\omega_{\beta}=\omega_p/\sqrt{2\gamma}` with :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz factor of the slowest particles in all beams.
+
 Field solver parameters
 -----------------------
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -101,10 +101,10 @@ General parameters
     Currently, this option only affects plasma operations (gather, push and deposition).
     The tile size can be set with ``plasmas.sort_bin_size``.
 
-* ``hipace.nt_per_betatron`` (`Real`) optional (default `0.07`)
+* ``hipace.nt_per_betatron`` (`Real`) optional (default `40.`)
     Only used when using adaptive time step (see ``hipace.dt`` above).
     Number of time steps per betatron period (of the full blowout regime).
-    The time step is given by :math:`\omega_{\beta}\Delta t = 2 /pi /` ``nt_per_omega_betatron`` where :math:`\omega_{\beta}=\omega_p/\sqrt{2\gamma}` with :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz factors of the slowest particles in all beams.
+    The time step is given by :math:`\omega_{\beta}\Delta t = 2 \pi /` ``nt_per_betatron`` where :math:`\omega_{\beta}=\omega_p/\sqrt{2\gamma}` with :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz factors of the slowest particles in all beams.
 
 Field solver parameters
 -----------------------

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -101,10 +101,10 @@ General parameters
     Currently, this option only affects plasma operations (gather, push and deposition).
     The tile size can be set with ``plasmas.sort_bin_size``.
 
-* ``hipace.nt_per_omega_betatron`` (`Real`) optional (default `0.07`)
+* ``hipace.nt_per_betatron`` (`Real`) optional (default `0.07`)
     Only used when using adaptive time step (see ``hipace.dt`` above).
-    Time step, normalized to the betatron angular frequency (of the full blowout regime).
-    The time step is given by :math:`\omega_{\beta}\Delta t =` ``nt_per_omega_betatron`` where :math:`\omega_{\beta}=\omega_p/\sqrt{2\gamma}` with :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz factor of the slowest particles in all beams.
+    Number of time steps per betatron period (of the full blowout regime).
+    The time step is given by :math:`\omega_{\beta}\Delta t = 2 /pi /` ``nt_per_omega_betatron`` where :math:`\omega_{\beta}=\omega_p/\sqrt{2\gamma}` with :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz factors of the slowest particles in all beams.
 
 Field solver parameters
 -----------------------

--- a/examples/beam_in_vacuum/analysis_adaptive_ts.py
+++ b/examples/beam_in_vacuum/analysis_adaptive_ts.py
@@ -16,7 +16,7 @@ print(dt1)
 print(dt2)
 
 uz = 1000
-nt_per_omega_betatron = 0.07
+nt_per_betatron = 40.
 dt_analytic = np.sqrt(2*uz)*nt_per_omega_betatron
 error_analytic = (dt1[0]-dt_analytic)/dt_analytic
 assert(error_analytic < 1e-5)

--- a/examples/beam_in_vacuum/analysis_adaptive_ts.py
+++ b/examples/beam_in_vacuum/analysis_adaptive_ts.py
@@ -16,8 +16,8 @@ print(dt1)
 print(dt2)
 
 uz = 1000
-nt_per_betatron = 40.
-dt_analytic = np.sqrt(2*uz)*nt_per_omega_betatron
+nt_per_betatron = 89.7597901025655
+dt_analytic = np.sqrt(2*uz)/nt_per_betatron*2*np.pi
 error_analytic = (dt1[0]-dt_analytic)/dt_analytic
 assert(error_analytic < 1e-5)
 print("Error on the first time step ", error_analytic)

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -91,7 +91,9 @@ Hipace::Hipace () :
 
     amrex::ParmParse pph("hipace");
 
-    queryWithParser(pph, "dt", m_dt);
+    std::string str_dt {""};
+    queryWithParser(pph, "dt", str_dt);
+    if (str_dt != "adaptive") queryWithParser(pph, "dt", m_dt);
     queryWithParser(pph, "verbose", m_verbose);
     queryWithParser(pph, "numprocs_x", m_numprocs_x);
     queryWithParser(pph, "numprocs_y", m_numprocs_y);

--- a/src/utils/AdaptiveTimeStep.H
+++ b/src/utils/AdaptiveTimeStep.H
@@ -16,7 +16,7 @@ private:
     /** Whether to use an adaptive time step */
     bool m_do_adaptive_time_step = false;
     /** Number of time steps per betatron period for the adaptive time step */
-    amrex::Real m_nt_per_omega_betatron = 0.07;
+    amrex::Real m_nt_per_betatron = 40.;
 
 public:
     /** Constructor */

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -20,7 +20,7 @@ AdaptiveTimeStep::AdaptiveTimeStep ()
     std::string str_dt = "";
     queryWithParser(ppa, "dt", str_dt);
     if (str_dt == "adaptive") m_do_adaptive_time_step = true;
-    queryWithParser(ppa, "nt_per_omega_betatron", m_nt_per_omega_betatron);
+    queryWithParser(ppa, "nt_per_betatron", m_nt_per_betatron);
 }
 
 #ifdef AMREX_USE_MPI
@@ -152,7 +152,8 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
         {
             const amrex::Real omega_p = std::sqrt(plasma_density * phys_const.q_e*phys_const.q_e
                                           / ( phys_const.ep0*phys_const.m_e ));
-            new_dt = std::sqrt(2.*chosen_min_uz)/omega_p * m_nt_per_omega_betatron;
+            amrex::Real omega_betatron = omega_p / std::sqrt(2.*chosen_min_uz);
+            new_dt = 2.*MathConst::pi/omega_betatron / m_nt_per_betatron;
         }
 
         /* set the new time step */

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -19,8 +19,10 @@ AdaptiveTimeStep::AdaptiveTimeStep ()
     amrex::ParmParse ppa("hipace");
     std::string str_dt = "";
     queryWithParser(ppa, "dt", str_dt);
-    if (str_dt == "adaptive") m_do_adaptive_time_step = true;
-    queryWithParser(ppa, "nt_per_betatron", m_nt_per_betatron);
+    if (str_dt == "adaptive"){
+        m_do_adaptive_time_step = true;
+        queryWithParser(ppa, "nt_per_betatron", m_nt_per_betatron);
+    }
 }
 
 #ifdef AMREX_USE_MPI

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -17,7 +17,9 @@ struct WhichDouble {
 AdaptiveTimeStep::AdaptiveTimeStep ()
 {
     amrex::ParmParse ppa("hipace");
-    queryWithParser(ppa, "do_adaptive_time_step", m_do_adaptive_time_step);
+    std::string str_dt = "";
+    queryWithParser(ppa, "dt", str_dt);
+    if (str_dt == "adaptive") m_do_adaptive_time_step = true;
     queryWithParser(ppa, "nt_per_omega_betatron", m_nt_per_omega_betatron);
 }
 

--- a/tests/adaptive_time_step.1Rank.sh
+++ b/tests/adaptive_time_step.1Rank.sh
@@ -32,7 +32,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.ppc = 4 4 1 \
         hipace.external_Ez_slope = -.5 \
         hipace.verbose=1\
-        hipace.do_adaptive_time_step=1\
+        hipace.dt=adaptive\
         plasmas.adaptive_density=1 \
         > negative_gradient.txt
 
@@ -50,7 +50,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.ppc = 4 4 1 \
         hipace.external_Ez_slope = .5 \
         hipace.verbose=1\
-        hipace.do_adaptive_time_step=1\
+        hipace.dt = adaptive\
         plasmas.adaptive_density=1 \
         > positive_gradient.txt
 

--- a/tests/adaptive_time_step.1Rank.sh
+++ b/tests/adaptive_time_step.1Rank.sh
@@ -34,6 +34,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         hipace.verbose=1\
         hipace.dt=adaptive\
         plasmas.adaptive_density=1 \
+        hipace.nt_per_betatron = 89.7597901025655 \
         > negative_gradient.txt
 
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
@@ -52,6 +53,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         hipace.verbose=1\
         hipace.dt = adaptive\
         plasmas.adaptive_density=1 \
+        hipace.nt_per_betatron = 89.7597901025655 \
         > positive_gradient.txt
 
 # Compare the result with theory


### PR DESCRIPTION
This PR proposes to set adaptive time step with `hipace.dt = adaptive` instead of `hipace.do_adaptive_time_step = 1`. Besides, the doc entry is added.