### PR TITLE
[mini] Silent warning on deprecated np.int

### DIFF
--- a/examples/linear_wake/analysis.py
+++ b/examples/linear_wake/analysis.py
@@ -74,9 +74,9 @@ nz = len(rho_meta.z)
 nb_array = np.zeros(nz)
 beam_starting_position = 1 / kp
 distance_to_start_pos =  rho_meta.zmax - beam_starting_position
-index_beam_head = np.int(distance_to_start_pos / dzeta)
+index_beam_head = int(distance_to_start_pos / dzeta)
 beam_length = 2 / kp
-beam_length_i = np.int(beam_length / dzeta)
+beam_length_i = int(beam_length / dzeta)
 if (args.gaussian_beam):
     sigma_z = 1.41 / kp
     peak_density = 0.01*ne


### PR DESCRIPTION
As observed in CI, `np.int` now raises a warning:
```
/home/runner/work/hipace/hipace/examples/linear_wake/analysis.py:77: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
```