### PR TITLE
avoid amrex ref_ratio which does not exist without MR

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -85,6 +85,9 @@ public:
      * the coarsest refinement level. */
     void PostProcessBaseGrids (amrex::BoxArray& ba0) const override;
 
+    /** returns refinement ratio for lev = 1 or {1,1,1} for lev = 0 */
+    static amrex::IntVect GetRefRatio (int lev);
+
     /** Init AmrCore and allocate beam and plasma containers */
     void InitData ();
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -421,7 +421,7 @@ Hipace::Evolve ()
             ResizeFDiagFAB(it);
 
             amrex::Vector<amrex::Vector<BeamBins>> bins;
-            bins = m_multi_beam.findParticlesInEachSlice(finestLevel()+1, it, bx, ref_ratio[0],
+            bins = m_multi_beam.findParticlesInEachSlice(finestLevel()+1, it, bx,
                                                          geom, m_box_sorters);
             AMREX_ALWAYS_ASSERT( bx.bigEnd(Direction::z) >= bx.smallEnd(Direction::z) + 2 );
             // Solve head slice
@@ -489,7 +489,8 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox,
 
         const amrex::Box& bx = boxArray(lev)[ibox];
 
-        const int nsubslice = (lev == 1) ? ref_ratio[0][Direction::z] : 1;
+        static amrex::IntVect tmp_ref_ratio = GetRefRatio(lev);
+        const int nsubslice = (lev == 1) ? tmp_ref_ratio[Direction::z] : 1;
 
         for (int isubslice = nsubslice-1; isubslice >= 0; --isubslice) {
 
@@ -1304,13 +1305,24 @@ Hipace::ResizeFDiagFAB (const int it)
 
         if (lev == 1) {
             const amrex::Box& bx_lev0 = boxArray(0)[it];
-            const int ref_ratio_z = ref_ratio[0][Direction::z];
+            static amrex::IntVect tmp_ref_ratio = GetRefRatio(lev);
+            const int ref_ratio_z = tmp_ref_ratio[Direction::z];
             // Ensuring the IO boxes on level 1 are aligned with the boxes on level 0
             bx.setSmall(Direction::z, ref_ratio_z*bx_lev0.smallEnd(Direction::z));
             bx.setBig  (Direction::z, ref_ratio_z*bx_lev0.bigEnd(Direction::z)+(ref_ratio_z-1));
         }
 
         m_diags.ResizeFDiagFAB(bx, lev);
+    }
+}
+
+amrex::IntVect
+Hipace::GetRefRatio (int lev)
+{
+    if (lev==0) {
+        return amrex::IntVect{1,1,1};
+    } else {
+        return GetInstance().ref_ratio[lev-1];
     }
 }
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -489,8 +489,7 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox,
 
         const amrex::Box& bx = boxArray(lev)[ibox];
 
