### PR TITLE
Version Define File

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(HiPACE::HiPACE ALIAS HiPACE)
 # own headers
 target_include_directories(HiPACE PRIVATE
     $<BUILD_INTERFACE:${HiPACE_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${HiPACE_BINARY_DIR}/src>
 )
 
 # if we include <AMReX_buildInfo.H> we will need to call:
@@ -165,8 +166,6 @@ set_hipace_binary_name()
 # Defines #####################################################################
 #
 # Let's use them as sparsely as possible to avoid MxNxOxP... binary variants.
-get_source_version(HiPACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_definitions(HiPACE PUBLIC HIPACE_GIT_VERSION="${HiPACE_GIT_VERSION}")
 
 
 # Warnings ####################################################################
@@ -176,6 +175,13 @@ set_cxx_warnings()
 
 # Generate Configuration and .pc Files ########################################
 #
+get_source_version(HiPACE ${HiPACE_SOURCE_DIR})
+configure_file(
+    ${HiPACE_SOURCE_DIR}/src/HipaceVersion.H.in
+    ${HiPACE_BINARY_DIR}/src/HipaceVersion.H
+    @ONLY
+)
+
 # these files are used if HiPACE is installed and picked up by a downstream
 # project (not needed yet)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(HiPACE
   PRIVATE
     main.cpp
     Hipace.cpp
+    HipaceVersion.cpp
 )
 
 add_subdirectory(fields)

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1385,16 +1385,6 @@ Hipace::WriteDiagnostics (int output_step, const int it, const OpenPMDWriterCall
 #endif
 }
 
-std::string
-Hipace::Version ()
-{
-#ifdef HIPACE_GIT_VERSION
-    return std::string(HIPACE_GIT_VERSION);
-#else
-    return std::string("Unknown");
-#endif
-}
-
 int
 Hipace::leftmostBoxWithParticles () const
 {

--- a/src/HipaceVersion.H.in
+++ b/src/HipaceVersion.H.in
@@ -1,0 +1,20 @@
+/* Copyright 2022
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: Axel Huebl
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef HIPACE_VERSION_H_
+#define HIPACE_VERSION_H_
+
+#ifndef HIPACE_VERSION
+#   define HIPACE_VERSION "@HiPACE_VERSION@"
+#endif
+
+#ifndef HIPACE_GIT_VERSION
+#   define HIPACE_GIT_VERSION "@HiPACE_GIT_VERSION@"
+#endif
+
+#endif // HIPACE_VERSION_H_

--- a/src/HipaceVersion.cpp
+++ b/src/HipaceVersion.cpp
@@ -1,0 +1,23 @@
+/* Copyright 2022
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: Axel Huebl
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "Hipace.H"
+#include "HipaceVersion.H"
+
+#include <string>
+
+
+std::string
+Hipace::Version ()
+{
+#ifdef HIPACE_GIT_VERSION
+    return std::string(HIPACE_GIT_VERSION);
+#else
+    return std::string("Unknown");
+#endif
+}


### PR DESCRIPTION
Move the `-D` defines that contain the latest HiPACE commit to a config file. Using always the latest commit counteracts `ccache` since the signature of the compilation call changes every commit.

X-ref: https://github.com/ECP-WarpX/WarpX/pull/2959

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
