### PR TITLE
C++17, CMake 3.18+

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,8 +8,8 @@ on:
 jobs:
 # enable again when we open-source (free core-hours for GH Actions)
 #
-#  linux_gcc_cxx14_ompi:
-#    name: GNU@7.5 C++14 OMPI
+#  linux_gcc_cxx17_ompi:
+#    name: GNU@7.5 C++17 OMPI
 #    runs-on: ubuntu-latest
 #    steps:
 #    - uses: actions/checkout@v2
@@ -44,8 +44,8 @@ jobs:
         export OMP_NUM_THREADS=2
         ctest --output-on-failure
 
-#  linux_gcc_cxx14:
-#    name: GNU@7.5 C++14 Serial
+#  linux_gcc_cxx17:
+#    name: GNU@7.5 C++17 Serial
 #    runs-on: ubuntu-latest
 #    steps:
 #    - uses: actions/checkout@v2
@@ -61,8 +61,8 @@ jobs:
 
 # enable again when we open-source (free core-hours for GH Actions)
 #
-#  linux_clang_cxx14:
-#    name: Clang@4.0.1 C++14 OMPI
+#  linux_clang7:
+#    name: Clang@7 C++17 OMPI
 #    runs-on: ubuntu-latest
 #    steps:
 #    - uses: actions/checkout@v2
@@ -72,8 +72,8 @@ jobs:
 #      run: |
 #        mkdir build
 #        cd build
-#        cmake ..                                             \
-#            -DCMAKE_C_COMPILER=$(which clang-4.0)            \
-#            -DCMAKE_CXX_COMPILER=$(which clang++-4.0)
+#        cmake ..                                           \
+#            -DCMAKE_C_COMPILER=$(which clang-7)            \
+#            -DCMAKE_CXX_COMPILER=$(which clang++-7)
 #        make -j 2 VERBOSE=ON
 #        ctest --output-on-failure

--- a/.github/workflows/setup/ubuntu_clang.sh
+++ b/.github/workflows/setup/ubuntu_clang.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020 The HiPACE++ Community
+# Copyright 2020-2022 The HiPACE++ Community
 #
 # License: BSD-3-Clause-LBNL
 # Authors: Axel Huebl
@@ -11,6 +11,6 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \
     build-essential     \
-    clang-4.0           \
+    clang-7             \
     libopenmpi-dev      \
     openmpi-bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.18.0)
 project(HiPACE VERSION 22.01)
 
 # helper functions
@@ -20,11 +20,23 @@ endif()
 # AMReX 21.06+ supports CUDA_ARCHITECTURES with CMake 3.20+
 # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
 # https://cmake.org/cmake/help/latest/policy/CMP0104.html
-if(CMAKE_VERSION VERSION_LESS 3.20)
-    if(POLICY CMP0104)
-        cmake_policy(SET CMP0104 OLD)
-    endif()
+if(POLICY CMP0104)
+    cmake_policy(SET CMP0104 OLD)
 endif()
+
+# We use simple syntax in cmake_dependent_option, so we are compatible with the
+# extended syntax in CMake 3.22+
+# https://cmake.org/cmake/help/v3.22/policy/CMP0127.html
+if(POLICY CMP0127)
+    cmake_policy(SET CMP0127 NEW)
+endif()
+
+
+# C++ Standard in Superbuilds #################################################
+#
+# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# openPMD-api until they increase their requirement.
+set_cxx17_superbuild()
 
 
 # CCache Support ##############################################################
