### PR TITLE
Add copyright header to all files

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,3 +1,9 @@
+# Copyright 2022 Axel Huebl
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 name: 🐧 CUDA
 
 on: [push, pull_request]

--- a/.github/workflows/disabled/macos.yml
+++ b/.github/workflows/disabled/macos.yml
@@ -1,3 +1,9 @@
+# Copyright 2020 Axel Huebl, MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 name: macos
 
 on: [pull_request]

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -1,3 +1,9 @@
+# Copyright 2021-2022 Axel Huebl
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 name: 🐧 HIP
 
 on: [push, pull_request]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,3 +1,10 @@
+# Copyright 2020-2022 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 name: linux
 
 on:

--- a/.github/workflows/setup/hip.sh
+++ b/.github/workflows/setup/hip.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+# Copyright 2021-2022 Axel Huebl
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2020 The WarpX Community
 #

--- a/.github/workflows/setup/macos.sh
+++ b/.github/workflows/setup/macos.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2020 The HiPACE++ Community
 #

--- a/.github/workflows/setup/macos_omp.sh
+++ b/.github/workflows/setup/macos_omp.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2020 The HiPACE++ Community
 #

--- a/.github/workflows/setup/nvcc11.sh
+++ b/.github/workflows/setup/nvcc11.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 Axel Huebl
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2021-2022 Axel Huebl
 #

--- a/.github/workflows/setup/nvhpc.sh
+++ b/.github/workflows/setup/nvhpc.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 Axel Huebl
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2021-2022 Axel Huebl
 #

--- a/.github/workflows/setup/ubuntu.sh
+++ b/.github/workflows/setup/ubuntu.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Copyright 2020-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+# Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2020 The HiPACE++ Community
 #

--- a/.github/workflows/setup/ubuntu_clang.sh
+++ b/.github/workflows/setup/ubuntu_clang.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Copyright 2020-2022 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2020-2022 The HiPACE++ Community
 #

--- a/.github/workflows/setup/ubuntu_ompi.sh
+++ b/.github/workflows/setup/ubuntu_ompi.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Copyright 2020-2021 AlexanderSinn, Axel Huebl, MaxThevenet
+# Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2020 The HiPACE++ Community
 #

--- a/.github/workflows/setup/ubuntu_ompi_cuda.sh
+++ b/.github/workflows/setup/ubuntu_ompi_cuda.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2020 The HiPACE++ Community
 #

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -1,3 +1,10 @@
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 # Copyright 2020 Axel Huebl, Maxence Thevenet
 #
 # This file is part of HiPACE++.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright 2020-2022 AlexanderSinn, Andrew Myers, Axel Huebl
+# MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 # Preamble ####################################################################
 #
 cmake_minimum_required(VERSION 3.18.0)

--- a/docs/equations_hipace.tex
+++ b/docs/equations_hipace.tex
@@ -1,3 +1,10 @@
+% Copyright 2021 MaxThevenet, Remi Lehe, Severin Diederichs
+%
+%
+% This file is part of HiPACE++.
+%
+% License: BSD-3-Clause-LBNL
+
 \documentclass{article}
 \usepackage[a4paper, total={6in, 8in}]{geometry}
 \usepackage[utf8]{inputenc}

--- a/docs/optimizations.txt
+++ b/docs/optimizations.txt
@@ -1,3 +1,9 @@
+# Copyright 2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 In order to kick-start HiPACE++, things were done in the simplest way possible, leaving obvious optimizations for later.
 This file lists these easy optimizations, to avoid missing low-hanging fruits.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,9 @@
+# Copyright 2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 sphinx_rtd_theme>=0.4.0
 recommonmark
 sphinx>=3.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,10 @@
+# Copyright 2021-2022 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/examples/beam_in_vacuum/analysis.py
+++ b/examples/beam_in_vacuum/analysis.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code HiPACE++
 #
 # It compares the transverse field By with the theoretical value, plots both

--- a/examples/beam_in_vacuum/analysis_2ranks.py
+++ b/examples/beam_in_vacuum/analysis_2ranks.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import matplotlib.pyplot as plt
 import numpy as np
 import argparse

