### PR TITLE
GPU Builds: Disable RDC

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -54,6 +54,11 @@ macro(find_amrex)
         set(AMReX_TINY_PROFILE ON CACHE BOOL "")
         set(AMReX_LINEAR_SOLVERS ON CACHE INTERNAL "")
 
+        # we don't need RDC and disabling it simplifies the build
+        # complexity and potentially improves code optimization
+        # note: once we add & enable ASCENT and SENSEI, we need RDC
+        set(AMReX_GPU_RDC OFF CACHE BOOL "")
+
         # AMReX_ASCENT
         # AMReX_CONDUIT
         # AMReX_SENSEI
@@ -112,6 +117,7 @@ macro(find_amrex)
         mark_as_advanced(AMReX_BASE_PROFILE) # mutually exclusive to tiny profile
         mark_as_advanced(AMReX_DPCPP)
         mark_as_advanced(AMReX_CUDA)
+        mark_as_advanced(AMReX_GPU_RDC)
         mark_as_advanced(AMReX_PARTICLES_PRECISION)
         mark_as_advanced(AMReX_PRECISION)
         mark_as_advanced(AMReX_EB)


### PR DESCRIPTION
We don't need relocatable device code (RDC) and disabling it simplifies the build complexity and potentially improves code optimization.

Once we add & enable ASCENT and SENSEI, we will conditionally need RDC.

X-ref:
- https://github.com/ECP-WarpX/WarpX/pull/1999
- https://github.com/ECP-WarpX/WarpX/pull/2742

## Check List

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