-        static amrex::IntVect tmp_ref_ratio = GetRefRatio(lev);
-        const int nsubslice = (lev == 1) ? tmp_ref_ratio[Direction::z] : 1;
+        const int nsubslice = (lev == 1) ? GetRefRatio(lev)[Direction::z] : 1;
 
         for (int isubslice = nsubslice-1; isubslice >= 0; --isubslice) {
 
@@ -1305,8 +1304,7 @@ Hipace::ResizeFDiagFAB (const int it)
 
         if (lev == 1) {
             const amrex::Box& bx_lev0 = boxArray(0)[it];
-            static amrex::IntVect tmp_ref_ratio = GetRefRatio(lev);
-            const int ref_ratio_z = tmp_ref_ratio[Direction::z];
+            const int ref_ratio_z = GetRefRatio(lev)[Direction::z];
             // Ensuring the IO boxes on level 1 are aligned with the boxes on level 0
             bx.setSmall(Direction::z, ref_ratio_z*bx_lev0.smallEnd(Direction::z));
             bx.setBig  (Direction::z, ref_ratio_z*bx_lev0.bigEnd(Direction::z)+(ref_ratio_z-1));

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -489,7 +489,7 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox,
 
         const amrex::Box& bx = boxArray(lev)[ibox];
 
-        const int nsubslice = (lev == 1) ? GetRefRatio(lev)[Direction::z] : 1;
+        const int nsubslice = GetRefRatio(lev)[Direction::z];
 
         for (int isubslice = nsubslice-1; isubslice >= 0; --isubslice) {
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -42,12 +42,11 @@ public:
      * \param[in] lev MR level
      * \param[in] ibox box index
      * \param[in] bx 3D box on which per-slice sorting is done
-     * \param[in] ref_ratio refinement ratio in (x, y, z)
      * \param[in] geom Geometry of the simulation domain
      * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
      */
      amrex::Vector<amrex::Vector<BeamBins>>
-     findParticlesInEachSlice (int lev, int ibox, amrex::Box bx, const amrex::IntVect& ref_ratio,
+     findParticlesInEachSlice (int lev, int ibox, amrex::Box bx,
                                amrex::Vector<amrex::Geometry> const& geom,
                                const amrex::Vector<BoxSorter>& a_box_sorter_vec);
     /** \brief Loop over all beam species and sort particles by box

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -46,7 +46,6 @@ MultiBeam::DepositCurrentSlice (
 
 amrex::Vector<amrex::Vector<BeamBins>>
 MultiBeam::findParticlesInEachSlice (int nlev, int ibox, amrex::Box bx,
-                                     const amrex::IntVect& ref_ratio,
                                      amrex::Vector<amrex::Geometry> const& geom,
                                      const amrex::Vector<BoxSorter>& a_box_sorter_vec)
 {
@@ -55,7 +54,7 @@ MultiBeam::findParticlesInEachSlice (int nlev, int ibox, amrex::Box bx,
         amrex::Vector<BeamBins> bins_per_level;
         for (int i=0; i<m_nbeams; i++) {
             bins_per_level.emplace_back(::findParticlesInEachSlice(lev, ibox, bx, m_all_beams[i],
-                                                            ref_ratio, geom, a_box_sorter_vec[i]));
+                                                                   geom, a_box_sorter_vec[i]));
         }
         bins.emplace_back(bins_per_level);
     }

--- a/src/particles/SliceSort.H
+++ b/src/particles/SliceSort.H
@@ -16,13 +16,12 @@ using BeamBins = amrex::DenseBins<BeamParticleContainer::ParticleType>;
  * \param[in] ibox index of the box
  * \param[in] bx 3d box in which particles are sorted per slice
  * \param[in] beam Beam particle container
- * \param[in] ref_ratio refinement ratio in (x,y,z)
  * \param[in] geom Geometry
  * \param[in] a_box_sorter object that sorts particles by box
  */
 BeamBins
 findParticlesInEachSlice (
-    int lev, int ibox, amrex::Box bx, BeamParticleContainer& beam, const amrex::IntVect& ref_ratio,
+    int lev, int ibox, amrex::Box bx, BeamParticleContainer& beam,
     amrex::Vector<amrex::Geometry> const& geom, const BoxSorter& a_box_sorter);
 
 #endif // HIPACE_SLICESORT_H_

--- a/src/particles/SliceSort.cpp
+++ b/src/particles/SliceSort.cpp
@@ -1,15 +1,17 @@
 #include "SliceSort.H"
 #include "utils/HipaceProfilerWrapper.H"
+#include "Hipace.H"
 
 #include <AMReX_ParticleTransformation.H>
 
 BeamBins
 findParticlesInEachSlice (
-    int lev, int ibox, amrex::Box bx, BeamParticleContainer& beam, const amrex::IntVect& ref_ratio,
+    int lev, int ibox, amrex::Box bx, BeamParticleContainer& beam,
     amrex::Vector<amrex::Geometry> const& geom, const BoxSorter& a_box_sorter)
 {
     HIPACE_PROFILE("findParticlesInEachSlice()");
 
+    static amrex::IntVect ref_ratio = Hipace::GetRefRatio(lev);
     // Slice box: only 1 cell transversally, same as bx longitudinally.
     amrex::Box cbx ({0,0,bx.smallEnd(2)}, {0,0,bx.bigEnd(2)});
     if (lev == 1) cbx.refine(ref_ratio);

--- a/src/particles/SliceSort.cpp
+++ b/src/particles/SliceSort.cpp
@@ -11,10 +11,9 @@ findParticlesInEachSlice (
 {
     HIPACE_PROFILE("findParticlesInEachSlice()");
 
-    static amrex::IntVect ref_ratio = Hipace::GetRefRatio(lev);
     // Slice box: only 1 cell transversally, same as bx longitudinally.
     amrex::Box cbx ({0,0,bx.smallEnd(2)}, {0,0,bx.bigEnd(2)});
-    if (lev == 1) cbx.refine(ref_ratio);
+    if (lev == 1) cbx.refine(Hipace::GetRefRatio(lev));
 
     const int np = a_box_sorter.boxCountsPtr()[ibox];
     const int offset = a_box_sorter.boxOffsetsPtr()[ibox];


### PR DESCRIPTION
This PR fixes a crucial, unnoticed bug that was introduced in #574, which caused the code to crash in `Debug`-mode.

@AlexanderSinn pointed out that `ref_ratio` has the size of `max_lev`, therefore a direct call to `ref_ratio[0]` caused the crash.
This is fixed by avoiding to call `ref_ratio[0]`.

To be tested:
- [x] that MR still gives the same results

.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
