### PR TITLE
Include destructor of hipace in profiler

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,11 +8,10 @@ int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
     {
-        HIPACE_PROFILE_VAR("main()", pmain);
+        HIPACE_PROFILE("main()");
         Hipace hipace;
         hipace.InitData();
         hipace.Evolve();
-        HIPACE_PROFILE_VAR_STOP(pmain);
     }
     amrex::Finalize();
 }


### PR DESCRIPTION
After #633 I noticed that the destructor of Hipace was no longer included in the profile region. This PR changes the Profiling type to one which includes the destructor of Hipace while still calling the destructor of the profiler before amrex::Finalize().

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
