### PR TITLE
update cmake in maxwell doc

### DIFF
--- a/docs/source/building/platforms/maxwell_desy.rst
+++ b/docs/source/building/platforms/maxwell_desy.rst
@@ -28,8 +28,8 @@ Install HiPACE++ (the first time, and whenever you want the latest version):
    git clone https://github.com/Hi-PACE/hipace.git $HOME/src/hipace # only the first time
    cd $HOME/src/hipace
    rm -rf build
-   cmake3 -S . -B build -DHiPACE_COMPUTE=CUDA
-   cmake3 --build build -j 16
+   cmake -S . -B build -DHiPACE_COMPUTE=CUDA
+   cmake --build build -j 16
 
 You can get familiar with the HiPACE++ input file format in our :doc:`../../run/get_started`
 section, to prepare an input file that suits your needs. You can then create your directory on


### PR DESCRIPTION
Related to #650:

Previously on Maxwell, `cmake` was referring to `cmake 2.x` and we used `cmake3`, which refers to `cmake 3.17`. Now, it got updated so that `cmake` refers to `cmake 3.20`, while `cmake3` still refers to `cmake 3.17`.

This PR updates the doc to use `cmake 3.20`

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
