### PR TITLE
add safeguard for bugged cuda version, and print cuda version

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -246,6 +246,10 @@ Hipace::InitData ()
 #else
     amrex::Print() << "HiPACE++ (" << Hipace::Version() << ") running in double precision\n";
 #endif
+#ifdef AMREX_USE_CUDA
+    amrex::Print() << "using CUDA version " << __CUDACC_VER_MAJOR__ << "." << __CUDACC_VER_MINOR__
+                   << "." << __CUDACC_VER_BUILD__ << "\n";
+#endif
 
 
     amrex::Vector<amrex::IntVect> new_max_grid_size;

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -238,8 +238,8 @@ namespace AnyDST
 
         if (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 1) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE((std::max(real_size[0], real_size[1]) <= 1024),
-                "Due to a bug in cuFFT, CUDA 11.1 supports only grid sizes <= 1024 grid points. "
-                "Please use CUDA version >= 11.2 (recommended) or <= 11.0 for larger grid sizes.");
+            "Due to a bug in cuFFT, CUDA 11.1 supports only nx, ny <= 1024. Please use CUDA "
+            "version >= 11.2 (recommended) or <= 11.0 for larger grid sizes.");
         }
 
         if(!dst_plan.use_small_dst) {

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -236,6 +236,12 @@ namespace AnyDST
         dst_plan.use_small_dst = (std::max(real_size[0], real_size[1]) >= 511);
         queryWithParser(pp, "use_small_dst", dst_plan.use_small_dst);
 
+        if (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 1) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE((std::max(real_size[0], real_size[1]) <= 1024),
+                "Due to a bug in cuFFT, CUDA 11.1 supports only grid sizes <= 1024 grid points. "
+                "Please use CUDA version >= 11.2 (recommended) or <= 11.0 for larger grid sizes.");
+        }
+
         if(!dst_plan.use_small_dst) {
             const int nx = real_size[0];
             const int ny = real_size[1];

--- a/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
@@ -24,6 +24,12 @@ namespace AnyFFT
     {
         FFTplan fft_plan;
 
+        if (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 1) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE((std::max(real_size[0], real_size[1]) <= 1024),
+                "Due to a bug in cuFFT, CUDA 11.1 supports only grid sizes <= 1024 grid points. "
+                "Please use CUDA version >= 11.2 (recommended) or <= 11.0 for larger grid sizes.");
+        }
+
         // Initialize fft_plan.m_plan with the vendor fft plan.
         cufftResult result;
         if (dir == direction::R2C){

--- a/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
@@ -26,8 +26,8 @@ namespace AnyFFT
 
         if (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 1) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE((std::max(real_size[0], real_size[1]) <= 1024),
-                "Due to a bug in cuFFT, CUDA 11.1 supports only grid sizes <= 1024 grid points. "
-                "Please use CUDA version >= 11.2 (recommended) or <= 11.0 for larger grid sizes.");
+            "Due to a bug in cuFFT, CUDA 11.1 supports only nx, ny <= 1024. Please use CUDA "
+            "version >= 11.2 (recommended) or <= 11.0 for larger grid sizes.");
         }
 
         // Initialize fft_plan.m_plan with the vendor fft plan.


### PR DESCRIPTION
Due to a bug in cuFFT in CUDA version 11.1, the FFTs return 0 if if the grid size is larger than 1024 grid points (it fails for 2048 grid points). 
This PR asserts for the version and grid size, preventing the user from getting faulty results without explanation.

Additionally, as a quality of life improvement, the CUDA version is printed at the beginning of the initialization.

last test missing:
- [x] check that the assert triggers for CUDA 11.1

I checked that CUDA 11.2 and 11.0 do not reproduce this bug.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
