### PR TITLE
[mini] constify field access

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -642,11 +642,11 @@ Hipace::ExplicitSolveBxBy (const int lev)
     using namespace amrex::literals;
 
     const int isl = WhichSlice::This;
-    amrex::MultiFab& slicemf = m_fields.getSlices(lev, isl);
+    const amrex::MultiFab& slicemf = m_fields.getSlices(lev, isl);
     const int nsl = WhichSlice::Next;
-    amrex::MultiFab& nslicemf = m_fields.getSlices(lev, nsl);
+    const amrex::MultiFab& nslicemf = m_fields.getSlices(lev, nsl);
     const int psl = WhichSlice::Previous1;
-    amrex::MultiFab& pslicemf = m_fields.getSlices(lev, psl);
+    const amrex::MultiFab& pslicemf = m_fields.getSlices(lev, psl);
     const amrex::BoxArray ba = slicemf.boxArray();
     const amrex::DistributionMapping dm = slicemf.DistributionMap();
 

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -113,6 +113,11 @@ public:
      * \param[in] islice slice index
      */
     amrex::MultiFab& getSlices (int lev, int islice) {return m_slices[lev][islice]; }
+    /** get function for the 2D slices (const version)
+     * \param[in] lev MR level
+     * \param[in] islice slice index
+     */
+    const amrex::MultiFab& getSlices (int lev, int islice) const {return m_slices[lev][islice]; }
     /** get amrex::MultiFab of a field in a slice
      * \param[in] lev MR level
      * \param[in] islice slice index

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -77,8 +77,8 @@ public:
      * \param[in] ibox index of the current box
      */
     void AdvanceBeamParticlesSlice (
-        Fields& fields, amrex::Geometry const& gm, int const lev, const int islice, const amrex::Box bx,
-        const amrex::Vector<BeamBins>& bins,
+        const Fields& fields, amrex::Geometry const& gm, int const lev, const int islice,
+        const amrex::Box bx, const amrex::Vector<BeamBins>& bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
 
     /** Loop over species and init them

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -81,8 +81,8 @@ MultiBeam::sortParticlesByBox (
 
 void
 MultiBeam::AdvanceBeamParticlesSlice (
-    Fields& fields, amrex::Geometry const& gm, int const lev, const int islice, const amrex::Box bx,
-    const amrex::Vector<BeamBins>& bins,
+    const Fields& fields, amrex::Geometry const& gm, int const lev, const int islice,
+    const amrex::Box bx, const amrex::Vector<BeamBins>& bins,
     const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox)
 {
     for (int i=0; i<m_nbeams; i++) {

--- a/src/particles/MultiPlasma.H
+++ b/src/particles/MultiPlasma.H
@@ -76,8 +76,8 @@ public:
      * \param[in] lev MR level
      */
     void AdvanceParticles (
-        Fields & fields, const Laser & laser, amrex::Geometry const& gm, bool temp_slice, bool do_push,
-        bool do_update, bool do_shift, int lev);
+        const Fields & fields, const Laser & laser, amrex::Geometry const& gm, bool temp_slice,
+        bool do_push, bool do_update, bool do_shift, int lev);
 
     /** \brief Resets the particle position x, y, to x_prev, y_prev
      *
@@ -104,7 +104,7 @@ public:
      * \param[in] geom Geometry of the simulation, to get the cell size
      * \param[in] fields the general field class
      */
-    void DoFieldIonization (const int lev, const amrex::Geometry& geom, Fields& fields);
+    void DoFieldIonization (const int lev, const amrex::Geometry& geom, const Fields& fields);
 
     bool IonizationOn () const;
     /** \brief whether all plasma species use a neutralizing background, e.g. no ion motion */

--- a/src/particles/MultiPlasma.cpp
+++ b/src/particles/MultiPlasma.cpp
@@ -113,8 +113,8 @@ MultiPlasma::DepositCurrent (
 
 void
 MultiPlasma::AdvanceParticles (
-    Fields & fields, const Laser & laser, amrex::Geometry const& gm, bool temp_slice, bool do_push,
-    bool do_update, bool do_shift, int lev)
+    const Fields & fields, const Laser & laser, amrex::Geometry const& gm, bool temp_slice,
+    bool do_push, bool do_update, bool do_shift, int lev)
 {
     for (int i=0; i<m_nplasmas; i++) {
         AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice,
@@ -148,7 +148,7 @@ MultiPlasma::DepositNeutralizingBackground (
 
 void
 MultiPlasma::DoFieldIonization (
-    const int lev, const amrex::Geometry& geom, Fields& fields)
+    const int lev, const amrex::Geometry& geom, const Fields& fields)
 {
     for (auto& plasma : m_all_plasmas) {
         plasma.IonizationModule(lev, geom, fields);

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -94,7 +94,7 @@ public:
      */
     void IonizationModule (const int lev,
                            const amrex::Geometry& geom,
-                           Fields& fields);
+                           const Fields& fields);
 
     /** Update m_density_func with m_density_table if applicable
      */

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -180,7 +180,7 @@ void
 PlasmaParticleContainer::
 IonizationModule (const int lev,
                   const amrex::Geometry& geom,
-                  Fields& fields)
+                  const Fields& fields)
 {
     HIPACE_PROFILE("PlasmaParticleContainer::IonizationModule()");
 

--- a/src/particles/pusher/BeamParticleAdvance.H
+++ b/src/particles/pusher/BeamParticleAdvance.H
@@ -23,8 +23,8 @@
  * \param[in] bins beam particle container bins, to push only the beam particles on slice islice
  */
 void
-AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
-                           int const lev, const int islice_local, const amrex::Box box,
-                           const int offset, const BeamBins& bins);
+AdvanceBeamParticlesSlice (BeamParticleContainer& beam, const Fields& fields,
+                           amrex::Geometry const& gm, int const lev, const int islice_local,
+                           const amrex::Box box, const int offset, const BeamBins& bins);
 
 #endif //  BEAMPARTICLEADVANCE_H_

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -15,9 +15,9 @@
 #include "GetDomainLev.H"
 
 void
-AdvanceBeamParticlesSlice (BeamParticleContainer& beam, Fields& fields, amrex::Geometry const& gm,
-                           int const lev, const int islice_local, const amrex::Box box,
-                           const int offset, const BeamBins& bins)
+AdvanceBeamParticlesSlice (BeamParticleContainer& beam, const Fields& fields,
+                           amrex::Geometry const& gm, int const lev, const int islice_local,
+                           const amrex::Box box, const int offset, const BeamBins& bins)
 {
     HIPACE_PROFILE("AdvanceBeamParticlesSlice()");
     using namespace amrex::literals;

--- a/src/particles/pusher/PlasmaParticleAdvance.H
+++ b/src/particles/pusher/PlasmaParticleAdvance.H
@@ -27,7 +27,7 @@
  * \param[in] laser laser pulse, which affects the plasma via the ponderomotive force
  */
 void
-AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
+AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Geometry const& gm, const bool temp_slice, const bool do_push,
                         const bool do_update, const bool do_shift, int const lev,
                         PlasmaBins& bins, const Laser& laser);

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 void
-AdvancePlasmaParticles (PlasmaParticleContainer& plasma, Fields & fields,
+AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Geometry const& gm, const bool temp_slice, const bool do_push,
                         const bool do_update, const bool do_shift, int const lev,
                         PlasmaBins& bins, const Laser& laser)


### PR DESCRIPTION
Previously `Fields` was not passed as `const` to functions were it could have been `const`.
This included the plasma particle advance, the beam particle advance, and field ionization.

This PR constifies these accesses.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
