### PR TITLE
deprecate hipace.do_adaptive_time_step

### DIFF
--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -1,4 +1,5 @@
 #include "AdaptiveTimeStep.H"
+#include "utils/DeprecatedInput.H"
 #include "Hipace.H"
 #include "HipaceProfilerWrapper.H"
 #include "Constants.H"
@@ -23,6 +24,7 @@ AdaptiveTimeStep::AdaptiveTimeStep ()
         m_do_adaptive_time_step = true;
         queryWithParser(ppa, "nt_per_betatron", m_nt_per_betatron);
     }
+    DeprecatedInput("hipace", "do_adaptive_time_step", "dt = adaptive");
 }
 
 #ifdef AMREX_USE_MPI

--- a/src/utils/DeprecatedInput.H
+++ b/src/utils/DeprecatedInput.H
@@ -15,7 +15,7 @@ DeprecatedInput(std::string const& pp_name, char const * const str,
         amrex::Abort(
             "DEPRECATED INPUT ERROR:\n"
             "Input parameter " + pp_name + "." + str + " no longer supported.\n"
-            "Use " + pp_name + "." + replacement + " instead (more info in the documentation). "
+            "See " + pp_name + "." + replacement + " instead (more info in the documentation). "
             + msg
             );
     }

--- a/src/utils/DeprecatedInput.H
+++ b/src/utils/DeprecatedInput.H
@@ -15,7 +15,7 @@ DeprecatedInput(std::string const& pp_name, char const * const str,
         amrex::Abort(
             "DEPRECATED INPUT ERROR:\n"
             "Input parameter " + pp_name + "." + str + " no longer supported.\n"
-            "See " + pp_name + "." + replacement + " instead (more info in the documentation). "
+            "Use " + pp_name + "." + replacement + " instead (more info in the documentation). "
             + msg
             );
     }


### PR DESCRIPTION
This small PR deprecates `hipace.do_adaptive_time_step`, so users get a proper error message when they try to use the deprecated form, instead of `hipace.dt = adaptive`. 


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
