### PR TITLE
Fix a bug in the multigrid

### DIFF
--- a/src/mg_solver/HpMultiGrid.cpp
+++ b/src/mg_solver/HpMultiGrid.cpp
@@ -455,6 +455,7 @@ MultiGrid::bottomsolve ()
         for (int ilev = 0; ilev < nlevs-1; ++ilev) {
             if (icell < ncells) {
                 cor[ilev].p[icell] = Real(0.);
+                cor[ilev].p[icell+ncells] = Real(0.);
             }
             __syncthreads();
 
@@ -517,6 +518,7 @@ MultiGrid::bottomsolve ()
             const int ilev = nlevs-1;
             if (icell < ncells) {
                 cor[ilev].p[icell] = Real(0.);
+                cor[ilev].p[icell+ncells] = Real(0.);
             }
             __syncthreads();
 


### PR DESCRIPTION
Forgot to initialize the second component to zero.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
