### PR TITLE
fix debug linking issue causing crash in Parser

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -11,4 +11,5 @@ target_sources(HiPACE
     AdaptiveTimeStep.cpp
     IOUtil.cpp
     GridCurrent.cpp
+    Parser.cpp
 )

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -29,15 +29,13 @@ queryWithParser (const amrex::ParmParse& pp, char const * const str, T& val);
 namespace Parser
 {
     // Cache for evaluated constants
-    static std::map<std::string, double> my_constants_cache{};
+    extern std::map<std::string, double> my_constants_cache;
 
     // Physical / Numerical Constants available to parsed expressions
-    static std::map<std::string, double> hipace_constants
-        {
-            {"pi", MathConst::pi},
-            {"true", 1},
-            {"false", 0}
-        };
+    extern std::map<std::string, double> hipace_constants;
+    // {"pi", MathConst::pi},
+    // {"true", 1},
+    // {"false", 0}
 
     /** \brief add Physical constants to Parser constants
      *

--- a/src/utils/Parser.cpp
+++ b/src/utils/Parser.cpp
@@ -1,0 +1,19 @@
+#include "Parser.H"
+#include "Constants.H"
+
+#include <map>
+#include <string>
+
+namespace Parser
+{
+    // Cache for evaluated constants
+    std::map<std::string, double> my_constants_cache{};
+
+    // Physical / Numerical Constants available to parsed expressions
+    std::map<std::string, double> hipace_constants
+        {
+            {"pi", MathConst::pi},
+            {"true", 1},
+            {"false", 0}
+        };
+}


### PR DESCRIPTION
It seems that in debug mode Parser::hipace_constants was linked differently compared to release mode. This caused a crash when using one of the constants in the input file if it was queried outside of Hipace.cpp.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
