### PR TITLE
MPI send buffer for the physical time

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -225,6 +225,8 @@ public:
     /** Physical time of the simulation. At the end of the time step, it is the physical time
      * at which the fields have been calculated. The beam is one step ahead. */
     static amrex::Real m_physical_time;
+    /** Physical time at the beginning of the simulation */
+    static amrex::Real m_initial_time;
     /** Level of verbosity */
     static int m_verbose;
     /** Order of the field gather and current deposition shape factor in the transverse directions

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -192,6 +192,7 @@ public:
     /** Send buffer for particle longitudinal parallelization (pipeline) */
     char* m_psend_buffer = nullptr;
     char* m_psend_buffer_ghost = nullptr;
+    amrex::Real m_tsend_buffer {-1.};
     /** Send buffer for the number of particles for each beam (pipeline) */
     amrex::Vector<int> m_np_snd = amrex::Vector<int>(0);
     amrex::Vector<int> m_np_snd_ghost = amrex::Vector<int>(0);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -260,7 +260,7 @@ Hipace::InitData ()
 
     AmrCore::InitFromScratch(0.0); // function argument is time
     constexpr int lev = 0;
-    m_multi_beam.InitData(geom[lev]);
+    m_physical_time = m_multi_beam.InitData(geom[lev]);
     m_multi_plasma.InitData(m_slice_ba, m_slice_dm, m_slice_geom, geom);
     m_adaptive_time_step.Calculate(m_dt, m_multi_beam, m_multi_plasma.maxDensity());
 #ifdef AMREX_USE_MPI

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -34,7 +34,7 @@ public:
     void ReadParameters ();
 
     /** \brief Allocate beam particle data and initialize particles with requested beam profile
-     * \param[out] physical time at which the simulation will start
+     * \return physical time at which the simulation will start
      */
     amrex::Real InitData (const amrex::Geometry& geom);
 
@@ -63,7 +63,7 @@ public:
 
 #ifdef HIPACE_USE_OPENPMD
     /** Checks the input file first to determine its Datatype
-     * \param[out] physical time at which the simulation will start
+     * \return physical time at which the simulation will start
      */
     amrex::Real InitBeamFromFileHelper (const std::string input_file,
                                         const bool coordinates_specified,
@@ -75,7 +75,7 @@ public:
                                         const bool species_specified);
 
     /** Initialize a beam from an external input file using openPMD and HDF5
-     * \param[out] physical time at which the simulation will start
+     * \return physical time at which the simulation will start
      */
     template<typename input_type>
     amrex::Real InitBeamFromFile (const std::string input_file,

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -33,7 +33,8 @@ public:
     /** Read parameters in the input file */
     void ReadParameters ();
 
-    /** Allocate data for the beam particles and initialize particles with requested beam profile
+    /** \brief Allocate beam particle data and initialize particles with requested beam profile
+     * \param[out] physical time at which the simulation will start
      */
     amrex::Real InitData (const amrex::Geometry& geom);
 
@@ -61,7 +62,9 @@ public:
                               const bool can, const amrex::Real zmin, const amrex::Real zmax);
 
 #ifdef HIPACE_USE_OPENPMD
-    /** Checks the input file first to determine its Datatype*/
+    /** Checks the input file first to determine its Datatype
+     * \param[out] physical time at which the simulation will start
+     */
     amrex::Real InitBeamFromFileHelper (const std::string input_file,
                                         const bool coordinates_specified,
                                         const amrex::Array<std::string, AMREX_SPACEDIM> file_coordinates_xyz,
@@ -71,7 +74,9 @@ public:
                                         const std::string species_name,
                                         const bool species_specified);
 
