### PR TITLE
Fix failing CI caused by a change in AMReX

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,8 @@ jobs:
         cmake ..                                   \
             -DHiPACE_COMPUTE=OMP                   \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-hipace  \
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_STANDARD=17                \
+            -DHiPACE_amrex_branch=22.01
         make -j 2 VERBOSE=ON
         export OMP_NUM_THREADS=2
         ctest --output-on-failure


### PR DESCRIPTION
CI currently fails due to a change in AMReX. This PR proposes to temporarily use a previous AMReX release in CI, until the issue is resolved.