### PR TITLE
move unused variable in serial to MPI code

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1113,9 +1113,9 @@ Hipace::Notify (const int step, const int it,
 {
     HIPACE_PROFILE("Hipace::Notify()");
 
+#ifdef AMREX_USE_MPI
     constexpr int lev = 0;
 
-#ifdef AMREX_USE_MPI
     NotifyFinish(it, only_ghost); // finish the previous send
 
     const int nbeams = m_multi_beam.get_nbeams();


### PR DESCRIPTION
When compiling in serial, there was a warning for an unused parameter in `Notify`.
The parameter is used below  `#ifdef AMREX_USE_MPI` to silence the warning.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
