### PR TITLE
More detailed performance diagnostics of AdvancePlasmaParticles

### DIFF
--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -11,17 +11,19 @@
 #include "GetAndSetPosition.H"
 #include "utils/HipaceProfilerWrapper.H"
 
+#include <string>
+
 void
 AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
                         amrex::Geometry const& gm, const bool temp_slice, const bool do_push,
                         const bool do_update, const bool do_shift, int const lev,
                         PlasmaBins& bins)
 {
-    char str[38] = "UpdateForcePushParticles_Plasma(    )";
-    if (temp_slice) str[32] = 't';
-    if (do_push) str[33] = 'p';
-    if (do_update) str[34] = 'u';
-    if (do_shift) str[35] = 's';
+    std::string str = "UpdateForcePushParticles_Plasma(    )";
+    if (temp_slice) str.at(32) = 't';
+    if (do_push) str.at(33) = 'p';
+    if (do_update) str.at(34) = 'u';
+    if (do_shift) str.at(35) = 's';
     HIPACE_PROFILE(str);
     using namespace amrex::literals;
 

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -17,11 +17,11 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
                         const bool do_update, const bool do_shift, int const lev,
                         PlasmaBins& bins)
 {
-    char str[60] = "UpdateForcePushParticles_PlasmaParticleContainer(    )";
-    if (temp_slice) str[49] = 't';
-    if (do_push) str[50] = 'p';
-    if (do_update) str[51] = 'u';
-    if (do_shift) str[52] = 's';
+    char str[38] = "UpdateForcePushParticles_Plasma(    )";
+    if (temp_slice) str[32] = 't';
+    if (do_push) str[33] = 'p';
+    if (do_update) str[34] = 'u';
+    if (do_shift) str[35] = 's';
     HIPACE_PROFILE(str);
     using namespace amrex::literals;
 

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -17,7 +17,12 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
                         const bool do_update, const bool do_shift, int const lev,
                         PlasmaBins& bins)
 {
-    HIPACE_PROFILE("UpdateForcePushParticles_PlasmaParticleContainer()");
+    char str[60] = "UpdateForcePushParticles_PlasmaParticleContainer(    )";
+    if (temp_slice) str[49] = 't';
+    if (do_push) str[50] = 'p';
+    if (do_update) str[51] = 'u';
+    if (do_shift) str[52] = 's';
+    HIPACE_PROFILE(str);
     using namespace amrex::literals;
 
     // only push plasma particles on their according MR level


### PR DESCRIPTION
Split up (and shorten name of) `UpdateForcePushParticles_PlasmaParticleContainer()` in the following way:

```
UpdateForcePushParticles_Plasma(tpus)
t: temp_slice
p: do_push
u: do_update
s: do_shift
```

```
TinyProfiler total time across processes [min...avg...max]: 74.1 ... 74.1 ... 74.1

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
DepositCurrent_PlasmaParticleContainer()            15873      28.09      28.09      28.09  37.91%
UpdateForcePushParticles_Plasma(tp  )               15360      16.44      16.44      16.44  22.19%
UpdateForcePushParticles_Plasma(  u )               15360      6.478      6.478      6.478   8.74%
AnyDST::C2Rfft()                                   129024      4.024      4.024      4.024   5.43%
Hipace::PredictorCorrectorLoopToSolveBxBy()           512      3.284      3.284      3.284   4.43%
AnyDST::ToComplex()                                129024      2.232      2.232      2.232   3.01%
AnyDST::ToSine()                                   129024      1.611      1.611      1.611   2.17%
AnyDST::Transpose()                                129024      1.436      1.436      1.436   1.94%
DepositCurrentSlice_BeamParticleContainer()         15872      1.282      1.282      1.282   1.73%
Fields::ComputeRelBFieldError()                     15872      1.231      1.231      1.231   1.66%
FillBoundary_nowait()                               32768     0.9452     0.9452     0.9452   1.28%
MultiFab::LinComb()                                 62464     0.9205     0.9205     0.9205   1.24%
FFTPoissonSolverDirichlet::SolvePoissonEquation()   32256     0.8529     0.8529     0.8529   1.15%
FabArray::setVal()                                  62988     0.7573     0.7573     0.7573   1.02%
UpdateForcePushParticles_Plasma( p  )                 512     0.5635     0.5635     0.5635   0.76%
Fields::LinCombination()                            32256     0.5404     0.5404     0.5404   0.73%
Hipace::WriteDiagnostics()                              2     0.5224     0.5224     0.5224   0.71%
MultiFab::Add()                                     32768     0.5196     0.5196     0.5196   0.70%
MultiFab::Copy()                                    33280     0.4515     0.4515     0.4515   0.61%
AnyDST::Execute()                                   64512     0.4089     0.4089     0.4089   0.55%
Hipace::SolveOneSlice()                               512     0.2272     0.2272     0.2272   0.31%
UpdateForcePushParticles_Plasma(  us)                 512     0.2151     0.2151     0.2151   0.29%
WriteBeamParticleData()                                 1      0.164      0.164      0.164   0.22%
AnyDST::CreatePlan()                                    1     0.1482     0.1482     0.1482   0.20%
```




- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