@@ -107,8 +119,8 @@ target_include_directories(HiPACE PRIVATE
 # add sources
 add_subdirectory(src)
 
-# C++ properties: at least a C++14 capable compiler is needed
-target_compile_features(HiPACE PUBLIC cxx_std_14)
+# C++ properties: at least a C++17 capable compiler is needed
+target_compile_features(HiPACE PUBLIC cxx_std_17)
 set_target_properties(HiPACE PROPERTIES
     CXX_EXTENSIONS OFF
     CXX_STANDARD_REQUIRED ON
@@ -122,13 +134,11 @@ target_link_libraries(HiPACE PUBLIC HiPACE::thirdparty::FFT)
 # AMReX helper function: propagate CUDA specific target & source properties
 if(HiPACE_COMPUTE STREQUAL CUDA)
     setup_target_for_cuda_compilation(HiPACE)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-        target_compile_features(HiPACE PUBLIC cuda_std_14)
-        set_target_properties(HiPACE PROPERTIES
-            CUDA_EXTENSIONS OFF
-            CUDA_STANDARD_REQUIRED ON
-        )
-    endif()
+    target_compile_features(HiPACE PUBLIC cuda_std_17)
+    set_target_properties(HiPACE PROPERTIES
+        CUDA_EXTENSIONS OFF
+        CUDA_STANDARD_REQUIRED ON
+    )
 endif()
 
 if(HiPACE_OPENPMD)

--- a/cmake/HiPACEFunctions.cmake
+++ b/cmake/HiPACEFunctions.cmake
@@ -1,3 +1,31 @@
+# Set C++17 for the whole build if not otherwise requested
+#
+# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# openPMD-api until they increase their requirement.
+#
+macro(set_cxx17_superbuild)
+    if(NOT DEFINED CMAKE_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD 17)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
+        set(CMAKE_CXX_EXTENSIONS OFF)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    endif()
+
+    if(NOT DEFINED CMAKE_CUDA_STANDARD)
+        set(CMAKE_CUDA_STANDARD 17)
+    endif()
+    if(NOT DEFINED CMAKE_CUDA_EXTENSIONS)
+        set(CMAKE_CUDA_EXTENSIONS OFF)
+    endif()
+    if(NOT DEFINED CMAKE_CUDA_STANDARD_REQUIRED)
+        set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    endif()
+endmacro()
+
+
 # find the CCache tool and use it if found
 #
 macro(set_ccache)

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -65,7 +65,7 @@ function(find_openpmd)
         else()
             set(COMPONENT_WMPI NOMPI)
         endif()
-        find_package(openPMD 0.14.2 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
+        find_package(openPMD 0.14.3 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
         message(STATUS "openPMD-api: Found version '${openPMD_VERSION}'")
     endif()
 endfunction()
@@ -81,7 +81,7 @@ if(HiPACE_OPENPMD)
     set(HiPACE_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(HiPACE_openpmd_internal)")
-    set(HiPACE_openpmd_branch "0.14.2"
+    set(HiPACE_openpmd_branch "0.14.3"
         CACHE STRING
         "Repository branch for HiPACE_openpmd_repo if(HiPACE_openpmd_internal)")
 

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -29,14 +29,14 @@ Dependencies
 HiPACE++ depends on the following popular third party software.
 Please see installation instructions below in the Developers section.
 
-- a mature `C++14 <https://en.wikipedia.org/wiki/C%2B%2B14>`__ compiler: e.g. GCC 5, Clang 3.6 or newer
-- `CMake 3.15.0+ <https://cmake.org/>`__
+- a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B14>`__ compiler: e.g. GCC 7, Clang 7, NVCC 11.0, MSVC 19.15 or newer
+- `CMake 3.18.0+ <https://cmake.org/>`__
 - `AMReX development <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
-- `openPMD-api 0.14.2+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api
+- `openPMD-api 0.14.3+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api
 
   - `HDF5 <https://support.hdfgroup.org/HDF5>`__ 1.8.13+ (optional; for ``.h5`` file support)
   - `ADIOS2 <https://github.com/ornladios/ADIOS2>`__ 2.7.0+ (optional; for ``.bp`` file support)
-- Nvidia GPU support: `CUDA Toolkit 9.0+ <https://developer.nvidia.com/cuda-downloads>`__ (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`__)
+- Nvidia GPU support: `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__ (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`__)
 - CPU-only: `FFTW3 <http://www.fftw.org/>`__ (only used serially; *not* needed for Nvidia GPUs)
 
 Optional dependencies include:
@@ -180,7 +180,7 @@ CMake Option                 Default & Values                                Des
 ``HiPACE_amrex_internal``    **ON**/OFF                                      Needs a pre-installed AMReX library if set to ``OFF``
 ``HiPACE_openpmd_src``       *None*                                          Path to openPMD-api source directory (preferred if set)
 ``HiPACE_openpmd_repo``      ``https://github.com/openPMD/openPMD-api.git``  Repository URI to pull and build openPMD-api from
-``HiPACE_openpmd_branch``    ``0.14.2``                                      Repository branch for ``HiPACE_openpmd_repo``
+``HiPACE_openpmd_branch``    ``0.14.3``                                      Repository branch for ``HiPACE_openpmd_repo``
 ``HiPACE_openpmd_internal``  **ON**/OFF                                      Needs a pre-installed openPMD-api library if set to ``OFF``
 ``AMReX_LINEAR_SOLVERS``     **ON**/OFF                                      Compile AMReX multigrid solver. Required for explicit solver
 ===========================  ==============================================  ============================================================


### PR DESCRIPTION
Update C++ requirements to compile with C++17 or newer.

Proper C++17 compilers:
- [x] Clang 7+
- [x] GCC 7+
- [x] NVCC 11.0+
- [x] NVC++ 19.1+
- [x] ROCm `hipcc`/`clang++ -x hip` (already used as C++17)
- [x] oneAPI `dpcpp`/`icpx` (already used as C++17)
- [x] Intel `icpc` 19.0.1+ (version 2021+ recommended)
- [x] MSVC 19.15+ (already used as C++17)
- [x] etc. https://en.cppreference.com/w/cpp/compiler_support#C.2B.2B17_features

Merge first:
- [x] CUDA CI: #651
- [x] CUDA C++17 bugfix: #652

Checklist:
- [x] same as https://github.com/ECP-WarpX/WarpX/pull/2300 + follow-ups
- [x] needs openPMD-api 0.14.3+
- [x] test and update documented HPC machines (compile + run)
  - [x] Juwels (JSC) (with #652 applied)
  - [x] Maxwell (DESY) (thx @SeverinDiederichs)
  - Spock (OLCF) has some issues currently, rather [use Crusher (OLCF)](https://warpx.readthedocs.io/en/latest/install/hpc/crusher.html).
