### PR TITLE
fix typo in table in documentation

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -16,16 +16,17 @@ in the input script with `my_constants`.
     my_constants.kp_inv = "clight / sqrt(ne * q_e^2  / (epsilon0 * m_e))"
     beam.radius = "kp_inv / 2"
 
-Thereby, the following constants are predefined (variable, name, SI value, normalized value):
+Thereby, the following constants are predefined:
 
-======== =================== ================= ============
-q_e      elementary charge   1.602176634e-19   1
-m_e      electron mass       9.1093837015e-31  1
-m_p      proton mass         1.67262192369e-27 1836.15267343
-epsilon0 vacuum permittivity 8.8541878128e-12  1
-mu0      vacuum permeability 1.25663706212e-06 1
-clight   speed of light      299'792'458.      1
-======== =================== ================= =============
+============ =================== ================= ====================
+**variable** **name**            **SI value**      **normalized value**
+q_e          elementary charge   1.602176634e-19   1
+m_e          electron mass       9.1093837015e-31  1
+m_p          proton mass         1.67262192369e-27 1836.15267343
+epsilon0     vacuum permittivity 8.8541878128e-12  1
+mu0          vacuum permeability 1.25663706212e-06 1
+clight       speed of light      299'792'458.      1
+============ =================== ================= ====================
 
 For a list of supported functions see the
 `AMReX documentation <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parser>`__.


### PR DESCRIPTION
There was a small typo in the table for the predefined constants in the documentation and it did not appear as a consequence.
This PR fixes the problem and puts the headings into the table, too

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
