### PR TITLE
Change checksum backend to h5py to improve CI performance

### DIFF
--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -185,7 +185,9 @@ struct EnforceBC
     {
         using namespace amrex::literals;
 
-        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_periodicity);
+        // TODO: The second m_phi should be amrex::Geometry RoundoffHiArray(),
+        // however there is no Geometry object to get this.
+        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_phi, m_periodicity);
         const bool invalid = (shifted && !m_is_per[0]);
         if (invalid) {
             m_weights[ip] = 0.0_rt;

--- a/tests/checksum/backend/openpmd_backend.py
+++ b/tests/checksum/backend/openpmd_backend.py
@@ -17,8 +17,7 @@ class Backend:
         ''' Constructor: store the dataset object
         '''
 
-        # test
-        self.dataset = OpenPMDTimeSeries(filename)
+        self.dataset = OpenPMDTimeSeries(filename, backend='h5py')
 
     def fields_list(self):
         ''' Return the list of fields defined on the grid

--- a/tests/checksum/backend/openpmd_backend.py
+++ b/tests/checksum/backend/openpmd_backend.py
@@ -17,6 +17,7 @@ class Backend:
         ''' Constructor: store the dataset object
         '''
 
+        # test
         self.dataset = OpenPMDTimeSeries(filename)
 
     def fields_list(self):


### PR DESCRIPTION
Based on #724

There seems to be something wrong with the `openpmd-api` backend in openPMD-viewer so change to `h5py` backend for now.

Default `openpmd-api` backend:

```
Test project /home/runner/work/hipace/hipace/build
      Start  1: blowout_wake.2Rank
 1/24 Test  #1: blowout_wake.2Rank ......................   Passed   12.82 sec
      Start  2: collisions.SI.1Rank
 2/24 Test  #2: collisions.SI.1Rank .....................   Passed    4.09 sec
      Start  3: ionization.2Rank
 3/24 Test  #3: ionization.2Rank ........................   Passed    3.34 sec
      Start  4: from_file.normalized.1Rank
 4/24 Test  #4: from_file.normalized.1Rank ..............   Passed    3.33 sec
      Start  5: from_file.SI.1Rank
 5/24 Test  #5: from_file.SI.1Rank ......................   Passed    3.41 sec
      Start  6: restart.normalized.1Rank
 6/24 Test  #6: restart.normalized.1Rank ................   Passed    1.45 sec
      Start  7: blowout_wake_explicit.2Rank
 7/24 Test  #7: blowout_wake_explicit.2Rank .............   Passed    5.13 sec
      Start  8: laser_blowout_wake_explicit.1Rank
 8/24 Test  #8: laser_blowout_wake_explicit.1Rank .......   Passed    6.61 sec
      Start  9: laser_blowout_wake_explicit.SI.1Rank
 9/24 Test  #9: laser_blowout_wake_explicit.SI.1Rank ....   Passed    6.86 sec
      Start 10: beam_evolution.1Rank
10/24 Test #10: beam_evolution.1Rank ....................   Passed   19.20 sec
      Start 11: adaptive_time_step.1Rank
11/24 Test #11: adaptive_time_step.1Rank ................   Passed   39.91 sec
      Start 12: grid_current.1Rank
12/24 Test #12: grid_current.1Rank ......................   Passed    1.88 sec
      Start 13: linear_wake.normalized.1Rank
13/24 Test #13: linear_wake.normalized.1Rank ............   Passed    5.01 sec
      Start 14: linear_wake.SI.1Rank
14/24 Test #14: linear_wake.SI.1Rank ....................   Passed    4.96 sec
      Start 15: gaussian_linear_wake.normalized.1Rank
15/24 Test #15: gaussian_linear_wake.normalized.1Rank ...   Passed   56.19 sec
      Start 16: gaussian_linear_wake.SI.1Rank
16/24 Test #16: gaussian_linear_wake.SI.1Rank ...........   Passed   54.87 sec
      Start 17: reset.2Rank
17/24 Test #17: reset.2Rank .............................   Passed    5.26 sec
      Start 18: beam_in_vacuum.SI.1Rank
18/24 Test #18: beam_in_vacuum.SI.1Rank .................   Passed    7.88 sec
      Start 19: beam_in_vacuum.normalized.1Rank
19/24 Test #19: beam_in_vacuum.normalized.1Rank .........   Passed    6.80 sec
      Start 20: next_deposition_beam.2Rank
20/24 Test #20: next_deposition_beam.2Rank ..............   Passed   13.76 sec
      Start 21: slice_IO.1Rank
21/24 Test #21: slice_IO.1Rank ..........................   Passed   11.44 sec
      Start 22: output_coarsening.2Rank
22/24 Test #22: output_coarsening.2Rank .................   Passed   14.89 sec
      Start 23: gaussian_weight.1Rank
23/24 Test #23: gaussian_weight.1Rank ...................   Passed   67.96 sec
      Start 24: beam_in_vacuum.normalized.2Rank
24/24 Test #24: beam_in_vacuum.normalized.2Rank .........   Passed   14.03 sec
```
`h5py` backend:
```
Test project /home/runner/work/hipace/hipace/build
      Start  1: blowout_wake.2Rank
 1/24 Test  #1: blowout_wake.2Rank ......................   Passed   10.01 sec
      Start  2: collisions.SI.1Rank
 2/24 Test  #2: collisions.SI.1Rank .....................   Passed    1.36 sec
      Start  3: ionization.2Rank
 3/24 Test  #3: ionization.2Rank ........................   Passed    2.58 sec
      Start  4: from_file.normalized.1Rank
 4/24 Test  #4: from_file.normalized.1Rank ..............   Passed    2.89 sec
      Start  5: from_file.SI.1Rank
 5/24 Test  #5: from_file.SI.1Rank ......................   Passed    2.97 sec
      Start  6: restart.normalized.1Rank
 6/24 Test  #6: restart.normalized.1Rank ................   Passed    1.21 sec
      Start  7: blowout_wake_explicit.2Rank
 7/24 Test  #7: blowout_wake_explicit.2Rank .............   Passed    2.08 sec
      Start  8: laser_blowout_wake_explicit.1Rank
 8/24 Test  #8: laser_blowout_wake_explicit.1Rank .......   Passed    4.26 sec
      Start  9: laser_blowout_wake_explicit.SI.1Rank
 9/24 Test  #9: laser_blowout_wake_explicit.SI.1Rank ....   Passed    4.20 sec
      Start 10: beam_evolution.1Rank
10/24 Test #10: beam_evolution.1Rank ....................   Passed    6.15 sec
      Start 11: adaptive_time_step.1Rank
11/24 Test #11: adaptive_time_step.1Rank ................   Passed    6.19 sec
      Start 12: grid_current.1Rank
12/24 Test #12: grid_current.1Rank ......................   Passed    1.35 sec
      Start 13: linear_wake.normalized.1Rank
13/24 Test #13: linear_wake.normalized.1Rank ............   Passed    3.25 sec
      Start 14: linear_wake.SI.1Rank
14/24 Test #14: linear_wake.SI.1Rank ....................   Passed    3.21 sec
      Start 15: gaussian_linear_wake.normalized.1Rank
15/24 Test #15: gaussian_linear_wake.normalized.1Rank ...   Passed    2.84 sec
      Start 16: gaussian_linear_wake.SI.1Rank
16/24 Test #16: gaussian_linear_wake.SI.1Rank ...........   Passed    2.88 sec
      Start 17: reset.2Rank
17/24 Test #17: reset.2Rank .............................   Passed    2.24 sec
      Start 18: beam_in_vacuum.SI.1Rank
18/24 Test #18: beam_in_vacuum.SI.1Rank .................   Passed    6.23 sec
      Start 19: beam_in_vacuum.normalized.1Rank
19/24 Test #19: beam_in_vacuum.normalized.1Rank .........   Passed    5.51 sec
      Start 20: next_deposition_beam.2Rank
20/24 Test #20: next_deposition_beam.2Rank ..............   Passed   10.89 sec
      Start 21: slice_IO.1Rank
21/24 Test #21: slice_IO.1Rank ..........................   Passed   10.06 sec
      Start 22: output_coarsening.2Rank
22/24 Test #22: output_coarsening.2Rank .................   Passed   13.50 sec
      Start 23: gaussian_weight.1Rank
23/24 Test #23: gaussian_weight.1Rank ...................   Passed   28.38 sec
      Start 24: beam_in_vacuum.normalized.2Rank
24/24 Test #24: beam_in_vacuum.normalized.2Rank .........   Passed   12.47 sec
```
