### PR TITLE
Normalize explicit solver with nominal density rather than max density

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -200,6 +200,10 @@ plasma parameters for each plasma are specified via `<plasma name>.plasma_proper
     The names of the plasmas, separated by a space.
     To run without plasma, choose the name `no_plasma`.
 
+* ``plasmas.nominal_density`` (`string`) optional (default `1.` in normalized units, `1.e23` in SI units)
+    Nominal density (in number per cubic meter) by which quantities are normalized in the explicit solver.
+    This should be roughly the peak density of the unperturbed plasma.
+
 * ``<plasma name>.density(x,y,z)`` (`float`) optional (default `0.`)
     The plasma density as function of `x`, `y` and `z`. `x` and `y` coordinates are taken from
     the simulation box and :math:`z = time \cdot c`. The density gets recalculated at the beginning

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -393,7 +393,7 @@ Hipace::Evolve ()
 
         if (m_verbose>=1) std::cout<<"Rank "<<rank<<" started  step "<<step<<" with dt = "<<m_dt<<'\n';
 
-        m_multi_plasma.CheckDensity();
+        if (m_explicit) m_multi_plasma.CheckDensity();
 
         ResetAllQuantities();
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -393,6 +393,8 @@ Hipace::Evolve ()
 
         if (m_verbose>=1) std::cout<<"Rank "<<rank<<" started  step "<<step<<" with dt = "<<m_dt<<'\n';
 
+        m_multi_plasma.CheckDensity();
+
         ResetAllQuantities();
 
         /* Store charge density of (immobile) ions into WhichSlice::RhoIons */
@@ -656,7 +658,7 @@ Hipace::ExplicitSolveBxBy (const int lev)
 
     // preparing conversion to normalized units, if applicable
     PhysConst pc = m_phys_const;
-    const amrex::Real n0 = m_multi_plasma.maxDensity();
+    const amrex::Real n0 = m_multi_plasma.GetNominalDensity();
     const amrex::Real omegap = std::sqrt(n0 * pc.q_e*pc.q_e/(pc.m_e*pc.ep0));
     const amrex::Real kp = omegap/pc.c;
     const amrex::Real kpinv = 1./kp;

--- a/src/particles/MultiPlasma.H
+++ b/src/particles/MultiPlasma.H
@@ -51,7 +51,7 @@ public:
      * the max is taken across species AND include m_adaptive_density, giving a way to
      * specify a density to the adaptive time step calculator even with no plasma species.
      */
-    amrex::Real maxDensity ();
+    amrex::Real maxDensity () const;
 
     /** \brief Loop over plasma species and Gather fields, update forces and push particles
      *
@@ -106,6 +106,13 @@ public:
     /** returns u_std of the plasma distribution */
     amrex::RealVect GetUStd () const;
 
+    /** Return the nominal density */
+    amrex::Real GetNominalDensity () const {return m_nominal_density;};
+
+    /** Check whether the on-axis density is close enough to the nominal density,
+     * to avoid machine-precision problems. */
+    void CheckDensity () const;
+
     int m_sort_bin_size {32}; /**< Tile size to sort plasma particles */
 
 private:
@@ -116,6 +123,7 @@ private:
     int m_nplasmas = 0; /**< number of plasma containers */
     /** Background (hypothetical) density, used to compute the adaptive time step */
     amrex::Real m_adaptive_density = 0.;
+    amrex::Real m_nominal_density; /**< Density to normalize quantities in the explicit solver */
 };
 
 #endif // MULTIPLASMA_H_


### PR DESCRIPTION
This fixes a bug reported by users: when using a longitudinally-varying density profile with the explicit solver, the results were incorrect. This is because the explicit solver normalized all quantities with the local density, leading to some inconsistencies (in particular the cell size was wrongfully modified). This PR proposes to normalize quantities in the explicit solver with a nominal quantity, constant during the simulation.