### PR TITLE
Redefine particle psi as normalized psi+1

### DIFF
--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -23,7 +23,7 @@ struct PlasmaIdx
         w = 0,                               // weight
         w0,                                  // initial weight
         ux, uy,                              // momentum
-        psi,                                 // pseudo-potential at the particle position. ATTENTION what is stored is actually psi+1
+        psi,                                 // pseudo-potential at the particle position. ATTENTION what is stored is actually normalized psi+1
         x_prev, y_prev,                      // temporary position
         ux_temp, uy_temp,                    // momentum
         psi_temp,                            //

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -23,7 +23,7 @@ struct PlasmaIdx
         w = 0,                               // weight
         w0,                                  // initial weight
         ux, uy,                              // momentum
-        psi,                                 //
+        psi,                                 // pseudo-potential at the particle position. ATTENTION what is stored is actually psi+1
         x_prev, y_prev,                      // temporary position
         ux_temp, uy_temp,                    // momentum
         psi_temp,                            //
@@ -33,7 +33,6 @@ struct PlasmaIdx
         Fuy1, Fuy2, Fuy3, Fuy4, Fuy5,        //
         Fpsi1, Fpsi2, Fpsi3, Fpsi4, Fpsi5,   //
         x0, y0,                              // initial positions
-        const_of_motion,                     // inital constant of motion (= 1 for a cold plasma)
         nattribs
     };
     enum {

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -355,7 +355,7 @@ IonizationModule (const int lev,
                 arrdata_elec[PlasmaIdx::y_prev  ][pidx] = arrdata_ion[PlasmaIdx::y_prev][ip];
                 arrdata_elec[PlasmaIdx::ux_temp ][pidx] = 0._rt;
                 arrdata_elec[PlasmaIdx::uy_temp ][pidx] = 0._rt;
-                arrdata_elec[PlasmaIdx::psi_temp][pidx] = 0._rt;
+                arrdata_elec[PlasmaIdx::psi_temp][pidx] = 1._rt;
                 arrdata_elec[PlasmaIdx::Fx1     ][pidx] = 0._rt;
                 arrdata_elec[PlasmaIdx::Fx2     ][pidx] = 0._rt;
                 arrdata_elec[PlasmaIdx::Fx3     ][pidx] = 0._rt;

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -243,8 +243,6 @@ IonizationModule (const int lev,
         const amrex::Real * const uxp = soa_ion.GetRealData(PlasmaIdx::ux).data();
         const amrex::Real * const uyp = soa_ion.GetRealData(PlasmaIdx::uy).data();
         const amrex::Real * const psip = soa_ion.GetRealData(PlasmaIdx::psi).data();
-        const amrex::Real * const const_of_motion = soa_ion.GetRealData(
-                                                                PlasmaIdx::const_of_motion).data();
 
         // Make Ion Mask and load ADK prefactors
         // Ion Mask is necessary to only resize electron particle tile once
@@ -282,14 +280,12 @@ IonizationModule (const int lev,
             const amrex::ParticleReal Ep = std::sqrt( Exp*Exp + Eyp*Eyp + Ezp*Ezp );
 
             // Compute probability of ionization p
-            const amrex::Real psi_1 = ( psip[ip] *
-                phys_const.q_e / (phys_const.m_e * clightsq) ) + const_of_motion[ip];
             const amrex::Real gammap = (1.0_rt + uxp[ip] * uxp[ip] * clightsq
                                                + uyp[ip] * uyp[ip] * clightsq
-                                               + psi_1 * psi_1 ) / ( 2.0_rt * psi_1 );
+                                               + psip[ip]* psip[ip] ) / ( 2.0_rt * psip[ip] );
             const int ion_lev_loc = ion_lev[ip];
             // gamma / (psi + 1) to complete dt for QSA
-            amrex::Real w_dtau = gammap / psi_1 * adk_prefactor[ion_lev_loc] *
+            amrex::Real w_dtau = gammap / psip[ip] * adk_prefactor[ion_lev_loc] *
                 std::pow(Ep, adk_power[ion_lev_loc]) *
                 std::exp( adk_exp_prefactor[ion_lev_loc]/Ep );
             amrex::Real p = 1._rt - std::exp( - w_dtau );
@@ -353,7 +349,8 @@ IonizationModule (const int lev,
                 arrdata_elec[PlasmaIdx::w0      ][pidx] = arrdata_ion[PlasmaIdx::w0    ][ip];
                 arrdata_elec[PlasmaIdx::ux      ][pidx] = 0._rt;
                 arrdata_elec[PlasmaIdx::uy      ][pidx] = 0._rt;
-                arrdata_elec[PlasmaIdx::psi     ][pidx] = 0._rt;
+                // later we could consider adding a finite temperature to the ionized electrons
+                arrdata_elec[PlasmaIdx::psi     ][pidx] = 1._rt;
                 arrdata_elec[PlasmaIdx::x_prev  ][pidx] = arrdata_ion[PlasmaIdx::x_prev][ip];
                 arrdata_elec[PlasmaIdx::y_prev  ][pidx] = arrdata_ion[PlasmaIdx::y_prev][ip];
                 arrdata_elec[PlasmaIdx::ux_temp ][pidx] = 0._rt;
@@ -386,8 +383,6 @@ IonizationModule (const int lev,
                 arrdata_elec[PlasmaIdx::Fpsi5   ][pidx] = 0._rt;
                 arrdata_elec[PlasmaIdx::x0      ][pidx] = arrdata_ion[PlasmaIdx::x0    ][ip];
                 arrdata_elec[PlasmaIdx::y0      ][pidx] = arrdata_ion[PlasmaIdx::y0    ][ip];
-                // later we could consider adding a finite temperature to the ionized electrons
-                arrdata_elec[PlasmaIdx::const_of_motion][pidx] = 1._rt;
                 int_arrdata_elec[PlasmaIdx::ion_lev][pidx] = init_ion_lev;
             }
         });

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -162,7 +162,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 arrdata[PlasmaIdx::w0       ][pidx] = base_density;
                 arrdata[PlasmaIdx::ux       ][pidx] = u[0] * c_light;
                 arrdata[PlasmaIdx::uy       ][pidx] = u[1] * c_light;
-                arrdata[PlasmaIdx::psi      ][pidx] = 0.;
+                arrdata[PlasmaIdx::psi      ][pidx] = sqrt(1.+u[0]*u[0]+u[1]*u[1]+u[2]*u[2])-u[2];
                 arrdata[PlasmaIdx::x_prev   ][pidx] = 0.;
                 arrdata[PlasmaIdx::y_prev   ][pidx] = 0.;
                 arrdata[PlasmaIdx::ux_temp  ][pidx] = u[0] * c_light;
@@ -196,8 +196,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 arrdata[PlasmaIdx::x0       ][pidx] = x;
                 arrdata[PlasmaIdx::y0       ][pidx] = y;
                 int_arrdata[PlasmaIdx::ion_lev][pidx] = init_ion_lev;
-                arrdata[PlasmaIdx::const_of_motion ][pidx] = sqrt(1._rt + u[0]*u[0] + u[1]*u[1]
-                                                                     + u[2]*u[2]) - u[2];
                 ++pidx;
             }
         });

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -167,7 +167,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 arrdata[PlasmaIdx::y_prev   ][pidx] = 0.;
                 arrdata[PlasmaIdx::ux_temp  ][pidx] = u[0] * c_light;
                 arrdata[PlasmaIdx::uy_temp  ][pidx] = u[1] * c_light;
