### PR TITLE
CI: CUDA

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,0 +1,72 @@
+name: 🐧 CUDA
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-cuda
+  cancel-in-progress: true
+
+jobs:
+# Ref.:
+#   https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/ubuntu18.04/10.1/base/Dockerfile
+#   https://github.com/ComputationalRadiationPhysics/picongpu/blob/0.5.0/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
+#   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
+  build_nvcc:
+    name: NVCC 11.0.2 SP
+    runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
+    env:
+      CXXFLAGS: "-Werror"
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        .github/workflows/setup/nvcc11.sh
+    - name: Build & Install
+      run: |
+        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+        which nvcc || echo "nvcc not in PATH!"
+
+        cmake -S . -B build            \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DAMReX_CUDA_ARCH=6.0        \
+          -DHiPACE_COMPUTE=CUDA        \
+          -DHiPACE_PRECISION=SINGLE    \
+          -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
+          -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
+        cmake --build build -j 2
+
+# NVHPC is currently very slow (43min), so we don't test it yet
+#  build_nvhpc21-9-nvcc:
+#    name: NVHPC@21.9 NVCC/NVC++ Release [tests]
+#    runs-on: ubuntu-20.04
+#    if: github.event.pull_request.draft == false
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Dependencies
+#      run: .github/workflows/setup/nvhpc.sh
+#    - name: Build & Install
+#      run: |
+#        source /etc/profile.d/modules.sh
+#        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.9
+#        which nvcc || echo "nvcc not in PATH!"
+#        which nvc++ || echo "nvc++ not in PATH!"
+#        which nvc || echo "nvc not in PATH!"
+#        nvcc --version
+#        nvc++ --version
+#        nvc --version
+#        cmake --version
+#
+#        export CC=$(which nvc)
+#        export CXX=$(which nvc++)
+#        export CUDACXX=$(which nvcc)
+#        export CUDAHOSTCXX=${CXX}
+#
+#        cmake -S . -B build            \
+#          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+#          -DHiPACE_COMPUTE=CUDA        \
+#          -DAMReX_CUDA_ARCH=8.0        \
+#          -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
+#          -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
+#        cmake --build build -j 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,23 +77,3 @@ jobs:
 #            -DCMAKE_CXX_COMPILER=$(which clang++-4.0)
 #        make -j 2 VERBOSE=ON
 #        ctest --output-on-failure
-
-#  linux_gcc_cxx14_ompi_cuda:
-#    name: CUDA@10.1.243 GCC@8 C++14
-#    runs-on: ubuntu-20.04
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Dependencies
-#      run: .github/workflows/setup/ubuntu_ompi_cuda.sh
-#    - name: Build & Install
-#      run: |
-#        mkdir build
-#        cd build
-#        cmake ..                                      \
-#            -DHiPACE_COMPUTE=CUDA                     \
-#            -DCMAKE_C_COMPILER=$(which gcc-8)         \
-#            -DCMAKE_CXX_COMPILER=$(which g++-8)       \
-#            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-8) \
-#            -DAMReX_CUDA_ARCH=6.0
-#        make -j 2 VERBOSE=ON
-#        ctest --output-on-failure

--- a/.github/workflows/setup/nvcc11.sh
+++ b/.github/workflows/setup/nvcc11.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021-2022 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+sudo apt-get -qqq update
+sudo apt-get install -y \
+    build-essential     \
+    ca-certificates     \
+    cmake               \
+    gnupg               \
+    libopenmpi-dev      \
+    ninja-build         \
+    openmpi-bin         \
+    pkg-config          \
+    wget
+
+sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+sudo apt-key add 7fa2af80.pub
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
+    | sudo tee /etc/apt/sources.list.d/cuda.list
+
+sudo apt-get update
+sudo apt-get install -y          \
+    cuda-command-line-tools-11-0 \
+    cuda-compiler-11-0           \
+    cuda-cupti-dev-11-0          \
+    cuda-minimal-build-11-0      \
+    cuda-nvml-dev-11-0           \
+    cuda-nvtx-11-0               \
+    libcufft-dev-11-0            \
+    libcurand-dev-11-0
+sudo ln -s cuda-11.0 /usr/local/cuda
+
+# cmake-easyinstall
+#
+sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
+sudo chmod a+x /usr/local/bin/cmake-easyinstall

--- a/.github/workflows/setup/nvhpc.sh
+++ b/.github/workflows/setup/nvhpc.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021-2022 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
+
+set -eu -o pipefail
+
+sudo apt-get -qqq update
+sudo apt-get install -y \
+    build-essential     \
+    ca-certificates     \
+    cmake               \
+    environment-modules \
+    gnupg               \
+    ninja-build         \
+    pkg-config          \
+    wget
+
+wget -q https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-21-9_21.9_amd64.deb \
+        https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-2021_21.9_amd64.deb
+sudo apt-get update
+sudo apt-get install -y ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
+rm -rf ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
+
+# things should reside in /opt/nvidia/hpc_sdk now
+
+# activation via:
+#   source /etc/profile.d/modules.sh
+#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.9


### PR DESCRIPTION
Add CUDA builds using the CUDA Toolkit (CTK), using `nvcc` and `g++`.

The newer Nvidia HPC Toolkit, using `nvcc` and `nvc++`, compiles 43min, so we don't add it yet.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