--- a/examples/beam_in_vacuum/analysis_adaptive_ts.py
+++ b/examples/beam_in_vacuum/analysis_adaptive_ts.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import numpy as np
 import re
 

--- a/examples/beam_in_vacuum/analysis_beam_push.py
+++ b/examples/beam_in_vacuum/analysis_beam_push.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import matplotlib.pyplot as plt
 import matplotlib
 import argparse

--- a/examples/beam_in_vacuum/analysis_from_file.py
+++ b/examples/beam_in_vacuum/analysis_from_file.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2021 AlexanderSinn, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code HiPACE++
 #
 # It is used in the beam from_file test and compares three beams,

--- a/examples/beam_in_vacuum/analysis_grid_current.py
+++ b/examples/beam_in_vacuum/analysis_grid_current.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code Hipace
 #
 # It calculates the sum of jz. The beam current and the grid current should cancel each other.

--- a/examples/beam_in_vacuum/analysis_transverse.py
+++ b/examples/beam_in_vacuum/analysis_transverse.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2021 MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code Hipace
 #
 # It compares the transverse field By from a serial and a parallel simulation

--- a/examples/blowout_wake/analysis.py
+++ b/examples/blowout_wake/analysis.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code HiPACE++
 #
 # It compares the transverse field By with the theoretical value, plots both

--- a/examples/blowout_wake/analysis_coarsening.py
+++ b/examples/blowout_wake/analysis_coarsening.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2021 AlexanderSinn
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code Hipace
 #
 # It compares a field from a simulation with full IO and from a simulation with coarse IO

--- a/examples/blowout_wake/analysis_slice_IO.py
+++ b/examples/blowout_wake/analysis_slice_IO.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code Hipace
 #
 # It compares a field from a simulation with full IO and from a simulation with only slice IO

--- a/examples/gaussian_weight/analysis.py
+++ b/examples/gaussian_weight/analysis.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants as scc

--- a/examples/linear_wake/analysis.py
+++ b/examples/linear_wake/analysis.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python3
 
+# Copyright 2020-2021 Axel Huebl, MathisMewes, MaxThevenet
+# Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This Python analysis script is part of the code Hipace
 #
 # It compares the transverse field By with the theoretical value, plots both

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright 2020 Andrew Myers, Axel Huebl, MaxThevenet
+# Severin Diederichs, atmyers
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     main.cpp

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -1,3 +1,11 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, Axel Huebl
+ * MaxThevenet, Remi Lehe, Severin Diederichs
+ * WeiqunZhang
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_H_
 #define HIPACE_H_
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, Axel Huebl
+ * MaxThevenet, Remi Lehe, Severin Diederichs
+ * WeiqunZhang, coulibaly-mouhamed
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "particles/SliceSort.H"

--- a/src/diagnostics/CMakeLists.txt
+++ b/src/diagnostics/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     OpenPMDWriter.cpp

