### PR TITLE
Restore default behavior: use latest amrex development

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,8 +39,7 @@ jobs:
         cmake ..                                   \
             -DHiPACE_COMPUTE=OMP                   \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-hipace  \
-            -DCMAKE_CXX_STANDARD=17                \
-            -DHiPACE_amrex_branch=22.01
+            -DCMAKE_CXX_STANDARD=17
         make -j 2 VERBOSE=ON
         export OMP_NUM_THREADS=2
         ctest --output-on-failure

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -154,8 +154,7 @@ set(HiPACE_amrex_src ""
 set(HiPACE_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(HiPACE_amrex_internal)")
-# set(HiPACE_amrex_branch "development"
-set(HiPACE_amrex_branch "22.01"
+set(HiPACE_amrex_branch "development"
     CACHE STRING
     "Repository branch for HiPACE_amrex_repo if(HiPACE_amrex_internal)")
 


### PR DESCRIPTION
After @atmyers's fix in https://github.com/Hi-PACE/hipace/pull/684, this PR restores the default behavior: use latest AMReX development branch for CI and as default when building the code.