### PR TITLE
also allow random seed on GPU

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -85,10 +85,8 @@ Hipace::Hipace () :
     amrex::ParmParse pp;// Traditionally, max_step and stop_time do not have prefix.
     queryWithParser(pp, "max_step", m_max_step);
 
-#ifndef AMREX_USE_GPU
     int seed;
     if (queryWithParser(pp, "random_seed", seed)) amrex::ResetRandomSeed(seed);
-#endif
 
     amrex::ParmParse pph("hipace");
 


### PR DESCRIPTION
The input parameter `random_seed` was only available on CPU, however, we found it useful to also allow it on GPU. This PR enables it on GPU.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
