### PR TITLE
choose default output path by backend

### DIFF
--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -152,7 +152,7 @@ public:
     void reset ();
 
     /** Prefix/path for the output files */
-    std::string m_file_prefix = "diags/hdf5";
+    std::string m_file_prefix;
 
     /** Temporary workaround to display normalized momentum correctly */
     bool m_openpmd_viewer_workaround = true;

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -12,8 +12,28 @@ OpenPMDWriter::OpenPMDWriter ()
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_real_names.size() == BeamIdx::nattribs,
         "List of real names in openPMD Writer class do not match BeamIdx::nattribs");
     amrex::ParmParse pp("hipace");
-    queryWithParser(pp, "file_prefix", m_file_prefix);
     queryWithParser(pp, "openpmd_backend", m_openpmd_backend);
+    // pick first available backend if default is chosen
+    if( m_openpmd_backend == "default" ) {
+#if openPMD_HAVE_HDF5==1
+        m_openpmd_backend = "h5";
+#elif openPMD_HAVE_ADIOS2==1
+        m_openpmd_backend = "bp";
+#else
+        m_openpmd_backend = "json";
+#endif
+    }
+
+    // set default output path according to backend
+    if (m_openpmd_backend == "h5") {
+        m_file_prefix = "diags/hdf5";
+    } else if (m_openpmd_backend == "bp") {
+        m_file_prefix = "diags/adios2";
+    } else if (m_openpmd_backend == "json") {
+        m_file_prefix = "diags/json";
+    }
+    // overwrite output path by choice of the user
+    queryWithParser(pp, "file_prefix", m_file_prefix);
 
     // temporary workaround until openPMD-viewer gets fixed
     amrex::ParmParse ppd("diagnostic");
@@ -29,17 +49,6 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
     // Dump every m_output_period steps and after last step
     if (output_period < 0 ||
        (!(output_step == max_step) && output_step % output_period != 0)) return;
-
-    // pick first available backend if default is chosen
-    if( m_openpmd_backend == "default" ) {
-#if openPMD_HAVE_HDF5==1
-        m_openpmd_backend = "h5";
-#elif openPMD_HAVE_ADIOS2==1
-        m_openpmd_backend = "bp";
-#else
-        m_openpmd_backend = "json";
-#endif
-    }
 
     if (nlev > 1) {
         for (int lev=0; lev<nlev; ++lev) {


### PR DESCRIPTION
This PR resolves #655.

Previously, the default output path was always `diags/hdf5` even if the backend was adios2. Now, the default output path will be set according to the chosen backend. 

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