-    /** Initialize a beam from an external input file using openPMD and HDF5 */
+    /** Initialize a beam from an external input file using openPMD and HDF5
+     * \param[out] physical time at which the simulation will start
+     */
     template<typename input_type>
     amrex::Real InitBeamFromFile (const std::string input_file,
                                   const bool coordinates_specified,

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -35,7 +35,7 @@ public:
 
     /** Allocate data for the beam particles and initialize particles with requested beam profile
      */
-    void InitData (const amrex::Geometry& geom);
+    amrex::Real InitData (const amrex::Geometry& geom);
 
     /** Initialize a beam with a fix number of particles per cell */
     void InitBeamFixedPPC (
@@ -62,25 +62,25 @@ public:
 
 #ifdef HIPACE_USE_OPENPMD
     /** Checks the input file first to determine its Datatype*/
-    void InitBeamFromFileHelper (const std::string input_file,
-                                 const bool coordinates_specified,
-                                 const amrex::Array<std::string, AMREX_SPACEDIM> file_coordinates_xyz,
-                                 const amrex::Geometry& geom,
-                                 amrex::Real n_0,
-                                 const int num_iteration,
-                                 const std::string species_name,
-                                 const bool species_specified);
+    amrex::Real InitBeamFromFileHelper (const std::string input_file,
+                                        const bool coordinates_specified,
+                                        const amrex::Array<std::string, AMREX_SPACEDIM> file_coordinates_xyz,
+                                        const amrex::Geometry& geom,
+                                        amrex::Real n_0,
+                                        const int num_iteration,
+                                        const std::string species_name,
+                                        const bool species_specified);
 
     /** Initialize a beam from an external input file using openPMD and HDF5 */
     template<typename input_type>
-    void InitBeamFromFile (const std::string input_file,
-                           const bool coordinates_specified,
-                           const amrex::Array<std::string, AMREX_SPACEDIM> file_coordinates_xyz,
-                           const amrex::Geometry& geom,
-                           amrex::Real n_0,
-                           const int num_iteration,
-                           const std::string species_name,
-                           const bool species_specified);
+    amrex::Real InitBeamFromFile (const std::string input_file,
+                                  const bool coordinates_specified,
+                                  const amrex::Array<std::string, AMREX_SPACEDIM> file_coordinates_xyz,
+                                  const amrex::Geometry& geom,
+                                  amrex::Real n_0,
+                                  const int num_iteration,
+                                  const std::string species_name,
+                                  const bool species_specified);
 #endif
 
     std::string get_name () const {return m_name;}

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -55,11 +55,11 @@ BeamParticleContainer::ReadParameters ()
     }
 }
 
-void
+amrex::Real
 BeamParticleContainer::InitData (const amrex::Geometry& geom)
 {
     PhysConst phys_const = get_phys_const();
-
+    amrex::Real ptime {0.};
     if (m_injection_type == "fixed_ppc") {
 
         amrex::ParmParse pp(m_name);
@@ -138,8 +138,9 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
             m_plasma_density = 0;
         }
 
-        InitBeamFromFileHelper(m_input_file, coordinates_specified, m_file_coordinates_xyz, geom,
-                          m_plasma_density, m_num_iteration, m_species_name, species_specified);
+        ptime = InitBeamFromFileHelper(m_input_file, coordinates_specified, m_file_coordinates_xyz,
+                                       geom, m_plasma_density, m_num_iteration, m_species_name,
+                                       species_specified);
 #else
         amrex::Abort("beam particle injection via external_file requires openPMD support: "
                      "Add HiPACE_OPENPMD=ON when compiling HiPACE++.\n");
@@ -153,6 +154,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
     /* setting total number of particles, which is required for openPMD I/O */
     m_total_num_particles = TotalNumberOfParticles();
 
+    return ptime;
 }
 
 amrex::Long BeamParticleContainer::TotalNumberOfParticles (bool only_valid, bool only_local) const

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -315,7 +315,7 @@ InitBeamFixedWeight (int num_to_add,
 }
 
 #ifdef HIPACE_USE_OPENPMD
