### PR TITLE
Fix the scope of profiler for SYCL

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,12 +7,12 @@
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
-    HIPACE_PROFILE_VAR("main()", pmain);
     {
+        HIPACE_PROFILE_VAR("main()", pmain);
         Hipace hipace;
         hipace.InitData();
         hipace.Evolve();
+        HIPACE_PROFILE_VAR_STOP(pmain);
     }
-    HIPACE_PROFILE_VAR_STOP(pmain);
     amrex::Finalize();
 }


### PR DESCRIPTION
In main.cpp, the destructor of the profiler was called after
amrex::Finalize.  This would cause an error in SYCL due to a device
synchronization call in the dtor, because the SYCL queues in amrex had been
deleted.  In this commit, we limit the scope of the profiler so that its
destructor is called before the queues are deleted.  Note that it was never
an issue for CUDA/HIP, because the device synchronization calls in those
backends do not need any amrex objects.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