--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -1,3 +1,10 @@
+/* Copyright 2021-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef DIAGNOSTIC_H_
 #define DIAGNOSTIC_H_
 

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2021-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "Diagnostic.H"
 #include "Hipace.H"
 #include <AMReX_ParmParse.H>

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef OPENPMDWRITER_H_
 #define OPENPMDWRITER_H_
 

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "diagnostics/OpenPMDWriter.H"
 #include "fields/Fields.H"
 #include "utils/HipaceProfilerWrapper.H"

--- a/src/fields/CMakeLists.txt
+++ b/src/fields/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright 2020 Andrew Myers, MaxThevenet, Remi Lehe
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     Fields.cpp

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -1,3 +1,11 @@
+/* Copyright 2020-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+ * Remi Lehe, Severin Diederichs, WeiqunZhang
+ * coulibaly-mouhamed
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef FIELDS_H_
 #define FIELDS_H_
 

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ * WeiqunZhang, coulibaly-mouhamed
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "Fields.H"
 #include "fft_poisson_solver/FFTPoissonSolverPeriodic.H"
 #include "fft_poisson_solver/FFTPoissonSolverDirichlet.H"

--- a/src/fields/fft_poisson_solver/CMakeLists.txt
+++ b/src/fields/fft_poisson_solver/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright 2020 Andrew Myers, MaxThevenet, Remi Lehe
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     FFTPoissonSolver.cpp

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -1,3 +1,10 @@
+/* Copyright 2020 Axel Huebl, MaxThevenet, Remi Lehe
+ * WeiqunZhang
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef FFT_POISSON_SOLVER_H_
 #define FFT_POISSON_SOLVER_H_
 

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020 MaxThevenet, Remi Lehe, WeiqunZhang
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "FFTPoissonSolver.H"
 
 FFTPoissonSolver::~FFTPoissonSolver ()

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef FFT_POISSON_SOLVER_DIRICHLET_H_
 #define FFT_POISSON_SOLVER_DIRICHLET_H_
 

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+ * Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "FFTPoissonSolverDirichlet.H"
 #include "fft/AnyDST.H"
 #include "utils/Constants.H"

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
@@ -1,3 +1,10 @@
+/* Copyright 2020 Axel Huebl, MaxThevenet, Remi Lehe
+ * WeiqunZhang
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef FFT_POISSON_SOLVER_PERIODIC_H_
 #define FFT_POISSON_SOLVER_PERIODIC_H_
 

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+ * Remi Lehe, WeiqunZhang
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "FFTPoissonSolverPeriodic.H"
 #include "fft/AnyFFT.H"
 #include "utils/Constants.H"

--- a/src/fields/fft_poisson_solver/fft/AnyDST.H
+++ b/src/fields/fft_poisson_solver/fft/AnyDST.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef ANYDST_H_
 #define ANYDST_H_
 

--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 Axel Huebl, MaxThevenet, Remi Lehe
+ * Severin Diederichs, WeiqunZhang
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019-2020
  *
  * This file is part of WarpX.

--- a/src/fields/fft_poisson_solver/fft/CMakeLists.txt
+++ b/src/fields/fft_poisson_solver/fft/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Remi Lehe
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 if (HiPACE_COMPUTE STREQUAL CUDA)
   target_sources(HiPACE
     PRIVATE

--- a/src/fields/fft_poisson_solver/fft/CuFFTUtils.H
+++ b/src/fields/fft_poisson_solver/fft/CuFFTUtils.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 Axel Huebl, MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef CUFFTUTILS_H_
 #define CUFFTUTILS_H_
 

--- a/src/fields/fft_poisson_solver/fft/CuFFTUtils.cpp
+++ b/src/fields/fft_poisson_solver/fft/CuFFTUtils.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2020 MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "CuFFTUtils.H"
 
 #include <map>

--- a/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
+++ b/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 Axel Huebl
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef ROCFFTUTILS_H_
 #define ROCFFTUTILS_H_
 

--- a/src/fields/fft_poisson_solver/fft/RocFFTUtils.cpp
+++ b/src/fields/fft_poisson_solver/fft/RocFFTUtils.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2021 Axel Huebl
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "RocFFTUtils.H"
 #include <AMReX.H>
 

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "AnyDST.H"
 #include "CuFFTUtils.H"
 #include "utils/HipaceProfilerWrapper.H"

--- a/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 MaxThevenet, Remi Lehe, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019-2020
  *
  * This file is part of WarpX.

--- a/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "AnyDST.H"
 #include "utils/HipaceProfilerWrapper.H"
 

--- a/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2020 MaxThevenet, Remi Lehe
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019-2020
  *
  * This file is part of WarpX.

--- a/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2021-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+ * Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "AnyDST.H"
 #include "RocFFTUtils.H"
 #include "utils/HipaceProfilerWrapper.H"

--- a/src/fields/fft_poisson_solver/fft/WrapRocFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocFFT.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2021 Axel Huebl
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019-2020
  *
  * This file is part of WarpX.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+ * Weiqun Zhang
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -1,3 +1,11 @@
+/* Copyright 2020-2021 AlexanderSinn, Andrew Myers, Axel Huebl
+ * MaxThevenet, Remi Lehe, Severin Diederichs
+ * atmyers
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_BeamParticleContainer_H_
 #define HIPACE_BeamParticleContainer_H_
 

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 AlexanderSinn, Andrew Myers, MaxThevenet
+ * Remi Lehe, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "BeamParticleContainer.H"
 #include "utils/Constants.H"
 #include "Hipace.H"

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2020-2021 AlexanderSinn, Andrew Myers, Axel Huebl
+ * MaxThevenet, Severin Diederichs, Weiqun Zhang
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "BeamParticleContainer.H"
 #include "utils/Constants.H"
 #include "ParticleUtil.H"

--- a/src/particles/BoxSort.H
+++ b/src/particles/BoxSort.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_BoxSort_H_
 #define HIPACE_BoxSort_H_
 

--- a/src/particles/BoxSort.cpp
+++ b/src/particles/BoxSort.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2021 AlexanderSinn, MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "BoxSort.H"
 
 #include <AMReX_ParticleTransformation.H>

--- a/src/particles/CMakeLists.txt
+++ b/src/particles/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Copyright 2020-2021 Andrew Myers, Axel Huebl, MaxThevenet
+# Remi Lehe, Severin Diederichs, atmyers
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     BeamParticleContainer.cpp

--- a/src/particles/ExternalFields.H
+++ b/src/particles/ExternalFields.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef EXTERNALFIELDS_H_
 #define EXTERNALFIELDS_H_
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef MULTIBEAM_H_
 #define MULTIBEAM_H_
 

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "MultiBeam.H"
 #include "deposition/BeamDepositCurrent.H"
 #include "particles/SliceSort.H"

--- a/src/particles/MultiPlasma.H
+++ b/src/particles/MultiPlasma.H
@@ -1,3 +1,10 @@
+/* Copyright 2021-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef MULTIPLASMA_H_
 #define MULTIPLASMA_H_
 

--- a/src/particles/MultiPlasma.cpp
+++ b/src/particles/MultiPlasma.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2021-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "MultiPlasma.H"
 #include "particles/deposition/PlasmaDepositCurrent.H"
 #include "particles/pusher/PlasmaParticleAdvance.H"

--- a/src/particles/ParticleUtil.H
+++ b/src/particles/ParticleUtil.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 Andrew Myers, MaxThevenet, Remi Lehe
+ * Severin Diederichs, Weiqun Zhang
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_ParticleUtil_H_
 #define HIPACE_ParticleUtil_H_
 

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -1,3 +1,11 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, Axel Huebl
+ * MaxThevenet, Severin Diederichs, atmyers
+ * Ángel Ferran Pousa
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_PlasmaParticleContainer_H_
 #define HIPACE_PlasmaParticleContainer_H_
 

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, MaxThevenet
+ * Severin Diederichs, Weiqun Zhang, Ángel Ferran Pousa
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "Hipace.H"
 #include "PlasmaParticleContainer.H"
 #include "utils/HipaceProfilerWrapper.H"

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -1,3 +1,11 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, Axel Huebl
+ * MaxThevenet, Severin Diederichs, Weiqun Zhang
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "PlasmaParticleContainer.H"
 #include "utils/Constants.H"
 #include "ParticleUtil.H"

--- a/src/particles/ShapeFactors.H
+++ b/src/particles/ShapeFactors.H
@@ -1,3 +1,11 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, MaxThevenet
+ * Remi Lehe, Severin Diederichs, WeiqunZhang
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019 Maxence Thevenet
  *
  * This file is part of WarpX.

--- a/src/particles/SliceSort.H
+++ b/src/particles/SliceSort.H
@@ -1,3 +1,9 @@
+/* Copyright 2021-2022 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_SLICESORT_H_
 #define HIPACE_SLICESORT_H_
 

--- a/src/particles/SliceSort.cpp
+++ b/src/particles/SliceSort.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2021-2022 Axel Huebl, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "SliceSort.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "Hipace.H"

--- a/src/particles/TileSort.H
+++ b/src/particles/TileSort.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_TILESORT_H_
 #define HIPACE_TILESORT_H_
 

--- a/src/particles/TileSort.cpp
+++ b/src/particles/TileSort.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2021-2022 Axel Huebl, MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "TileSort.H"
 #include "utils/HipaceProfilerWrapper.H"
 

--- a/src/particles/deposition/BeamDepositCurrent.H
+++ b/src/particles/deposition/BeamDepositCurrent.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Remi Lehe
+ * Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef BEAMDEPOSITCURRENT_H_
 #define BEAMDEPOSITCURRENT_H_
 

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, MaxThevenet
+ * Remi Lehe, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "BeamDepositCurrent.H"
 #include "particles/BeamParticleContainer.H"
 #include "particles/deposition/BeamDepositCurrentInner.H"

--- a/src/particles/deposition/BeamDepositCurrentInner.H
+++ b/src/particles/deposition/BeamDepositCurrentInner.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+ * Remi Lehe, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
  * Remi Lehe, Weiqun Zhang, Michael Rowan
  *

--- a/src/particles/deposition/CMakeLists.txt
+++ b/src/particles/deposition/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Copyright 2020 Andrew Myers, MaxThevenet, Remi Lehe
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     BeamDepositCurrent.cpp

--- a/src/particles/deposition/PlasmaDepositCurrent.H
+++ b/src/particles/deposition/PlasmaDepositCurrent.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef PLASMADEPOSITCURRENT_H_
 #define PLASMADEPOSITCURRENT_H_
 

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "PlasmaDepositCurrent.H"
 
 #include "particles/PlasmaParticleContainer.H"

--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, MaxThevenet
+ * Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
  * Remi Lehe, Weiqun Zhang, Michael Rowan
  *

--- a/src/particles/profiles/CMakeLists.txt
+++ b/src/particles/profiles/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright 2020 Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     GetInitialDensity.cpp

--- a/src/particles/profiles/GetInitialDensity.H
+++ b/src/particles/profiles/GetInitialDensity.H
@@ -1,3 +1,9 @@
+/* Copyright 2020 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef GETINTIALDENSITY_H_
 #define GETINTIALDENSITY_H_
 

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "GetInitialDensity.H"
 #include "utils/Parser.H"
 

--- a/src/particles/profiles/GetInitialMomentum.H
+++ b/src/particles/profiles/GetInitialMomentum.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs, Weiqun Zhang
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef GETINTIALMOMENTUM_H_
 #define GETINTIALMOMENTUM_H_
 

--- a/src/particles/profiles/GetInitialMomentum.cpp
+++ b/src/particles/profiles/GetInitialMomentum.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "GetInitialMomentum.H"
 #include "utils/Parser.H"
 

--- a/src/particles/pusher/BeamParticleAdvance.H
+++ b/src/particles/pusher/BeamParticleAdvance.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2022 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef BEAMPARTICLEADVANCE_H_
 #define BEAMPARTICLEADVANCE_H_
 

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, Andrew Myers, MaxThevenet
+ * Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "BeamParticleAdvance.H"
 #include "particles/ExternalFields.H"
 #include "FieldGather.H"

--- a/src/particles/pusher/CMakeLists.txt
+++ b/src/particles/pusher/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright 2020 Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     PlasmaParticleAdvance.cpp

--- a/src/particles/pusher/FieldGather.H
+++ b/src/particles/pusher/FieldGather.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019 Axel Huebl, David Grote, Maxence Thevenet
  * Revathi Jambunathan, Weiqun Zhang
  *

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
  * Weiqun Zhang
  *

--- a/src/particles/pusher/GetDomainLev.H
+++ b/src/particles/pusher/GetDomainLev.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_GETDOMAINLEV_H_
 #define HIPACE_GETDOMAINLEV_H_
 

--- a/src/particles/pusher/PlasmaParticleAdvance.H
+++ b/src/particles/pusher/PlasmaParticleAdvance.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef PLASMAPARTICLEADVANCE_H_
 #define PLASMAPARTICLEADVANCE_H_
 

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "PlasmaParticleAdvance.H"
 
 #include "particles/PlasmaParticleContainer.H"

--- a/src/particles/pusher/PushPlasmaParticles.H
+++ b/src/particles/pusher/PushPlasmaParticles.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef PUSHPLASMAPARTICLES_H_
 #define PUSHPLASMAPARTICLES_H_
 

--- a/src/particles/pusher/UpdateForceTerms.H
+++ b/src/particles/pusher/UpdateForceTerms.H
@@ -1,3 +1,10 @@
+/* Copyright 2020-2022 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef UPDATEFORCETERMS_H_
 #define UPDATEFORCETERMS_H_
 

--- a/src/utils/AdaptiveTimeStep.H
+++ b/src/utils/AdaptiveTimeStep.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef ADAPTIVETIMESTEP_H_
 #define ADAPTIVETIMESTEP_H_
 

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -1,3 +1,10 @@
+/* Copyright 2020-2021 AlexanderSinn, MaxThevenet, Severin Diederichs
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "AdaptiveTimeStep.H"
 #include "utils/DeprecatedInput.H"
 #include "Hipace.H"

--- a/src/utils/AtomicWeightTable.H
+++ b/src/utils/AtomicWeightTable.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 AlexanderSinn
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 // This script was automatically generated!
 // Edit src/utils/write_atomic_weight_cpp.py instead!
 #ifndef HIPACE_ATOMIC_WEIGHT_TABLE_H_

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 target_sources(HiPACE
   PRIVATE
     Constants.cpp

--- a/src/utils/Constants.H
+++ b/src/utils/Constants.H
@@ -1,3 +1,10 @@
+/* Copyright 2020 Axel Huebl, MaxThevenet, Remi Lehe
+ *
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_Constants_H_
 #define HIPACE_Constants_H_
 

--- a/src/utils/Constants.cpp
+++ b/src/utils/Constants.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2020 MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "Constants.H"
 #include "Hipace.H"
 

--- a/src/utils/DeprecatedInput.H
+++ b/src/utils/DeprecatedInput.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_DeprecatedInput_H_
 #define HIPACE_DeprecatedInput_H_
 

--- a/src/utils/GridCurrent.H
+++ b/src/utils/GridCurrent.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef GRIDCURRENT_H_
 #define GRIDCURRENT_H_
 

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2021 AlexanderSinn, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "GridCurrent.H"
 #include "Hipace.H"
 #include "HipaceProfilerWrapper.H"

--- a/src/utils/HipaceProfilerWrapper.H
+++ b/src/utils/HipaceProfilerWrapper.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 AlexanderSinn, MaxThevenet
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 /* Copyright 2020 Axel Huebl, Maxence Thevenet
  *
  * This file is part of WarpX.

--- a/src/utils/IOUtil.H
+++ b/src/utils/IOUtil.H
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_IOUTIL_H_
 #define HIPACE_IOUTIL_H_
 

--- a/src/utils/IOUtil.cpp
+++ b/src/utils/IOUtil.cpp
@@ -1,3 +1,9 @@
+/* Copyright 2020-2021 MaxThevenet, Severin Diederichs
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #include "IOUtil.H"
 
 #include <AMReX_IndexType.H>

--- a/src/utils/IonizationEnergiesTable.H
+++ b/src/utils/IonizationEnergiesTable.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 AlexanderSinn
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 // This script was automatically generated!
 // Edit src/utils/write_atomic_data_cpp.py instead!
 #ifndef HIPACE_IONIZATION_TABLE_H_

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -1,3 +1,9 @@
+/* Copyright 2021 AlexanderSinn
+ *
+ * This file is part of HiPACE++.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
 #ifndef HIPACE_Parser_H_
 #define HIPACE_Parser_H_
 

--- a/src/utils/write_atomic_data_cpp.py
+++ b/src/utils/write_atomic_data_cpp.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+
+# Copyright 2021 AlexanderSinn
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 #
 # Copyright 2019-2020 Axel Huebl, Luca Fedeli, Maxence Thevenet
 #

--- a/src/utils/write_atomic_weight_cpp.py
+++ b/src/utils/write_atomic_weight_cpp.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python
 
+# Copyright 2021 AlexanderSinn
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 """
 This python script reads atomic masses tables in relative_atomic_masses.txt
 (generated from the NIST website) and extracts

--- a/tests/adaptive_time_step.1Rank.sh
+++ b/tests/adaptive_time_step.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a HiPACE++ simulation in the blowout regime and compares the result
 # with SI units.

--- a/tests/beam_evolution.1Rank.sh
+++ b/tests/beam_evolution.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the blowout regime and compares the result
 # with SI units.

--- a/tests/beam_in_vacuum.SI.1Rank.sh
+++ b/tests/beam_in_vacuum.SI.1Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation for a can beam in vacuum, and compares the result
 # of the simulation to theory.

--- a/tests/beam_in_vacuum.SI.Serial.sh
+++ b/tests/beam_in_vacuum.SI.Serial.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation for a can beam in vacuum, and compares the result
 # of the simulation to theory.

--- a/tests/beam_in_vacuum.normalized.1Rank.sh
+++ b/tests/beam_in_vacuum.normalized.1Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation for a can beam in vacuum, and compares the result
 # of the simulation to theory.

--- a/tests/beam_in_vacuum.normalized.2Rank.sh
+++ b/tests/beam_in_vacuum.normalized.2Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation for a can beam in vacuum in serial and parallel and
 # checks that they give the same result

--- a/tests/beam_in_vacuum.normalized.Serial.sh
+++ b/tests/beam_in_vacuum.normalized.Serial.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation for a can beam in vacuum, and compares the result
 # of the simulation to theory.

--- a/tests/blowout_wake.2Rank.sh
+++ b/tests/blowout_wake.2Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Andrew Myers, Axel Huebl, MaxThevenet
+# Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the blowout regime and compares the result
 # with SI units.

--- a/tests/blowout_wake.Serial.sh
+++ b/tests/blowout_wake.Serial.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the blowout regime and cand compares the result
 # of the simulation to a benchmark.

--- a/tests/blowout_wake_explicit.2Rank.sh
+++ b/tests/blowout_wake_explicit.2Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 Andrew Myers, Axel Huebl, MaxThevenet
+# Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in normalized units with the explicit solver
 # in the blowout regime and compares the checksum with a benchmark.

--- a/tests/checksum/__init__.py
+++ b/tests/checksum/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2020 MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+

--- a/tests/checksum/backend/amrex_backend.py
+++ b/tests/checksum/backend/amrex_backend.py
@@ -1,3 +1,9 @@
+# Copyright 2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 Copyright 2021
 

--- a/tests/checksum/backend/openpmd_backend.py
+++ b/tests/checksum/backend/openpmd_backend.py
@@ -1,3 +1,9 @@
+# Copyright 2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 Copyright 2021
 

--- a/tests/checksum/benchmark.py
+++ b/tests/checksum/benchmark.py
@@ -1,3 +1,9 @@
+# Copyright 2020-2021 MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 Copyright 2020
 

--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -1,3 +1,9 @@
+# Copyright 2020-2021 Axel Huebl, MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 Copyright 2020
 

--- a/tests/checksum/checksumAPI.py
+++ b/tests/checksum/checksumAPI.py
@@ -1,5 +1,12 @@
 #! /usr/bin/env python3
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 """
 Copyright 2020
 

--- a/tests/checksum/config.py
+++ b/tests/checksum/config.py
@@ -1,3 +1,9 @@
+# Copyright 2020 MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 """
 Copyright 2020
 

--- a/tests/checksum/reset_all_benchmarks.sh
+++ b/tests/checksum/reset_all_benchmarks.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Copyright 2020-2022 AlexanderSinn, Axel Huebl, MaxThevenet
+# Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It resets all checksum benchmarks one by one,
 # based on the current version of the code.

--- a/tests/from_file.SI.1Rank.sh
+++ b/tests/from_file.SI.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 AlexanderSinn, MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the Hipace test suite.
 # It runs a Hipace simulation in the blowout regime and cand compares the result
 # of the simulation to a benchmark.

--- a/tests/from_file.normalized.1Rank.sh
+++ b/tests/from_file.normalized.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 AlexanderSinn, MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the Hipace test suite.
 # It runs a Hipace simulation in the blowout regime and cand compares the result
 # of the simulation to a benchmark.

--- a/tests/gaussian_linear_wake.SI.1Rank.sh
+++ b/tests/gaussian_linear_wake.SI.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the linear regime with a Gaussian drive beam
 # and compares the result with theory.

--- a/tests/gaussian_linear_wake.normalized.1Rank.sh
+++ b/tests/gaussian_linear_wake.normalized.1Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the linear regime and compares the result
 # with theory.

--- a/tests/gaussian_weight.1Rank.sh
+++ b/tests/gaussian_weight.1Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation initializing a Gaussian beam, and compares the result
 # of the simulation to theory.

--- a/tests/grid_current.1Rank.sh
+++ b/tests/grid_current.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a small simulation with a fixed ppc beam and a grid current and ensures that they cancel
 # each other

--- a/tests/hosing.2Rank.sh
+++ b/tests/hosing.2Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 AlexanderSinn, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the blowout regime and compares the result
 # with SI units.

--- a/tests/ionization.2Rank.sh
+++ b/tests/ionization.2Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 AlexanderSinn, Andrew Myers, Axel Huebl
+# MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation with in neutral hydrogen that gets ionized by the beam
 

--- a/tests/linear_wake.SI.1Rank.sh
+++ b/tests/linear_wake.SI.1Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the linear regime and compares the result
 # with theory.

--- a/tests/linear_wake.normalized.1Rank.sh
+++ b/tests/linear_wake.normalized.1Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Axel Huebl, MaxThevenet, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation in the linear regime and compares the result
 # with theory.

--- a/tests/next_deposition_beam.2Rank.sh
+++ b/tests/next_deposition_beam.2Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation with a beam in vacuum with transverse currents
 # in serial and parallel and asserts that both give the same result.

--- a/tests/output_coarsening.2Rank.sh
+++ b/tests/output_coarsening.2Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 AlexanderSinn
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation with full and coarse IO and compares them
 

--- a/tests/reset.2Rank.sh
+++ b/tests/reset.2Rank.sh
@@ -1,5 +1,13 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 Andrew Myers, Axel Huebl, MaxThevenet
+# Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation for a can beam, and compares the result
 # of the simulation to a benchmark.

--- a/tests/restart.normalized.1Rank.sh
+++ b/tests/restart.normalized.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2021 AlexanderSinn, MaxThevenet
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the Hipace test suite.
 # It runs a Hipace simulation in the blowout regime and cand compares the result
 # of the simulation to a benchmark.

--- a/tests/slice_IO.1Rank.sh
+++ b/tests/slice_IO.1Rank.sh
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+# Copyright 2020-2021 MaxThevenet, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # This file is part of the HiPACE++ test suite.
 # It runs a Hipace simulation with full IO and xz-slice IO, and checks that the results are equal.
 

--- a/tools/analysis.py
+++ b/tools/analysis.py
@@ -1,5 +1,13 @@
 #! /usr/bin/env python
 
+# Copyright 2020 MaxThevenet, Remi Lehe, Severin Diederichs
+#
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
+
 # Plots Ex field and particles at the end of the run,
 # and save image to img.png
 # usage: ./analysis.py

--- a/tools/convert_hipace_to_hipace++_file.py
+++ b/tools/convert_hipace_to_hipace++_file.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+
+# Copyright 2021 AlexanderSinn, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 # convert_hipace_to_hipace++_file.py
 """
 Conversion Script to convert hdf5 beam files to openPMD files that can be used by HiPACE++

--- a/tools/write_beam.py
+++ b/tools/write_beam.py
@@ -1,3 +1,9 @@
+# Copyright 2020-2021 AlexanderSinn, Severin Diederichs
+#
+# This file is part of HiPACE++.
+#
+# License: BSD-3-Clause-LBNL
+
 import math
 import openpmd_api as io
 import numpy as np


### PR DESCRIPTION
This PR proposes to add a Copyright header to all files, by slightly modifying https://github.com/ECP-WarpX/WarpX/blob/development/Tools/DevUtils/update_copyright.sh. Committed with `--author="Tools"`.