-                arrdata[PlasmaIdx::psi_temp ][pidx] = 0.;
+                arrdata[PlasmaIdx::psi_temp ][pidx] = sqrt(1.+u[0]*u[0]+u[1]*u[1]+u[2]*u[2])-u[2];
                 arrdata[PlasmaIdx::Fx1      ][pidx] = 0.;
                 arrdata[PlasmaIdx::Fx2      ][pidx] = 0.;
                 arrdata[PlasmaIdx::Fx3      ][pidx] = 0.;

--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -98,7 +98,6 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
         soa.GetRealData(PlasmaIdx::uy).data() : soa.GetRealData(PlasmaIdx::uy_temp).data();
     const amrex::Real * const psip = (!temp_slice) ?
         soa.GetRealData(PlasmaIdx::psi).data() : soa.GetRealData(PlasmaIdx::psi_temp).data();
-    const amrex::Real * const const_of_motion = soa.GetRealData(PlasmaIdx::const_of_motion).data();
 
     // Extract box properties
     const amrex::Real dxi = 1.0/dx[0];
@@ -184,18 +183,14 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
                     const int ip = do_tiling ? indices[offsets[itile]+idx] : idx;
                     if (pos_structs[ip].id() < 0) return;
 
-                    const amrex::Real psi = psip[ip] *
-                        phys_const.q_e / (phys_const.m_e * phys_const.c * phys_const.c);
-
                     // calculate 1/gamma for plasma particles
