### PR TITLE
ignore or remove unused parameters

### DIFF
--- a/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
@@ -237,7 +237,6 @@ namespace AnyDST
         DSTplan dst_plan;
         const int nx = real_size[0];
         const int ny = real_size[1];
-        rocfft_status status;
         int dim = 2;
 
         // Allocate expanded_position_array Real of size (2*nx+2, 2*ny+2)

--- a/src/particles/ShapeFactors.H
+++ b/src/particles/ShapeFactors.H
@@ -20,6 +20,7 @@ template <int depos_order>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int compute_shape_factor (amrex::Real* const sx, amrex::Real xint)
 {
+    amrex::ignore_unused(sx, xint);
     return 0;
 }
 


### PR DESCRIPTION
In HIP CI I noticed a few warnings for unused parameters. 

In `WarpRocDST.cpp` the variable `rocfft_status status;` is indeed never used (later a `rocfft_status result` is used), so I removed it.

In the templated `compute_shape_factor` two variables are not used, the warning is suppressed by `amrex::ignore_unused()`

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
