### PR TITLE
Fix a data type problem with openpmd metadata writer

### DIFF
--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -143,10 +143,10 @@ OpenPMDWriter::WriteFieldData (
         openPMD::Datatype datatype = openPMD::determineDatatype< amrex::Real >();
         amrex::IntVect prob_size = data_box.bigEnd() - data_box.smallEnd()
                                    + amrex::IntVect::TheUnitVector();
-        amrex::Vector<long long unsigned int> probsize_reformat = {AMREX_D_DECL(
-                     static_cast<long long unsigned int>(geom[lev].Domain().size()[2]),
-                     static_cast<long long unsigned int>(prob_size[1]),
-                     static_cast<long long unsigned int>(prob_size[0])
+        amrex::Vector<std::uint64_t> probsize_reformat = {AMREX_D_DECL(
+                     static_cast<std::uint64_t>(geom[lev].Domain().size()[2]),
+                     static_cast<std::uint64_t>(prob_size[1]),
+                     static_cast<std::uint64_t>(prob_size[0])
                       )};
         openPMD::Extent global_size = probsize_reformat; //geom[lev].Domain().size());
         // If slicing requested, remove number of points for the slicing direction

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -143,10 +143,10 @@ OpenPMDWriter::WriteFieldData (
         openPMD::Datatype datatype = openPMD::determineDatatype< amrex::Real >();
         amrex::IntVect prob_size = data_box.bigEnd() - data_box.smallEnd()
                                    + amrex::IntVect::TheUnitVector();
-        amrex::Vector<long unsigned int> probsize_reformat = {AMREX_D_DECL(
-                     static_cast<long unsigned int>(geom[lev].Domain().size()[2]),
-                     static_cast<long unsigned int>(prob_size[1]),
-                     static_cast<long unsigned int>(prob_size[0])
+        amrex::Vector<long long unsigned int> probsize_reformat = {AMREX_D_DECL(
+                     static_cast<long long unsigned int>(geom[lev].Domain().size()[2]),
+                     static_cast<long long unsigned int>(prob_size[1]),
+                     static_cast<long long unsigned int>(prob_size[0])
                       )};
         openPMD::Extent global_size = probsize_reformat; //geom[lev].Domain().size());
         // If slicing requested, remove number of points for the slicing direction


### PR DESCRIPTION
When compiling locally (AppleClang 12.0.0.12000032) I got error
```
/Users/maxence/hipace/src/diagnostics/OpenPMDWriter.cpp:151:25: error: no viable conversion from 'amrex::Vector<unsigned long>' to 'openPMD::Extent' (aka 'vector<unsigned long long>')
        openPMD::Extent global_size = probsize_reformat; //geom[lev].Domain().size());
                        ^             ~~~~~~~~~~~~~~~~~
```
This PR proposes to change the type of `probsize_reformat` from `amrex::Vector<long unsigned int>` to `amrex::Vector<std::uint64_t>`, which fixes build issue, and compiles both locally (Clang) and on the booster (GCC).