-void
+amrex::Real
 BeamParticleContainer::
 InitBeamFromFileHelper (const std::string input_file,
                         const bool coordinates_specified,
@@ -367,22 +367,23 @@ InitBeamFromFileHelper (const std::string input_file,
 
     }
 
+    amrex::Real ptime {0.};
     if( input_type == openPMD::Datatype::FLOAT ) {
-        InitBeamFromFile<float>(input_file, coordinates_specified, file_coordinates_xyz,
-                                geom, n_0, num_iteration, species_name, species_known);
+        ptime = InitBeamFromFile<float>(input_file, coordinates_specified, file_coordinates_xyz,
+                                        geom, n_0, num_iteration, species_name, species_known);
     }
     else if( input_type == openPMD::Datatype::DOUBLE ) {
-        InitBeamFromFile<double>(input_file, coordinates_specified, file_coordinates_xyz,
-                                 geom, n_0, num_iteration, species_name, species_known);
+        ptime = InitBeamFromFile<double>(input_file, coordinates_specified, file_coordinates_xyz,
+                                         geom, n_0, num_iteration, species_name, species_known);
     }
     else{
         amrex::Abort("Unknown Datatype used in Beam Input file. Must use double or float\n");
     }
-    return;
+    return ptime;
 }
 
 template <typename input_type>
-void
+amrex::Real
 BeamParticleContainer::
 InitBeamFromFile (const std::string input_file,
                   const bool coordinates_specified,
@@ -395,10 +396,12 @@ InitBeamFromFile (const std::string input_file,
 {
     HIPACE_PROFILE("BeamParticleContainer::InitParticles");
 
+    amrex::Real physical_time {0.};
+
     auto series = openPMD::Series( input_file , openPMD::Access::READ_ONLY );
 
     if( series.iterations[num_iteration].containsAttribute("time") ) {
-        Hipace::m_physical_time = series.iterations[num_iteration].time<input_type>();
+        physical_time = series.iterations[num_iteration].time<input_type>();
     }
 
     // Initialize variables to translate between names from the file and names in Hipace
@@ -673,6 +676,6 @@ InitBeamFromFile (const std::string input_file,
         }
     }
 
-    return;
+    return physical_time;
 }
 #endif // HIPACE_USE_OPENPMD

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -78,10 +78,11 @@ public:
 
     /** Loop over species and init them
      * \param[in] geom Simulation geometry
+     * \param[out] physical time at which the simulation will start
      */
     amrex::Real InitData (const amrex::Geometry& geom);
 
-    /** Return 1 species
+    /** \brief Return 1 species
      * \param[in] i index of the beam
      */
     BeamParticleContainer& getBeam (int i) {return m_all_beams[i];}

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -79,7 +79,7 @@ public:
     /** Loop over species and init them
      * \param[in] geom Simulation geometry
      */
-    void InitData (const amrex::Geometry& geom);
+    amrex::Real InitData (const amrex::Geometry& geom);
 
     /** Return 1 species
      * \param[in] i index of the beam

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -78,7 +78,7 @@ public:
 
     /** Loop over species and init them
      * \param[in] geom Simulation geometry
-     * \param[out] physical time at which the simulation will start
+     * \return physical time at which the simulation will start
      */
     amrex::Real InitData (const amrex::Geometry& geom);
 

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -18,12 +18,14 @@ MultiBeam::MultiBeam (amrex::AmrCore* /*amr_core*/)
     m_n_real_particles.resize(m_nbeams, 0);
 }
 
-void
+amrex::Real
 MultiBeam::InitData (const amrex::Geometry& geom)
 {
+    amrex::Real ptime {0.};
     for (auto& beam : m_all_beams) {
-        beam.InitData(geom);
+        ptime = beam.InitData(geom);
     }
+    return ptime;
 }
 
 void


### PR DESCRIPTION
The MPI communication of the physical time was buggy, probably because the buffer was freed immediately after MPI_Isend returned. This PR fixes it with a permanent buffer, and should also fix NotifyFinish. This [input file](https://github.com/Hi-PACE/hipace/files/7566204/inputs.txt) provides a reproducer (run on 8 GPUs on the Juwels Booster). This PR fixes the bug for this reproducer. A blocking send also appears to fix the issue. @SeverinDiederichs if you have a tricky run that could be a hard test for this PR (e.g. with adaptive time step), could you give it a try?
Note: this PR also slightly changes the handling of initial physical time (avoid setting `Hipace::m_physical_time` from a separate class).