### PR TITLE
Fix: CUDA C++17 Builds (ParticleBins)

### DIFF
--- a/src/particles/SliceSort.cpp
+++ b/src/particles/SliceSort.cpp
@@ -32,7 +32,7 @@ findParticlesInEachSlice (
     bins.build(
         np, particle_ptr, cbx,
         // Pass lambda function that returns the slice index
-        [=] AMREX_GPU_HOST_DEVICE (const BeamParticleContainer::ParticleType& p)
+        [=] AMREX_GPU_DEVICE (const BeamParticleContainer::ParticleType& p)
         noexcept -> amrex::IntVect
         {
             return amrex::IntVect(

--- a/src/particles/TileSort.cpp
+++ b/src/particles/TileSort.cpp
@@ -33,7 +33,7 @@ findParticlesInEachTile (
         bins.build(
             amrex::BinPolicy::OpenMP, pti.numParticles(), pti.GetArrayOfStructs().begin(), cbx,
             // Pass lambda function that returns the tile index
-            [=] AMREX_GPU_HOST_DEVICE (const PlasmaParticleContainer::ParticleType& p)
+            [=] (const PlasmaParticleContainer::ParticleType& p)
             noexcept -> amrex::IntVect
             {
                 return amrex::IntVect(


### PR DESCRIPTION
Seen with CUDA 11.3 on Juwels with C++17 builds:
```
/p/home/jusers/huebl1/juwels/src/hipace/src/particles/SliceSort.cpp:40:17:   required from here
nvcc_internal_extended_lambda_implementation:696:77: error: ‘operator()’ is not a member of ‘amrex::IntVect (findParticlesInEachSlice(int, int, amrex::Box, BeamParticleContainer&, const amrex::Vector<amrex::Geometry>&, const BoxSorter&)::<lambda(const ParticleType&)>::*)(const amrex::Particle<0, 0>&) const noexcept’
/p/home/jusers/huebl1/juwels/src/hipace/src/particles/SliceSort.cpp: In function ‘BeamBins findParticlesInEachSlice(int, int, amrex::Box, BeamParticleContainer&, const amrex::Vector<amrex::Geometry>&, const BoxSorter&)’:
/p/home/jusers/huebl1/juwels/src/hipace/src/particles/SliceSort.cpp:40:17: error: no matching function for call to ‘__nv_hdl_create_wrapper_t<false, false, __nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, int, amrex::Box, BeamParticleContainer&, const amrex::Vector<amrex::Geometry>&, const BoxSorter&), findParticlesInEachSlice, 1>, const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3>::__nv_hdl_create_wrapper(findParticlesInEachSlice(int, int, amrex::Box, BeamParticleContainer&, const amrex::Vector<amrex::Geometry>&, const BoxSorter&)::<lambda(const ParticleType&)>, const amrex::GpuArray<double, 3>&, const amrex::GpuArray<double, 3>&, const amrex::Dim3&)’
   40 |         });
      |                 ^
nvcc_internal_extended_lambda_implementation:715:13: note: candidate: ‘template<class Lambda> static decltype (typename __nv_hdl_helper_trait_outer<IsMutable, HasFuncPtrConv, CaptureArgs ...>::__nv_hdl_helper_trait<Tag, Lambda>::get(lam, __nv_hdl_create_wrapper_t<IsMutable, HasFuncPtrConv, Tag, CaptureArgs ...>::__nv_hdl_create_wrapper::args ...)) __nv_hdl_create_wrapper_t<IsMutable, HasFuncPtrConv, Tag, CaptureArgs>::__nv_hdl_create_wrapper(Lambda&&, CaptureArgs ...) [with Lambda = Lambda; bool IsMutable = false; bool HasFuncPtrConv = false; Tag = __nv_dl_tag<amrex::DenseBins<amrex::Particle<0, 0> > (*)(int, int, amrex::Box, BeamParticleContainer&, const amrex::Vector<amrex::Geometry>&, const BoxSorter&), findParticlesInEachSlice, 1>; CaptureArgs = {const amrex::GpuArray<double, 3>, const amrex::GpuArray<double, 3>, const amrex::Dim3}]’
nvcc_internal_extended_lambda_implementation:715:13: note:   substitution of deduced template arguments resulted in errors seen above
```

Same as: https://github.com/ECP-WarpX/WarpX/pull/2129

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