-                    const amrex::Real gaminv = (2.0_rt * (psi+const_of_motion[ip]) )
+                    const amrex::Real gaminv = (2.0_rt * psip[ip] )
                                                 /(1.0_rt + uxp[ip]*uxp[ip]*clightsq
                                                          + uyp[ip]*uyp[ip]*clightsq
-                                                         + (psi+const_of_motion[ip])*
-                                                           (psi+const_of_motion[ip]));
+                                                         + psip[ip]*psip[ip]);
 
-                    if (( 1.0_rt/(gaminv*(psi+const_of_motion[ip])) < 0.0_rt) ||
-                        ( 1.0_rt/(gaminv*(psi+const_of_motion[ip])) > max_qsa_weighting_factor))
+                    if (( 1.0_rt/(gaminv * psip[ip]) < 0.0_rt) ||
+                        ( 1.0_rt/(gaminv * psip[ip]) > max_qsa_weighting_factor))
                     {
                         // This particle violates the QSA, discard it and do not deposit its current
                         amrex::Gpu::Atomic::Add(p_n_qsa_violation, 1);
@@ -206,22 +201,19 @@ void doDepositionShapeN (const PlasmaParticleIterator& pti,
                     // calculate plasma particle velocities
                     const amrex::Real vx = uxp[ip]*gaminv;
                     const amrex::Real vy = uyp[ip]*gaminv;
-                    const amrex::Real vz = phys_const.c*(1.0_rt -(psi +const_of_motion[ip])*gaminv);
+                    const amrex::Real vz = phys_const.c*(1.0_rt -psip[ip]*gaminv);
 
                     // calculate charge of the plasma particles
                     const amrex::Real q = can_ionize ? ion_lev[ip] * charge : charge;
-                    const amrex::Real wq = q * wp[ip]/(gaminv * (psi + const_of_motion[ip]))*invvol;
+                    const amrex::Real wq = q * wp[ip]/(gaminv * psip[ip])*invvol;
 
                     // wqx, wqy wqz are particle current in each direction
                     const amrex::Real wqx = wq*vx;
                     const amrex::Real wqy = wq*vy;
                     const amrex::Real wqz = wq*vz;
-                    const amrex::Real wqxx = q * wp[ip] * uxp[ip] * uxp[ip] * invvol
-                        / ((psi+const_of_motion[ip])*(psi+const_of_motion[ip]));
-                    const amrex::Real wqxy = q * wp[ip] * uxp[ip] * uyp[ip] * invvol
-                        / ((psi+const_of_motion[ip])*(psi+const_of_motion[ip]));
-                    const amrex::Real wqyy = q * wp[ip] * uyp[ip] * uyp[ip] * invvol
-                        / ((psi+const_of_motion[ip])*(psi+const_of_motion[ip]));
+                    const amrex::Real wqxx = q*wp[ip]*uxp[ip]*uxp[ip]*invvol / (psip[ip]*psip[ip]);
+                    const amrex::Real wqxy = q*wp[ip]*uxp[ip]*uyp[ip]*invvol / (psip[ip]*psip[ip]);
+                    const amrex::Real wqyy = q*wp[ip]*uyp[ip]*uyp[ip]*invvol / (psip[ip]*psip[ip]);
 
                     // --- Compute shape factors
                     // x direction

--- a/src/particles/pusher/UpdateForceTerms.H
+++ b/src/particles/pusher/UpdateForceTerms.H
@@ -71,7 +71,7 @@ void UpdateForceTerms(const amrex::ParticleReal& uxp,
     Fuy1 = -charge_mass_ratio/phys_const.c * ( gammap * EypBxp / psip -
             phys_const.c * Bxp - ( uxp * Bzp ) / psip );
     /* Change for psi along zeta */
-    Fpsi1 = -charge_mass_ratio * phys_const.m_e / phys_const.q_e *
+    Fpsi1 = -charge_mass_ratio /phys_const.c/phys_const.c *
             (( uxp*ExmByp + uyp*EypBxp )/phys_const.c/psip - Ezp );
 }
 

--- a/src/particles/pusher/UpdateForceTerms.H
+++ b/src/particles/pusher/UpdateForceTerms.H
@@ -15,7 +15,6 @@
  * \param[in] uxp momentum in x direction
  * \param[in] uyp momentum in y direction
  * \param[in] psip plasma pseudo-potential
- * \param[in] const_of_motionp constant of motion
  * \param[in] ExmByp ExmBy field at particle position
  * \param[in] EypBxp EypBx field at particle position
  * \param[in] Ezp Ez field at particle position
@@ -36,7 +35,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void UpdateForceTerms(const amrex::ParticleReal& uxp,
                       const amrex::ParticleReal& uyp,
                       const amrex::ParticleReal& psip,
-                      const amrex::ParticleReal& const_of_motionp,
                       const amrex::ParticleReal& ExmByp,
                       const amrex::ParticleReal& EypBxp,
                       const amrex::ParticleReal& Ezp,
@@ -58,24 +56,23 @@ void UpdateForceTerms(const amrex::ParticleReal& uxp,
 
     const amrex::Real gammap = (1.0_rt + uxp*uxp*clightsq
                                        + uyp*uyp*clightsq
-                                       + (psip+const_of_motionp)*(psip+const_of_motionp))
-                                       /(2.0_rt * (psip + const_of_motionp) );
+                                       + psip*psip
+        ) / (2.0_rt * psip );
 
     const amrex::Real charge_mass_ratio = charge / mass;
     /* Change for x-position along zeta */
-    Fx1 = -uxp / (psip + const_of_motionp) / phys_const.c;
+    Fx1 = -uxp / psip / phys_const.c;
     /* Change for y-position along zeta */
-    Fy1 = -uyp / (psip + const_of_motionp) / phys_const.c;
+    Fy1 = -uyp / psip / phys_const.c;
     /* Change for ux along zeta */
-    Fux1 = -charge_mass_ratio/phys_const.c * (gammap * ExmByp / (psip + const_of_motionp) +
-            phys_const.c * Byp + ( uyp * Bzp ) / (psip + const_of_motionp) );
+    Fux1 = -charge_mass_ratio/phys_const.c * (gammap * ExmByp / psip +
+            phys_const.c * Byp + ( uyp * Bzp ) / psip );
     /* Change for uy along zeta */
-    Fuy1 = -charge_mass_ratio/phys_const.c * ( gammap * EypBxp / (psip + const_of_motionp) -
-            phys_const.c * Bxp - ( uxp * Bzp ) / (psip + const_of_motionp) );
+    Fuy1 = -charge_mass_ratio/phys_const.c * ( gammap * EypBxp / psip -
+            phys_const.c * Bxp - ( uxp * Bzp ) / psip );
     /* Change for psi along zeta */
     Fpsi1 = -charge_mass_ratio * phys_const.m_e / phys_const.q_e *
-            (1.0_rt/phys_const.c * ( uxp*ExmByp + uyp*EypBxp )/(psip + const_of_motionp) - Ezp );
-
+            (( uxp*ExmByp + uyp*EypBxp )/phys_const.c/psip - Ezp );
 }
 
 /** \brief Shifting the force term coefficients


### PR DESCRIPTION
Originally, plasma particles just stored psi (in the unit system used for the simulation), and we just added 1 everywhere (as psi always appear as `psi+1`). Adding 1 didn't cost much. However, in order to support plasma temperature, `1` becomes a constant of motion, that also needs to be stored per-particle, costing 1 particle array. This PR proposes to merge both together, and the particle array `psi` is now `normalized_psi + const_of_motion`.

This was tested on GPU: after 5 time steps on 4 GPUs in different conditions, the figure below shows the on-axis Ez field on dev (top), this PR (center) and the difference (bottom), w w/o a plasma temperature. The second figure shows a similar test, in SI. Results are unchanged by this PR (and a small acceleration of a few % is observed).
### Normalized
![Screenshot 2022-03-15 at 12 11 05](https://user-images.githubusercontent.com/26292713/158371388-d6f7907d-9be0-4280-9d9d-9d6baa8544bd.png)
### SI
![Screenshot 2022-03-15 at 12 48 48](https://user-images.githubusercontent.com/26292713/158371728-dc3b6cad-e014-4404-b968-d43e71b985b6.png)