### PR TITLE
[WIP] add GPU tiling

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -267,6 +267,7 @@ public:
     static int m_do_device_synchronize;
     /** Whether to use tiling for particle operations */
     static bool m_do_tiling;
+    static bool m_do_gpu_tiling;
     /** How much the box is coarsened for beam injection, to avoid exceeding max int in cell count.
      * Otherwise, changing this parameter only will not affect the simulation results. */
     static int m_beam_injection_cr;

--- a/src/particles/TileSort.cpp
+++ b/src/particles/TileSort.cpp
@@ -38,9 +38,9 @@ findParticlesInEachTile (
 
         // Find the particles that are in each tile and return collections of indices per tile.
         bins.build(
-            amrex::BinPolicy::OpenMP, pti.numParticles(), pti.GetArrayOfStructs().begin(), cbx,
+            pti.numParticles(), pti.GetArrayOfStructs().begin(), cbx,
             // Pass lambda function that returns the tile index
-            [=] (const PlasmaParticleContainer::ParticleType& p)
+            [=] AMREX_GPU_DEVICE (const PlasmaParticleContainer::ParticleType& p)
             noexcept -> amrex::IntVect
             {
                 return amrex::IntVect(

--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -84,6 +84,7 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
     const PhysConst phys_const = get_phys_const();
 
     const bool do_tiling = Hipace::m_do_tiling;
+    const bool do_gpu_tiling = Hipace::m_do_gpu_tiling;
 
     // Extract particle properties
     auto& aos = pti.GetArrayOfStructs(); // For positions
@@ -127,7 +128,7 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
     int n_qsa_violation = 0;
     amrex::Gpu::DeviceScalar<int> gpu_n_qsa_violation(n_qsa_violation);
     int* p_n_qsa_violation = gpu_n_qsa_violation.dataPtr();
-    PlasmaBins::index_type const * const indices = do_tiling ? bins.permutationPtr() : nullptr;
+    PlasmaBins::index_type const * const indices = do_tiling || do_gpu_tiling ? bins.permutationPtr() : nullptr;
     PlasmaBins::index_type const * const offsets = do_tiling ? bins.offsetsPtr() : nullptr;
 
 #ifdef AMREX_USE_OMP
@@ -181,7 +182,11 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
                 num_particles,
                 [=] AMREX_GPU_DEVICE (long idx) {
 
+#ifndef AMREX_USE_GPU
                     const int ip = do_tiling ? indices[offsets[itile]+idx] : idx;
+#else
+                    const int ip = do_gpu_tiling ? indices[idx] : idx;
+#endif
                     if (pos_structs[ip].id() < 0) return;
 
                     const amrex::Real psi = psip[ip] *


### PR DESCRIPTION
This accelerates current deposition a bit (although not much)
```
output_01.txt:DepositCurrent_PlasmaParticleContainer()             5240      8.452      8.452      8.452  30.61%
output_02.txt:DepositCurrent_PlasmaParticleContainer()             5240      7.698      7.698      7.698  28.96%
output_04.txt:DepositCurrent_PlasmaParticleContainer()             5240      8.024      8.024      8.024  28.45%
output_08.txt:DepositCurrent_PlasmaParticleContainer()             5240        8.3        8.3        8.3  25.90%
output_off.txt:DepositCurrent_PlasmaParticleContainer()             5240      8.226      8.226      8.226  31.65%
```
_i means tiling with a tile size of i*i (last line is without tiling)