### PR TITLE
Fix crash in debug mode caused by missized geometry

### DIFF
--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -132,13 +132,15 @@ void
 Diagnostic::TrimIOBox (amrex::Box& box_3d, amrex::Box& domain_3d, amrex::RealBox& rbox_3d)
 {
     if (m_slice_dir >= 0){
+        const amrex::Real half_cell_size = rbox_3d.length(m_slice_dir) /
+                                           ( 2 * domain_3d.length(m_slice_dir) );
+        const amrex::Real mid = (rbox_3d.lo(m_slice_dir) + rbox_3d.hi(m_slice_dir)) / 2;
         // Flatten the box down to 1 cell in the approprate direction.
         box_3d.setSmall(m_slice_dir, 0);
         box_3d.setBig  (m_slice_dir, 0);
         domain_3d.setSmall(m_slice_dir, 0);
         domain_3d.setBig  (m_slice_dir, 0);
-        const amrex::Real mid = (rbox_3d.lo(m_slice_dir) + rbox_3d.hi(m_slice_dir))/2;
-        rbox_3d.setLo(m_slice_dir, mid);
-        rbox_3d.setHi(m_slice_dir, mid);
+        rbox_3d.setLo(m_slice_dir, mid - half_cell_size);
+        rbox_3d.setHi(m_slice_dir, mid + half_cell_size);
     }
 }

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -133,8 +133,8 @@ Diagnostic::TrimIOBox (amrex::Box& box_3d, amrex::Box& domain_3d, amrex::RealBox
 {
     if (m_slice_dir >= 0){
         const amrex::Real half_cell_size = rbox_3d.length(m_slice_dir) /
-                                           ( 2 * domain_3d.length(m_slice_dir) );
-        const amrex::Real mid = (rbox_3d.lo(m_slice_dir) + rbox_3d.hi(m_slice_dir)) / 2;
+                                           ( 2. * domain_3d.length(m_slice_dir) );
+        const amrex::Real mid = (rbox_3d.lo(m_slice_dir) + rbox_3d.hi(m_slice_dir)) / 2.;
         // Flatten the box down to 1 cell in the approprate direction.
         box_3d.setSmall(m_slice_dir, 0);
         box_3d.setBig  (m_slice_dir, 0);


### PR DESCRIPTION
For Hipace it’s only important that `(lo+hi)/2` is the center point of the 3d box, however amrex additionally asserts `hi > lo`.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
