### PR TITLE
[mini] Do not compile AMReX linear solvers by default

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -52,7 +52,7 @@ macro(find_amrex)
         set(AMReX_BUILD_TUTORIALS OFF CACHE INTERNAL "")
         set(AMReX_PARTICLES ON CACHE INTERNAL "")
         set(AMReX_TINY_PROFILE ON CACHE BOOL "")
-        set(AMReX_LINEAR_SOLVERS ON CACHE INTERNAL "")
+        set(AMReX_LINEAR_SOLVERS OFF CACHE INTERNAL "")
 
         # we don't need RDC and disabling it simplifies the build
         # complexity and potentially improves code optimization

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -183,7 +183,7 @@ CMake Option                 Default & Values                                Des
 ``HiPACE_openpmd_repo``      ``https://github.com/openPMD/openPMD-api.git``  Repository URI to pull and build openPMD-api from
 ``HiPACE_openpmd_branch``    ``0.14.3``                                      Repository branch for ``HiPACE_openpmd_repo``
 ``HiPACE_openpmd_internal``  **ON**/OFF                                      Needs a pre-installed openPMD-api library if set to ``OFF``
-``AMReX_LINEAR_SOLVERS``     **ON**/OFF                                      Compile AMReX multigrid solver. Required for explicit solver
+``AMReX_LINEAR_SOLVERS``     ON/**OFF**                                      Compile AMReX multigrid solver. Required for explicit solver
 ===========================  ==============================================  ============================================================
 
 For example, one can also build against a local AMReX copy.


### PR DESCRIPTION
The default linear MG solver is now in HiPACE++ since #699. Therefore, there is no reason to compile the AMReX linear solvers by default, which should save quite some compilation time, particularly useful for CI.