### PR TITLE
allow for offset fixed ppc beam

### DIFF
--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -55,6 +55,7 @@ public:
         const amrex::Real     a_zmin,
         const amrex::Real     a_zmax,
         const amrex::Real     a_radius,
+        const amrex::Array<amrex::Real, 3> a_position_mean,
         const amrex::Real     a_min_density,
         const amrex::Vector<int>& random_ppc);
 

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -74,13 +74,15 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         getWithParser(pp, "zmin", m_zmin);
         getWithParser(pp, "zmax", m_zmax);
         getWithParser(pp, "radius", m_radius);
+        amrex::Array<amrex::Real, AMREX_SPACEDIM> position_mean{0., 0., 0.};
+        queryWithParser(pp, "position_mean", position_mean);
         queryWithParser(pp, "min_density", m_min_density);
         amrex::Vector<int> random_ppc {false, false, false};
         queryWithParser(pp, "random_ppc", random_ppc);
         const GetInitialDensity get_density(m_name);
         const GetInitialMomentum get_momentum(m_name);
         InitBeamFixedPPC(m_ppc, get_density, get_momentum, geom, m_zmin,
-                         m_zmax, m_radius, m_min_density, random_ppc);
+                         m_zmax, m_radius, position_mean, m_min_density, random_ppc);
 
     } else if (m_injection_type == "fixed_weight") {
 

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -72,6 +72,7 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                   const amrex::Real a_zmin,
                   const amrex::Real a_zmax,
                   const amrex::Real a_radius,
+                  const amrex::Array<amrex::Real, 3> a_position_mean,
                   const amrex::Real a_min_density,
                   const amrex::Vector<int>& random_ppc)
 {
@@ -105,6 +106,9 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
     const amrex::Real scale_fac = Hipace::m_normalized_units ?
         1./num_ppc*cr[0]*cr[1]*cr[2] : dx[0]*dx[1]*dx[2]/num_ppc;
 
+    const amrex::Real x_mean = a_position_mean[0];
+    const amrex::Real y_mean = a_position_mean[1];
+
     // First: loop over all cells, and count the particles effectively injected.
     amrex::Box domain_box = a_geom.Domain();
     domain_box.coarsen(cr);
@@ -137,7 +141,8 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     // If particles are evenly spaced, discard particles
                     // individually if they are out of bounds
                     if (z >= a_zmax || z < a_zmin ||
-                        (x*x+y*y) > a_radius*a_radius) continue;
+                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > a_radius*a_radius)
+                        continue;
                 } else {
                     // If particles are randomly spaced, discard particles
                     // if the cell is outside the domain
@@ -145,7 +150,8 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     amrex::Real yc = plo[1]+j*dx[1];
                     amrex::Real zc = plo[2]+k*dx[2];
                     if (zc >= a_zmax || zc < a_zmin ||
-                        (xc*xc+yc*yc) > a_radius*a_radius) continue;
+                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > a_radius*a_radius)
+                        continue;
                 }
 
                 const amrex::Real density = get_density(x, y, z);
@@ -218,7 +224,8 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     // If particles are evenly spaced, discard particles
                     // individually if they are out of bounds
                     if (z >= a_zmax || z < a_zmin ||
-                        (x*x+y*y) > a_radius*a_radius) continue;
+                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > a_radius*a_radius)
+                        continue;
                 } else {
                     // If particles are randomly spaced, discard particles
                     // if the cell is outside the domain
@@ -226,7 +233,8 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     amrex::Real yc = plo[1]+j*dx[1];
                     amrex::Real zc = plo[2]+k*dx[2];
                     if (zc >= a_zmax || zc < a_zmin ||
-                        (xc*xc+yc*yc) > a_radius*a_radius) continue;
+                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > a_radius*a_radius)
+                        continue;
                 }
 
                 const amrex::Real density = get_density(x, y, z);

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -141,8 +141,9 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     // If particles are evenly spaced, discard particles
                     // individually if they are out of bounds
                     if (z >= a_zmax || z < a_zmin ||
-                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > a_radius*a_radius)
-                        continue;
+                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > a_radius*a_radius) {
+                            continue;
+                        }
                 } else {
                     // If particles are randomly spaced, discard particles
                     // if the cell is outside the domain
@@ -150,8 +151,9 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     amrex::Real yc = plo[1]+j*dx[1];
                     amrex::Real zc = plo[2]+k*dx[2];
                     if (zc >= a_zmax || zc < a_zmin ||
-                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > a_radius*a_radius)
-                        continue;
+                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > a_radius*a_radius) {
+                            continue;
+                        }
                 }
 
                 const amrex::Real density = get_density(x, y, z);
@@ -224,8 +226,9 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     // If particles are evenly spaced, discard particles
                     // individually if they are out of bounds
                     if (z >= a_zmax || z < a_zmin ||
-                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > a_radius*a_radius)
-                        continue;
+                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > a_radius*a_radius) {
+                            continue;
+                        }
                 } else {
                     // If particles are randomly spaced, discard particles
                     // if the cell is outside the domain
@@ -233,8 +236,9 @@ InitBeamFixedPPC (const amrex::IntVect& a_num_particles_per_cell,
                     amrex::Real yc = plo[1]+j*dx[1];
                     amrex::Real zc = plo[2]+k*dx[2];
                     if (zc >= a_zmax || zc < a_zmin ||
-                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > a_radius*a_radius)
-                        continue;
+                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > a_radius*a_radius) {
+                            continue;
+                        }
                 }
 
                 const amrex::Real density = get_density(x, y, z);

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -185,7 +185,9 @@ struct EnforceBC
     {
         using namespace amrex::literals;
 
-        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_periodicity);
+        // TODO: The second m_phi should be amrex::Geometry RoundoffHiArray(),
+        // however there is no Geometry object to get this.
+        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_phi, m_periodicity);
         const bool invalid = (shifted && !m_is_per[0]);
         if (invalid) {
             m_weights[ip] = 0.0_rt;


### PR DESCRIPTION
Based on #724

Allow `beam.position_mean = 2. -1. 0` to change the encompassing cylinder of fixed_ppc beams.

Flattop:

![download](https://user-images.githubusercontent.com/64009254/160173262-d95b4465-b965-43e0-bcdb-8f8b9cb81530.png)

![download](https://user-images.githubusercontent.com/64009254/160173273-bd4c0702-38f1-4e5b-8302-904b8f2b2b1c.png)

Gaussian:

![download](https://user-images.githubusercontent.com/64009254/160171348-792b4363-71e9-4b31-9a10-ef8738c8ca77.png)

![download](https://user-images.githubusercontent.com/64009254/160171372-e1626803-2213-4fc6-9418-fbe93a1443b8.png)


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
