### PR TITLE
Fix analysis imports

### DIFF
--- a/examples/beam_in_vacuum/analysis.py
+++ b/examples/beam_in_vacuum/analysis.py
@@ -18,13 +18,13 @@
 # Note: the simulation may take some time, as the box size must be high to have
 # decent agreement
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import matplotlib
 import numpy as np
 import scipy.constants as scc
 import argparse
 import sys
-from openpmd_viewer import OpenPMDTimeSeries
 
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--normalized-units',

--- a/examples/beam_in_vacuum/analysis_2ranks.py
+++ b/examples/beam_in_vacuum/analysis_2ranks.py
@@ -8,10 +8,10 @@
 # License: BSD-3-Clause-LBNL
 
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import numpy as np
 import argparse
-from openpmd_viewer import OpenPMDTimeSeries
 
 do_plot = False
 

--- a/examples/beam_in_vacuum/analysis_beam_push.py
+++ b/examples/beam_in_vacuum/analysis_beam_push.py
@@ -8,12 +8,11 @@
 # License: BSD-3-Clause-LBNL
 
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
-import matplotlib
 import argparse
 import numpy as np
 import scipy.constants as scc
-from openpmd_viewer import OpenPMDTimeSeries
 
 do_plot = True
 

--- a/examples/beam_in_vacuum/analysis_from_file.py
+++ b/examples/beam_in_vacuum/analysis_from_file.py
@@ -12,14 +12,10 @@
 # one from the write_beam script, two from hipace,
 # with each other and asserts if they are different.
 
-import matplotlib.pyplot as plt
-import scipy.constants as scc
-import matplotlib
-import sys
-import numpy as np
-import math
-import argparse
 import openpmd_api as io # to have access to Attribute Metadata
+import scipy.constants as scc
+import numpy as np
+import argparse
 
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of beam from_file')
 parser.add_argument('--beam-py',

--- a/examples/beam_in_vacuum/analysis_transverse.py
+++ b/examples/beam_in_vacuum/analysis_transverse.py
@@ -11,6 +11,7 @@
 # This script compares the transverse field By from a serial and a parallel simulation
 # with transverse beam currents and asserts that the results are the same
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import scipy.constants as scc
 import matplotlib
@@ -18,7 +19,6 @@ import sys
 import numpy as np
 import math
 import argparse
-from openpmd_viewer import OpenPMDTimeSeries
 
 parser = argparse.ArgumentParser(
     description='Script to analyze the correctness of beam with transverse current')

--- a/examples/blowout_wake/analysis.py
+++ b/examples/blowout_wake/analysis.py
@@ -18,6 +18,7 @@
 # Note: the simulation may take some time, as the box size must be high to have
 # decent agreement
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import scipy.constants as scc
 import matplotlib
@@ -25,7 +26,6 @@ import sys
 import numpy as np
 import math
 import argparse
-from openpmd_viewer import OpenPMDTimeSeries
 
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--normalized-data',

--- a/examples/blowout_wake/analysis_coarsening.py
+++ b/examples/blowout_wake/analysis_coarsening.py
@@ -9,6 +9,7 @@
 
 # This script compares a field from a simulation with full IO and from a simulation with coarse IO
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import scipy.constants as scc
 import matplotlib
@@ -16,7 +17,6 @@ import sys
 import numpy as np
 import math
 import argparse
-from openpmd_viewer import OpenPMDTimeSeries
 
 fields = ['Ez', 'ExmBy', 'EypBx']
 
@@ -40,4 +40,3 @@ for field in fields:
 
 del ts1
 del ts2
-

--- a/examples/blowout_wake/analysis_slice_IO.py
+++ b/examples/blowout_wake/analysis_slice_IO.py
@@ -11,6 +11,7 @@
 # This script compares a field from a simulation with
 # full IO and from a simulation with only slice IO
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import scipy.constants as scc
 import matplotlib
@@ -18,7 +19,6 @@ import sys
 import numpy as np
 import math
 import argparse
-from openpmd_viewer import OpenPMDTimeSeries
 
 do_plot = False
 field = 'Ez'

--- a/examples/gaussian_weight/analysis.py
+++ b/examples/gaussian_weight/analysis.py
@@ -7,12 +7,11 @@
 # Authors: MaxThevenet, Severin Diederichs
 # License: BSD-3-Clause-LBNL
 
-
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants as scc
 import argparse
-from openpmd_viewer import OpenPMDTimeSeries
 
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--normalized-units',

--- a/examples/linear_wake/analysis.py
+++ b/examples/linear_wake/analysis.py
@@ -21,6 +21,7 @@
 # Note: the simulation may take some time, as the box size must be high to have
 # decent agreement
 
+from openpmd_viewer import OpenPMDTimeSeries
 import matplotlib.pyplot as plt
 import scipy.constants as scc
 from scipy.stats import norm
@@ -29,7 +30,6 @@ import sys
 import numpy as np
 import math
 import argparse
-from openpmd_viewer import OpenPMDTimeSeries
 
 parser = argparse.ArgumentParser(description='Script to analyze the correctness of the beam in vacuum')
 parser.add_argument('--normalized-units',

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -185,7 +185,9 @@ struct EnforceBC
     {
         using namespace amrex::literals;
 
-        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_periodicity);
+        // TODO: The second m_phi should be amrex::Geometry RoundoffHiArray(),
+        // however there is no Geometry object to get this.
+        const bool shifted = enforcePeriodic(m_structs[ip], m_plo, m_phi, m_phi, m_periodicity);
         const bool invalid = (shifted && !m_is_per[0]);
         if (invalid) {
             m_weights[ip] = 0.0_rt;

--- a/tests/checksum/backend/openpmd_backend.py
+++ b/tests/checksum/backend/openpmd_backend.py
@@ -17,8 +17,7 @@ class Backend:
         ''' Constructor: store the dataset object
         '''
 
-        # test
-        self.dataset = OpenPMDTimeSeries(filename)
+        self.dataset = OpenPMDTimeSeries(filename, backend='h5py')
 
     def fields_list(self):
         ''' Return the list of fields defined on the grid

--- a/tests/checksum/backend/openpmd_backend.py
+++ b/tests/checksum/backend/openpmd_backend.py
@@ -17,6 +17,7 @@ class Backend:
         ''' Constructor: store the dataset object
         '''
 
+        # test
         self.dataset = OpenPMDTimeSeries(filename)
 
     def fields_list(self):


### PR DESCRIPTION
based on #724 and #725

On Maxwell (DESY) this crashes:
```
import matplotlib # or scipy
import openpmd_viewer
```
but this works:
```
import openpmd_viewer
import matplotlib
import scipy
```
This PR changes the import order in all analysis python scripts to run on Maxwell (after the dependencies are updated with pip).

Crash message:
```
[asinn@max-mpag001]~% module load maxwell gcc/9.3 openmpi/4 hdf5/1.10.6
[asinn@max-mpag001]~% python3
Python 3.6.8 (default, Nov 16 2020, 16:55:22)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-44)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import matplotlib
>>> import openpmd_viewer
*** Error in `python3': free(): invalid pointer: 0x00002b1ef9237c20 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x81329)[0x2b1ce4da1329]
/usr/lib64/llvm4.0/lib/libLLVM-4.0.so(_ZNSt6locale5_Impl16_M_install_facetEPKNS_2idEPKNS_5facetE+0x142)[0x2b1ef81ddd42]
/usr/lib64/llvm4.0/lib/libLLVM-4.0.so(_ZNSt6locale5_ImplC2Em+0x1e3)[0x2b1ef81c1873]
/usr/lib64/llvm4.0/lib/libLLVM-4.0.so(_ZNSt6locale18_S_initialize_onceEv+0x15)[0x2b1ef81c27e5]
/lib64/libpthread.so.0(+0x620b)[0x2b1ce440120b]
/usr/lib64/llvm4.0/lib/libLLVM-4.0.so(_ZNSt6locale13_S_initializeEv+0x21)[0x2b1ef81c2831]
/usr/lib64/llvm4.0/lib/libLLVM-4.0.so(_ZNSt6localeC1Ev+0x13)[0x2b1ef81c2873]
/usr/lib64/python3.6/site-packages/llvmlite/binding/libllvmlite.so(LLVMPY_GetHostCPUFeatures+0x75)[0x2b1ef6356cd5]
/lib64/libffi.so.6(ffi_call_unix64+0x4c)[0x2b1ef35ede2c]
/lib64/libffi.so.6(ffi_call+0x1f5)[0x2b1ef35ed755]
/usr/lib64/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so(_ctypes_callproc+0x2a0)[0x2b1ef33d8680]
/usr/lib64/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so(+0x97c6)[0x2b1ef33d17c6]
/lib64/libpython3.6m.so.1.0(_PyObject_FastCallDict+0x90)[0x2b1ce3f7bd20]
/lib64/libpython3.6m.so.1.0(+0x1522fc)[0x2b1ce40252fc]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151f3a)[0x2b1ce4024f3a]
/lib64/libpython3.6m.so.1.0(+0x152273)[0x2b1ce4025273]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151f3a)[0x2b1ce4024f3a]
/lib64/libpython3.6m.so.1.0(+0x152273)[0x2b1ce4025273]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151f3a)[0x2b1ce4024f3a]
/lib64/libpython3.6m.so.1.0(+0x152273)[0x2b1ce4025273]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151f3a)[0x2b1ce4024f3a]
/lib64/libpython3.6m.so.1.0(+0x152273)[0x2b1ce4025273]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151f3a)[0x2b1ce4024f3a]
/lib64/libpython3.6m.so.1.0(+0x152273)[0x2b1ce4025273]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(_PyFunction_FastCallDict+0x15a)[0x2b1ce402626a]
/lib64/libpython3.6m.so.1.0(_PyObject_FastCallDict+0x10e)[0x2b1ce3f7bd9e]
/lib64/libpython3.6m.so.1.0(_PyObject_Call_Prepend+0x61)[0x2b1ce3f7beb1]
/lib64/libpython3.6m.so.1.0(PyObject_Call+0x43)[0x2b1ce3f7bb23]
/lib64/libpython3.6m.so.1.0(+0xfbc75)[0x2b1ce3fcec75]
/lib64/libpython3.6m.so.1.0(+0xf8632)[0x2b1ce3fcb632]
/lib64/libpython3.6m.so.1.0(_PyObject_FastCallDict+0x90)[0x2b1ce3f7bd20]
/lib64/libpython3.6m.so.1.0(+0x1522fc)[0x2b1ce40252fc]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151f3a)[0x2b1ce4024f3a]
/lib64/libpython3.6m.so.1.0(+0x152273)[0x2b1ce4025273]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(_PyFunction_FastCallDict+0x15a)[0x2b1ce402626a]
/lib64/libpython3.6m.so.1.0(_PyObject_FastCallDict+0x10e)[0x2b1ce3f7bd9e]
/lib64/libpython3.6m.so.1.0(_PyObject_Call_Prepend+0x61)[0x2b1ce3f7beb1]
/lib64/libpython3.6m.so.1.0(PyObject_Call+0x43)[0x2b1ce3f7bb23]
/lib64/libpython3.6m.so.1.0(+0xfbc75)[0x2b1ce3fcec75]
/lib64/libpython3.6m.so.1.0(+0xf8632)[0x2b1ce3fcb632]
/lib64/libpython3.6m.so.1.0(_PyObject_FastCallDict+0x90)[0x2b1ce3f7bd20]
/lib64/libpython3.6m.so.1.0(+0x1522fc)[0x2b1ce40252fc]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151f3a)[0x2b1ce4024f3a]
/lib64/libpython3.6m.so.1.0(+0x152273)[0x2b1ce4025273]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x3a7)[0x2b1ce4019a17]
/lib64/libpython3.6m.so.1.0(+0x151317)[0x2b1ce4024317]
/lib64/libpython3.6m.so.1.0(_PyFunction_FastCallDict+0x24f)[0x2b1ce402635f]
/lib64/libpython3.6m.so.1.0(_PyObject_FastCallDict+0x10e)[0x2b1ce3f7bd9e]
/lib64/libpython3.6m.so.1.0(PyObject_CallFunctionObjArgs+0xe2)[0x2b1ce3f7d232]
/lib64/libpython3.6m.so.1.0(_PyObject_GenericGetAttrWithDict+0x1c1)[0x2b1ce3fbb081]
/lib64/libpython3.6m.so.1.0(_PyEval_EvalFrameDefault+0x439)[0x2b1ce4019aa9]
/lib64/libpython3.6m.so.1.0(PyEval_EvalCodeEx+0x22d)[0x2b1ce40255ed]
/lib64/libpython3.6m.so.1.0(+0xc0c93)[0x2b1ce3f93c93]
/lib64/libpython3.6m.so.1.0(PyObject_Call+0x43)[0x2b1ce3f7bb23]
======= Memory map: ========
00400000-00401000 r-xp 00000000 08:08 1057408                            /usr/bin/python3.6
00601000-00602000 r--p 00001000 08:08 1057408                            /usr/bin/python3.6
00602000-00603000 rw-p 00002000 08:08 1057408                            /usr/bin/python3.6
01d4f000-026a5000 rw-p 00000000 00:00 0                                  [heap]
2b1ce3caf000-2b1ce3cd1000 r-xp 00000000 08:08 1049209                    /usr/lib64/ld-2.17.so
2b1ce3cd1000-2b1ce3cd2000 rw-p 00000000 00:00 0
2b1ce3cd2000-2b1ce3cd9000 r--s 00000000 08:08 1314464                    /usr/lib64/gconv/gconv-modules.cache
2b1ce3cd9000-2b1ce3cdc000 r--p 00000000 00:30 1629726                    /software/gcc/9.3.0/lib64/libgcc_s.so.1
2b1ce3cdc000-2b1ce3ced000 r-xp 00003000 00:30 1629726                    /software/gcc/9.3.0/lib64/libgcc_s.so.1
2b1ce3ced000-2b1ce3cf1000 r--p 00014000 00:30 1629726                    /software/gcc/9.3.0/lib64/libgcc_s.so.1
2b1ce3cf1000-2b1ce3cf2000 r--p 00017000 00:30 1629726                    /software/gcc/9.3.0/lib64/libgcc_s.so.1
2b1ce3cf2000-2b1ce3cf3000 rw-p 00018000 00:30 1629726                    /software/gcc/9.3.0/lib64/libgcc_s.so.1
2b1ce3cf3000-2b1ce3cf4000 rwxp 00000000 00:00 0
2b1ce3cf4000-2b1ce3cf5000 rw-p 00000000 00:00 0
2b1ce3cfe000-2b1ce3cff000 rw-p 00000000 00:00 0
2b1ce3d10000-2b1ce3e95000 rw-p 00000000 00:00 0
2b1ce3ed0000-2b1ce3ed1000 r--p 00021000 08:08 1049209                    /usr/lib64/ld-2.17.so
2b1ce3ed1000-2b1ce3ed2000 rw-p 00022000 08:08 1049209                    /usr/lib64/ld-2.17.so
2b1ce3ed2000-2b1ce3ed3000 rw-p 00000000 00:00 0
2b1ce3ed3000-2b1ce4160000 r-xp 00000000 08:08 1057394                    /usr/lib64/libpython3.6m.so.1.0
2b1ce4160000-2b1ce4360000 ---p 0028d000 08:08 1057394                    /usr/lib64/libpython3.6m.so.1.0
2b1ce4360000-2b1ce4363000 r--p 0028d000 08:08 1057394                    /usr/lib64/libpython3.6m.so.1.0
2b1ce4363000-2b1ce43c9000 rw-p 00290000 08:08 1057394                    /usr/lib64/libpython3.6m.so.1.0
2b1ce43c9000-2b1ce43fb000 rw-p 00000000 00:00 0
2b1ce43fb000-2b1ce4412000 r-xp 00000000 08:08 1049246                    /usr/lib64/libpthread-2.17.so
2b1ce4412000-2b1ce4611000 ---p 00017000 08:08 1049246                    /usr/lib64/libpthread-2.17.so
2b1ce4611000-2b1ce4612000 r--p 00016000 08:08 1049246                    /usr/lib64/libpthread-2.17.so
2b1ce4612000-2b1ce4613000 rw-p 00017000 08:08 1049246                    /usr/lib64/libpthread-2.17.so
2b1ce4613000-2b1ce4617000 rw-p 00000000 00:00 0
2b1ce4617000-2b1ce4619000 r-xp 00000000 08:08 1049226                    /usr/lib64/libdl-2.17.so
2b1ce4619000-2b1ce4819000 ---p 00002000 08:08 1049226                    /usr/lib64/libdl-2.17.so
2b1ce4819000-2b1ce481a000 r--p 00002000 08:08 1049226                    /usr/lib64/libdl-2.17.so
2b1ce481a000-2b1ce481b000 rw-p 00003000 08:08 1049226                    /usr/lib64/libdl-2.17.so
2b1ce481b000-2b1ce481d000 r-xp 00000000 08:08 1049254                    /usr/lib64/libutil-2.17.so
2b1ce481d000-2b1ce4a1c000 ---p 00002000 08:08 1049254                    /usr/lib64/libutil-2.17.so
2b1ce4a1c000-2b1ce4a1d000 r--p 00001000 08:08 1049254                    /usr/lib64/libutil-2.17.so
2b1ce4a1d000-2b1ce4a1e000 rw-p 00002000 08:08 1049254                    /usr/lib64/libutil-2.17.so
2b1ce4a1e000-2b1ce4b1f000 r-xp 00000000 08:08 1049228                    /usr/lib64/libm-2.17.so
2b1ce4b1f000-2b1ce4d1e000 ---p 00101000 08:08 1049228                    /usr/lib64/libm-2.17.so
2b1ce4d1e000-2b1ce4d1f000 r--p 00100000 08:08 1049228                    /usr/lib64/libm-2.17.so
2b1ce4d1f000-2b1ce4d20000 rw-p 00101000 08:08 1049228                    /usr/lib64/libm-2.17.so
2b1ce4d20000-2b1ce4ee4000 r-xp 00000000 08:08 1049220                    /usr/lib64/libc-2.17.so
2b1ce4ee4000-2b1ce50e3000 ---p 001c4000 08:08 1049220                    /usr/lib64/libc-2.17.so
2b1ce50e3000-2b1ce50e7000 r--p 001c3000 08:08 1049220                    /usr/lib64/libc-2.17.so
2b1ce50e7000-2b1ce50e9000 rw-p 001c7000 08:08 1049220                    /usr/lib64/libc-2.17.so
2b1ce50e9000-2b1ce50ee000 rw-p 00000000 00:00 0
2b1ce50ee000-2b1ceb631000 r--p 00000000 08:08 1060787                    /usr/lib/locale/locale-archive
2b1ceb631000-2b1ceb637000 r-xp 00000000 08:08 2493237                    /usr/lib64/python3.6/lib-dynload/readline.cpython-36m-x86_64-linux-gnu.so
2b1ceb637000-2b1ceb836000 ---p 00006000 08:08 2493237                    /usr/lib64/python3.6/lib-dynload/readline.cpython-36m-x86_64-linux-gnu.so
2b1ceb836000-2b1ceb837000 r--p 00005000 08:08 2493237                    /usr/lib64/python3.6/lib-dynload/readline.cpython-36m-x86_64-linux-gnu.so
2b1ceb837000-2b1ceb839000 rw-p 00006000 08:08 2493237                    /usr/lib64/python3.6/lib-dynload/readline.cpython-36m-x86_64-linux-gnu.so
2b1ceb839000-2b1ceb9f9000 rw-p 00000000 00:00 0
2b1ceba32000-2b1cebab2000 rw-p 00000000 00:00 0
2b1cebab2000-2b1cebab5000 r-xp 00000000 08:08 2493208                    /usr/lib64/python3.6/lib-dynload/_heapq.cpython-36m-x86_64-linux-gnu.so
2b1cebab5000-2b1cebcb4000 ---p 00003000 08:08 2493208                    /usr/lib64/python3.6/lib-dynload/_heapq.cpython-36m-x86_64-linux-gnu.so
2b1cebcb4000-2b1cebcb5000 r--p 00002000 08:08 2493208                    /usr/lib64/python3.6/lib-dynload/_heapq.cpython-36m-x86_64-linux-gnu.so
2b1cebcb5000-2b1cebcb7000 rw-p 00003000 08:08 2493208                    /usr/lib64/python3.6/lib-dynload/_heapq.cpython-36m-x86_64-linux-gnu.so
2b1cebcb7000-2b1cebcf7000 rw-p 00000000 00:00 0
2b1cebcf7000-2b1cebd33000 r-xp 00000000 08:08 1049589                    /usr/lib64/libreadline.so.6.2
2b1cebd33000-2b1cebf33000 ---p 0003c000 08:08 1049589                    /usr/lib64/libreadline.so.6.2
2b1cebf33000-2b1cebf35000 r--p 0003c000 08:08 1049589                    /usr/lib64/libreadline.so.6.2
2b1cebf35000-2b1cebf3b000 rw-p 0003e000 08:08 1049589                    /usr/lib64/libreadline.so.6.2
2b1cebf3b000-2b1cebf3d000 rw-p 00000000 00:00 0
2b1cebf3d000-2b1cebf62000 r-xp 00000000 08:08 1049290                    /usr/lib64/libtinfo.so.5.9
2b1cebf62000-2b1cec162000 ---p 00025000 08:08 1049290                    /usr/lib64/libtinfo.so.5.9
2b1cec162000-2b1cec166000 r--p 00025000 08:08 1049290                    /usr/lib64/libtinfo.so.5.9
2b1cec166000-2b1cec167000 rw-p 00029000 08:08 1049290                    /usr/lib64/libtinfo.so.5.9
2b1cec167000-2b1cec168000 r-xp 00000000 08:08 2493215                    /usr/lib64/python3.6/lib-dynload/_opcode.cpython-36m-x86_64-linux-gnu.so
2b1cec168000-2b1cec367000 ---p 00001000 08:08 2493215                    /usr/lib64/python3.6/lib-dynload/_opcode.cpython-36m-x86_64-linux-gnu.so
2b1cec367000-2b1cec368000 r--p 00000000 08:08 2493215                    /usr/lib64/python3.6/lib-dynload/_opcode.cpython-36m-x86_64-linux-gnu.so
2b1cec368000-2b1cec369000 rw-p 00001000 08:08 2493215                    /usr/lib64/python3.6/lib-dynload/_opcode.cpython-36m-x86_64-linux-gnu.so
2b1cec369000-2b1cec36f000 r-xp 00000000 08:08 2493245                    /usr/lib64/python3.6/lib-dynload/zlib.cpython-36m-x86_64-linux-gnu.so
2b1cec36f000-2b1cec56e000 ---p 00006000 08:08 2493245                    /usr/lib64/python3.6/lib-dynload/zlib.cpython-36m-x86_64-linux-gnu.so
2b1cec56e000-2b1cec56f000 r--p 00005000 08:08 2493245                    /usr/lib64/python3.6/lib-dynload/zlib.cpython-36m-x86_64-linux-gnu.so
2b1cec56f000-2b1cec571000 rw-p 00006000 08:08 2493245                    /usr/lib64/python3.6/lib-dynload/zlib.cpython-36m-x86_64-linux-gnu.so
2b1cec5af000-2b1cec5c4000 r-xp 00000000 08:08 1049410                    /usr/lib64/libz.so.1.2.7
2b1cec5c4000-2b1cec7c3000 ---p 00015000 08:08 1049410                    /usr/lib64/libz.so.1.2.7
2b1cec7c3000-2b1cec7c4000 r--p 00014000 08:08 1049410                    /usr/lib64/libz.so.1.2.7
2b1cec7c4000-2b1cec7c5000 rw-p 00015000 08:08 1049410                    /usr/lib64/libz.so.1.2.7
2b1cec7c5000-2b1cec7c9000 r-xp 00000000 08:08 2493190                    /usr/lib64/python3.6/lib-dynload/_bz2.cpython-36m-x86_64-linux-gnu.so
2b1cec7c9000-2b1cec9c8000 ---p 00004000 08:08 2493190                    /usr/lib64/python3.6/lib-dynload/_bz2.cpython-36m-x86_64-linux-gnu.so
2b1cec9c8000-2b1cec9c9000 r--p 00003000 08:08 2493190                    /usr/lib64/python3.6/lib-dynload/_bz2.cpython-36m-x86_64-linux-gnu.so
2b1cec9c9000-2b1cec9ca000 rw-p 00004000 08:08 2493190                    /usr/lib64/python3.6/lib-dynload/_bz2.cpython-36m-x86_64-linux-gnu.so
2b1cec9ca000-2b1cec9d9000 r-xp 00000000 08:08 1049527                    /usr/lib64/libbz2.so.1.0.6
2b1cec9d9000-2b1cecbd8000 ---p 0000f000 08:08 1049527                    /usr/lib64/libbz2.so.1.0.6
2b1cecbd8000-2b1cecbd9000 r--p 0000e000 08:08 1049527                    /usr/lib64/libbz2.so.1.0.6
2b1cecbd9000-2b1cecbda000 rw-p 0000f000 08:08 1049527                    /usr/lib64/libbz2.so.1.0.6
2b1cecbda000-2b1cecbe1000 r-xp 00000000 08:08 2493212                    /usr/lib64/python3.6/lib-dynload/_lzma.cpython-36m-x86_64-linux-gnu.so
2b1cecbe1000-2b1cecde0000 ---p 00007000 08:08 2493212                    /usr/lib64/python3.6/lib-dynload/_lzma.cpython-36m-x86_64-linux-gnu.so
2b1cecde0000-2b1cecde1000 r--p 00006000 08:08 2493212                    /usr/lib64/python3.6/lib-dynload/_lzma.cpython-36m-x86_64-linux-gnu.so
2b1cecde1000-2b1cecde3000 rw-p 00007000 08:08 2493212                    /usr/lib64/python3.6/lib-dynload/_lzma.cpython-36m-x86_64-linux-gnu.so
2b1cecde3000-2b1cece08000 r-xp 00000000 08:08 1049423                    /usr/lib64/liblzma.so.5.2.2
2b1cece08000-2b1ced007000 ---p 00025000 08:08 1049423                    /usr/lib64/liblzma.so.5.2.2
2b1ced007000-2b1ced008000 r--p 00024000 08:08 1049423                    /usr/lib64/liblzma.so.5.2.2
2b1ced008000-2b1ced009000 rw-p 00025000 08:08 1049423                    /usr/lib64/liblzma.so.5.2.2
2b1ced009000-2b1ced00b000 r-xp 00000000 08:08 2493230                    /usr/lib64/python3.6/lib-dynload/grp.cpython-36m-x86_64-linux-gnu.so
2b1ced00b000-2b1ced20a000 ---p 00002000 08:08 2493230                    /usr/lib64/python3.6/lib-dynload/grp.cpython-36m-x86_64-linux-gnu.so
2b1ced20a000-2b1ced20b000 r--p 00001000 08:08 2493230                    /usr/lib64/python3.6/lib-dynload/grp.cpython-36m-x86_64-linux-gnu.so
2b1ced20b000-2b1ced20c000 rw-p 00002000 08:08 2493230                    /usr/lib64/python3.6/lib-dynload/grp.cpython-36m-x86_64-linux-gnu.so
2b1ced20c000-2b1ced20f000 r-xp 00000000 08:08 2493217                    /usr/lib64/python3.6/lib-dynload/_posixsubprocess.cpython-36m-x86_64-linux-gnu.so
2b1ced20f000-2b1ced40e000 ---p 00003000 08:08 2493217                    /usr/lib64/python3.6/lib-dynload/_posixsubprocess.cpython-36m-x86_64-linux-gnu.so
2b1ced40e000-2b1ced40f000 r--p 00002000 08:08 2493217                    /usr/lib64/python3.6/lib-dynload/_posixsubprocess.cpython-36m-x86_64-linux-gnu.so
2b1ced40f000-2b1ced410000 rw-p 00003000 08:08 2493217                    /usr/lib64/python3.6/lib-dynload/_posixsubprocess.cpython-36m-x86_64-linux-gnu.so
2b1ced410000-2b1ced416000 r-xp 00000000 08:08 2493239                    /usr/lib64/python3.6/lib-dynload/select.cpython-36m-x86_64-linux-gnu.so
2b1ced416000-2b1ced615000 ---p 00006000 08:08 2493239                    /usr/lib64/python3.6/lib-dynload/select.cpython-36m-x86_64-linux-gnu.so
2b1ced615000-2b1ced616000 r--p 00005000 08:08 2493239                    /usr/lib64/python3.6/lib-dynload/select.cpython-36m-x86_64-linux-gnu.so
2b1ced616000-2b1ced618000 rw-p 00006000 08:08 2493239                    /usr/lib64/python3.6/lib-dynload/select.cpython-36m-x86_64-linux-gnu.so
2b1ced618000-2b1ced658000 rw-p 00000000 00:00 0
2b1ced658000-2b1ced662000 r-xp 00000000 08:08 2493231                    /usr/lib64/python3.6/lib-dynload/math.cpython-36m-x86_64-linux-gnu.so
2b1ced662000-2b1ced861000 ---p 0000a000 08:08 2493231                    /usr/lib64/python3.6/lib-dynload/math.cpython-36m-x86_64-linux-gnu.so
2b1ced861000-2b1ced862000 r--p 00009000 08:08 2493231                    /usr/lib64/python3.6/lib-dynload/math.cpython-36m-x86_64-linux-gnu.so
2b1ced862000-2b1ced864000 rw-p 0000a000 08:08 2493231                    /usr/lib64/python3.6/lib-dynload/math.cpython-36m-x86_64-linux-gnu.so
2b1ced864000-2b1ced86a000 r-xp 00000000 08:08 2493207                    /usr/lib64/python3.6/lib-dynload/_hashlib.cpython-36m-x86_64-linux-gnu.so
2b1ced86a000-2b1ceda69000 ---p 00006000 08:08 2493207                    /usr/lib64/python3.6/lib-dynload/_hashlib.cpython-36m-x86_64-linux-gnu.so
2b1ceda69000-2b1ceda6a000 r--p 00005000 08:08 2493207                    /usr/lib64/python3.6/lib-dynload/_hashlib.cpython-36m-x86_64-linux-gnu.so
2b1ceda6a000-2b1ceda6b000 rw-p 00006000 08:08 2493207                    /usr/lib64/python3.6/lib-dynload/_hashlib.cpython-36m-x86_64-linux-gnu.so
2b1ceda6b000-2b1cedad2000 r-xp 00000000 08:08 1065058                    /usr/lib64/libssl.so.1.0.2k
2b1cedad2000-2b1cedcd2000 ---p 00067000 08:08 1065058                    /usr/lib64/libssl.so.1.0.2k
2b1cedcd2000-2b1cedcd6000 r--p 00067000 08:08 1065058                    /usr/lib64/libssl.so.1.0.2k
2b1cedcd6000-2b1cedcdd000 rw-p 0006b000 08:08 1065058                    /usr/lib64/libssl.so.1.0.2k
2b1cedcdd000-2b1cedf14000 r-xp 00000000 08:08 1050744                    /usr/lib64/libcrypto.so.1.0.2k
2b1cedf14000-2b1cee113000 ---p 00237000 08:08 1050744                    /usr/lib64/libcrypto.so.1.0.2k
2b1cee113000-2b1cee12f000 r--p 00236000 08:08 1050744                    /usr/lib64/libcrypto.so.1.0.2k
2b1cee12f000-2b1cee13c000 rw-p 00252000 08:08 1050744                    /usr/lib64/libcrypto.so.1.0.2k
2b1cee13c000-2b1cee140000 rw-p 00000000 00:00 0
2b1cee140000-2b1cee18a000 r-xp 00000000 08:08 1050725                    /usr/lib64/libgssapi_krb5.so.2.2
2b1cee18a000-2b1cee38a000 ---p 0004a000 08:08 1050725                    /usr/lib64/libgssapi_krb5.so.2.2
2b1cee38a000-2b1cee38b000 r--p 0004a000 08:08 1050725                    /usr/lib64/libgssapi_krb5.so.2.2
2b1cee38b000-2b1cee38d000 rw-p 0004b000 08:08 1050725                    /usr/lib64/libgssapi_krb5.so.2.2
2b1cee38d000-2b1cee466000 r-xp 00000000 08:08 1050735                    /usr/lib64/libkrb5.so.3.3
2b1cee466000-2b1cee665000 ---p 000d9000 08:08 1050735                    /usr/lib64/libkrb5.so.3.3
2b1cee665000-2b1cee673000 r--p 000d8000 08:08 1050735                    /usr/lib64/libkrb5.so.3.3
2b1cee673000-2b1cee676000 rw-p 000e6000 08:08 1050735                    /usr/lib64/libkrb5.so.3.3
2b1cee676000-2b1cee679000 r-xp 00000000 08:08 1049421                    /usr/lib64/libcom_err.so.2.1
2b1cee679000-2b1cee878000 ---p 00003000 08:08 1049421                    /usr/lib64/libcom_err.so.2.1
2b1cee878000-2b1cee879000 r--p 00002000 08:08 1049421                    /usr/lib64/libcom_err.so.2.1
2b1cee879000-2b1cee87a000 rw-p 00003000 08:08 1049421                    /usr/lib64/libcom_err.so.2.1
2b1cee87a000-2b1cee8ab000 r-xp 00000000 08:08 1050729                    /usr/lib64/libk5crypto.so.3.1
2b1cee8ab000-2b1ceeaaa000 ---p 00031000 08:08 1050729                    /usr/lib64/libk5crypto.so.3.1
2b1ceeaaa000-2b1ceeaac000 r--p 00030000 08:08 1050729                    /usr/lib64/libk5crypto.so.3.1
2b1ceeaac000-2b1ceeaad000 rw-p 00032000 08:08 1050729                    /usr/lib64/libk5crypto.so.3.1
2b1ceeaad000-2b1ceeabb000 r-xp 00000000 08:08 1050737                    /usr/lib64/libkrb5support.so.0.1
2b1ceeabb000-2b1ceecbb000 ---p 0000e000 08:08 1050737                    /usr/lib64/libkrb5support.so.0.1
2b1ceecbb000-2b1ceecbc000 r--p 0000e000 08:08 1050737                    /usr/lib64/libkrb5support.so.0.1
2b1ceecbc000-2b1ceecbd000 rw-p 0000f000 08:08 1050737                    /usr/lib64/libkrb5support.so.0.1
2b1ceecbd000-2b1ceecc0000 r-xp 00000000 08:08 1050360                    /usr/lib64/libkeyutils.so.1.5
2b1ceecc0000-2b1ceeebf000 ---p 00003000 08:08 1050360                    /usr/lib64/libkeyutils.so.1.5
2b1ceeebf000-2b1ceeec0000 r--p 00002000 08:08 1050360                    /usr/lib64/libkeyutils.so.1.5
2b1ceeec0000-2b1ceeec1000 rw-p 00003000 08:08 1050360                    /usr/lib64/libkeyutils.so.1.5
2b1ceeec1000-2b1ceeed7000 r-xp 00000000 08:08 1049248                    /usr/lib64/libresolv-2.17.so
2b1ceeed7000-2b1cef0d7000 ---p 00016000 08:08 1049248                    /usr/lib64/libresolv-2.17.so
2b1cef0d7000-2b1cef0d8000 r--p 00016000 08:08 1049248                    /usr/lib64/libresolv-2.17.so
2b1cef0d8000-2b1cef0d9000 rw-p 00017000 08:08 1049248                    /usr/lib64/libresolv-2.17.so
2b1cef0d9000-2b1cef0db000 rw-p 00000000 00:00 0
2b1cef0db000-2b1cef0ff000 r-xp 00000000 08:08 1049407                    /usr/lib64/libselinux.so.1
2b1cef0ff000-2b1cef2fe000 ---p 00024000 08:08 1049407                    /usr/lib64/libselinux.so.1
2b1cef2fe000-2b1cef2ff000 r--p 00023000 08:08 1049407                    /usr/lib64/libselinux.so.1
2b1cef2ff000-2b1cef300000 rw-p 00024000 08:08 1049407                    /usr/lib64/libselinux.so.1
2b1cef300000-2b1cef302000 rw-p 00000000 00:00 0
2b1cef302000-2b1cef362000 r-xp 00000000 08:08 1049398                    /usr/lib64/libpcre.so.1.2.0
2b1cef362000-2b1cef562000 ---p 00060000 08:08 1049398                    /usr/lib64/libpcre.so.1.2.0
2b1cef562000-2b1cef563000 r--p 00060000 08:08 1049398                    /usr/lib64/libpcre.so.1.2.0
2b1cef563000-2b1cef564000 rw-p 00061000 08:08 1049398                    /usr/lib64/libpcre.so.1.2.0
2b1cef564000-2b1cef56d000 r-xp 00000000 08:08 2493189                    /usr/lib64/python3.6/lib-dynload/_blake2.cpython-36m-x86_64-linux-gnu.so
2b1cef56d000-2b1cef76d000 ---p 00009000 08:08 2493189                    /usr/lib64/python3.6/lib-dynload/_blake2.cpython-36m-x86_64-linux-gnu.so
2b1cef76d000-2b1cef76e000 r--p 00009000 08:08 2493189                    /usr/lib64/python3.6/lib-dynload/_blake2.cpython-36m-x86_64-linux-gnu.so
2b1cef76e000-2b1cef76f000 rw-p 0000a000 08:08 2493189                    /usr/lib64/python3.6/lib-dynload/_blake2.cpython-36m-x86_64-linux-gnu.so
2b1cef76f000-2b1cef786000 r-xp 00000000 08:08 2493219                    /usr/lib64/python3.6/lib-dynload/_sha3.cpython-36m-x86_64-linux-gnu.so
2b1cef786000-2b1cef985000 ---p 00017000 08:08 2493219                    /usr/lib64/python3.6/lib-dynload/_sha3.cpython-36m-x86_64-linux-gnu.so
2b1cef985000-2b1cef986000 r--p 00016000 08:08 2493219                    /usr/lib64/python3.6/lib-dynload/_sha3.cpython-36m-x86_64-linux-gnu.so
2b1cef986000-2b1cef988000 rw-p 00017000 08:08 2493219                    /usr/lib64/python3.6/lib-dynload/_sha3.cpython-36m-x86_64-linux-gnu.so
2b1cef988000-2b1cef98a000 r-xp 00000000 08:08 2493188                    /usr/lib64/python3.6/lib-dynload/_bisect.cpython-36m-x86_64-linux-gnu.so
2b1cef98a000-2b1cefb89000 ---p 00002000 08:08 2493188                    /usr/lib64/python3.6/lib-dynload/_bisect.cpython-36m-x86_64-linux-gnu.so
2b1cefb89000-2b1cefb8a000 r--p 00001000 08:08 2493188                    /usr/lib64/python3.6/lib-dynload/_bisect.cpython-36m-x86_64-linux-gnu.so
2b1cefb8a000-2b1cefb8b000 rw-p 00002000 08:08 2493188                    /usr/lib64/python3.6/lib-dynload/_bisect.cpython-36m-x86_64-linux-gnu.so
2b1cefb8b000-2b1cefb8f000 r-xp 00000000 08:08 2493218                    /usr/lib64/python3.6/lib-dynload/_random.cpython-36m-x86_64-linux-gnu.so
2b1cefb8f000-2b1cefd8e000 ---p 00004000 08:08 2493218                    /usr/lib64/python3.6/lib-dynload/_random.cpython-36m-x86_64-linux-gnu.so
2b1cefd8e000-2b1cefd8f000 r--p 00003000 08:08 2493218                    /usr/lib64/python3.6/lib-dynload/_random.cpython-36m-x86_64-linux-gnu.so
2b1cefd8f000-2b1cefd90000 rw-p 00004000 08:08 2493218                    /usr/lib64/python3.6/lib-dynload/_random.cpython-36m-x86_64-linux-gnu.so
2b1cefd90000-2b1cefdd0000 rw-p 00000000 00:00 0
2b1cefdd0000-2b1cefdd9000 r-xp 00000000 08:08 2493223                    /usr/lib64/python3.6/lib-dynload/_struct.cpython-36m-x86_64-linux-gnu.so
2b1cefdd9000-2b1ceffd8000 ---p 00009000 08:08 2493223                    /usr/lib64/python3.6/lib-dynload/_struct.cpython-36m-x86_64-linux-gnu.so
2b1ceffd8000-2b1ceffd9000 r--p 00008000 08:08 2493223                    /usr/lib64/python3.6/lib-dynload/_struct.cpython-36m-x86_64-linux-gnu.so
2b1ceffd9000-2b1ceffdb000 rw-p 00009000 08:08 2493223                    /usr/lib64/python3.6/lib-dynload/_struct.cpython-36m-x86_64-linux-gnu.so
2b1ceffdb000-2b1cf0364000 r-xp 00000000 00:3a 171429712                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_umath.cpython-36m-x86_64-linux-gnu.so
2b1cf0364000-2b1cf0564000 ---p 00389000 00:3a 171429712                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_umath.cpython-36m-x86_64-linux-gnu.so
2b1cf0564000-2b1cf0566000 r--p 00389000 00:3a 171429712                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_umath.cpython-36m-x86_64-linux-gnu.so
2b1cf0566000-2b1cf0583000 rw-p 0038b000 00:3a 171429712                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_umath.cpython-36m-x86_64-linux-gnu.so
2b1cf0583000-2b1cf05a4000 rw-p 00000000 00:00 0
2b1cf05a4000-2b1cf05a8000 rw-p 003f3000 00:3a 171429712                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_umath.cpython-36m-x86_64-linux-gnu.so
2b1cf05a8000-2b1cf05ab000 rw-p 003f7000 00:3a 171429712                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_umath.cpython-36m-x86_64-linux-gnu.so
2b1cf05ab000-2b1cf223b000 r-xp 00000000 00:3a 168842482                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libopenblasp-r0-09e95953.3.13.so
2b1cf223b000-2b1cf243b000 ---p 01c90000 00:3a 168842482                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libopenblasp-r0-09e95953.3.13.so
2b1cf243b000-2b1cf2441000 r--p 01c90000 00:3a 168842482                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libopenblasp-r0-09e95953.3.13.so
2b1cf2441000-2b1cf2457000 rw-p 01c96000 00:3a 168842482                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libopenblasp-r0-09e95953.3.13.so
2b1cf2457000-2b1cf2463000 rw-p 00000000 00:00 0
2b1cf2463000-2b1cf24b3000 rw-p 01d94000 00:3a 168842482                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libopenblasp-r0-09e95953.3.13.so
2b1cf24b3000-2b1cf24eb000 rw-p 01de4000 00:3a 168842482                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libopenblasp-r0-09e95953.3.13.so
2b1cf24eb000-2b1cf26f3000 r-xp 00000000 00:3a 168842481                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libgfortran-2e0d59d6.so.5.0.0
2b1cf26f3000-2b1cf28f2000 ---p 00208000 00:3a 168842481                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libgfortran-2e0d59d6.so.5.0.0
2b1cf28f2000-2b1cf28f5000 rw-p 00207000 00:3a 168842481                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libgfortran-2e0d59d6.so.5.0.0
2b1cf28f5000-2b1cf2901000 rw-p 0020a000 00:3a 168842481                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libgfortran-2e0d59d6.so.5.0.0
2b1cf2901000-2b1cf290a000 rw-p 00216000 00:3a 168842481                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libgfortran-2e0d59d6.so.5.0.0
2b1cf290a000-2b1cf2913000 rw-p 0021f000 00:3a 168842481                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libgfortran-2e0d59d6.so.5.0.0
2b1cf2913000-2b1cf2952000 r-xp 00000000 00:3a 168842479                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libquadmath-2d0c479f.so.0.0.0
2b1cf2952000-2b1cf2b51000 ---p 0003f000 00:3a 168842479                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libquadmath-2d0c479f.so.0.0.0
2b1cf2b51000-2b1cf2b52000 rw-p 0003e000 00:3a 168842479                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libquadmath-2d0c479f.so.0.0.0
2b1cf2b52000-2b1cf2b53000 rw-p 00040000 00:3a 168842479                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libquadmath-2d0c479f.so.0.0.0
2b1cf2b53000-2b1cf2b68000 r-xp 00000000 00:3a 168842480                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libz-eb09ad1d.so.1.2.3
2b1cf2b68000-2b1cf2d67000 ---p 00015000 00:3a 168842480                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libz-eb09ad1d.so.1.2.3
2b1cf2d67000-2b1cf2d68000 r--p 00014000 00:3a 168842480                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libz-eb09ad1d.so.1.2.3
2b1cf2d68000-2b1cf2d69000 rw-p 00015000 00:3a 168842480                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libz-eb09ad1d.so.1.2.3
2b1cf2d69000-2b1cf2d6a000 rw-p 00016000 00:3a 168842480                  /home/asinn/.local/lib/python3.6/site-packages/numpy.libs/libz-eb09ad1d.so.1.2.3
2b1cf2d6a000-2b1cf2d6e000 r-xp 00000000 08:08 1049425                    /usr/lib64/libuuid.so.1.3.0
2b1cf2d6e000-2b1cf2f6d000 ---p 00004000 08:08 1049425                    /usr/lib64/libuuid.so.1.3.0
2b1cf2f6d000-2b1cf2f6e000 r--p 00003000 08:08 1049425                    /usr/lib64/libuuid.so.1.3.0
2b1cf2f6e000-2b1cf2f6f000 rw-p 00004000 08:08 1049425                    /usr/lib64/libuuid.so.1.3.0
2b1cf2f6f000-2b1cf312f000 rw-p 00000000 00:00 0
2b1cf316c000-2b1cfb16c000 rw-p 00000000 00:00 0
2b1cfb16c000-2b1cfb20a000 r--p 00000000 00:30 1714046                    /software/gcc/9.3.0/lib64/libstdc++.so.6.0.28
2b1cfb20a000-2b1cfb2f3000 r-xp 0009e000 00:30 1714046                    /software/gcc/9.3.0/lib64/libstdc++.so.6.0.28
2b1cfb2f3000-2b1cfb33d000 r--p 00187000 00:30 1714046                    /software/gcc/9.3.0/lib64/libstdc++.so.6.0.28
2b1cfb33d000-2b1cfb348000 r--p 001d0000 00:30 1714046                    /software/gcc/9.3.0/lib64/libstdc++.so.6.0.28
2b1cfb348000-2b1cfb34b000 rw-p 001db000 00:30 1714046                    /software/gcc/9.3.0/lib64/libstdc++.so.6.0.28
2b1cfb34b000-2b1cfb34e000 rw-p 00000000 00:00 0
2b1cfb36d000-2b1d0336d000 rw-p 00000000 00:00 0
2b1d0336d000-2b1d0356d000 rw-p 00000000 00:00 0
2b1d0356e000-2b1d0b56e000 rw-p 00000000 00:00 0
2b1d0b56e000-2b1d0b76e000 rw-p 00000000 00:00 0
2b1d0b76f000-2b1d1376f000 rw-p 00000000 00:00 0
2b1d1376f000-2b1d1396f000 rw-p 00000000 00:00 0
2b1d13970000-2b1d1b970000 rw-p 00000000 00:00 0
2b1d1b970000-2b1d1ba70000 rw-p 00000000 00:00 0
2b1d1bb71000-2b1d23b71000 rw-p 00000000 00:00 0
2b1d23d72000-2b1d2bd72000 rw-p 00000000 00:00 0
2b1d2bf73000-2b1d33f73000 rw-p 00000000 00:00 0
2b1d34174000-2b1d3c174000 rw-p 00000000 00:00 0
2b1d3c375000-2b1d44375000 rw-p 00000000 00:00 0
2b1d44375000-2b1d44380000 r-xp 00000000 08:08 2493210                    /usr/lib64/python3.6/lib-dynload/_json.cpython-36m-x86_64-linux-gnu.so
2b1d44380000-2b1d4457f000 ---p 0000b000 08:08 2493210                    /usr/lib64/python3.6/lib-dynload/_json.cpython-36m-x86_64-linux-gnu.so
2b1d4457f000-2b1d44580000 r--p 0000a000 08:08 2493210                    /usr/lib64/python3.6/lib-dynload/_json.cpython-36m-x86_64-linux-gnu.so
2b1d44580000-2b1d44581000 rw-p 0000b000 08:08 2493210                    /usr/lib64/python3.6/lib-dynload/_json.cpython-36m-x86_64-linux-gnu.so
2b1d44777000-2b1d54777000 rw-p 00000000 00:00 0
2b1d54978000-2b1d5c978000 rw-p 00000000 00:00 0
2b1d5cb79000-2b1d64b79000 rw-p 00000000 00:00 0
2b1d64d7a000-2b1d6cd7a000 rw-p 00000000 00:00 0
2b1d6cf7b000-2b1d74f7b000 rw-p 00000000 00:00 0
2b1d7517c000-2b1d7d17c000 rw-p 00000000 00:00 0
2b1d7d37d000-2b1d8537d000 rw-p 00000000 00:00 0
2b1d8557e000-2b1d8d57e000 rw-p 00000000 00:00 0
2b1d8d77f000-2b1d9577f000 rw-p 00000000 00:00 0
2b1d95980000-2b1d9d980000 rw-p 00000000 00:00 0
2b1d9d980000-2b1d9da4f000 r-xp 00000000 00:3a 170625189                  /home/asinn/.local/lib/python3.6/site-packages/matplotlib/ft2font.cpython-36m-x86_64-linux-gnu.so
2b1d9da4f000-2b1d9dc4f000 ---p 000cf000 00:3a 170625189                  /home/asinn/.local/lib/python3.6/site-packages/matplotlib/ft2font.cpython-36m-x86_64-linux-gnu.so
2b1d9dc4f000-2b1d9dc56000 rw-p 000cf000 00:3a 170625189                  /home/asinn/.local/lib/python3.6/site-packages/matplotlib/ft2font.cpython-36m-x86_64-linux-gnu.so
2b1d9dc56000-2b1d9dc57000 rw-p 00000000 00:00 0
2b1d9dd82000-2b1dadd82000 rw-p 00000000 00:00 0
2b1dadf83000-2b1db5f83000 rw-p 00000000 00:00 0
2b1db6184000-2b1dc6184000 rw-p 00000000 00:00 0
2b1dc6184000-2b1dc61bb000 r-xp 00000000 08:08 2889426                    /usr/lib64/python3.6/site-packages/kiwisolver.cpython-36m-x86_64-linux-gnu.so
2b1dc61bb000-2b1dc63ba000 ---p 00037000 08:08 2889426                    /usr/lib64/python3.6/site-packages/kiwisolver.cpython-36m-x86_64-linux-gnu.so
2b1dc63ba000-2b1dc63bb000 r--p 00036000 08:08 2889426                    /usr/lib64/python3.6/site-packages/kiwisolver.cpython-36m-x86_64-linux-gnu.so
2b1dc63bb000-2b1dc63bd000 rw-p 00037000 08:08 2889426                    /usr/lib64/python3.6/site-packages/kiwisolver.cpython-36m-x86_64-linux-gnu.so
2b1dc6586000-2b1dce586000 rw-p 00000000 00:00 0
2b1dce787000-2b1dd6787000 rw-p 00000000 00:00 0
2b1dd6988000-2b1dde988000 rw-p 00000000 00:00 0
2b1ddeb89000-2b1de6b89000 rw-p 00000000 00:00 0
2b1de6d8a000-2b1deed8a000 rw-p 00000000 00:00 0
2b1deef8b000-2b1df6f8b000 rw-p 00000000 00:00 0
2b1df718c000-2b1dff18c000 rw-p 00000000 00:00 0
2b1dff38d000-2b1e0738d000 rw-p 00000000 00:00 0
2b1e0758e000-2b1e0f58e000 rw-p 00000000 00:00 0
2b1e0f78f000-2b1e1778f000 rw-p 00000000 00:00 0
2b1e17990000-2b1e1f990000 rw-p 00000000 00:00 0
2b1e1fb91000-2b1e27b91000 rw-p 00000000 00:00 0
2b1e27d92000-2b1e2fd92000 rw-p 00000000 00:00 0
2b1e2ff93000-2b1e37f93000 rw-p 00000000 00:00 0
2b1e38194000-2b1e40194000 rw-p 00000000 00:00 0
2b1e40395000-2b1e48395000 rw-p 00000000 00:00 0
2b1e48596000-2b1e50596000 rw-p 00000000 00:00 0
2b1e50596000-2b1e50597000 ---p 00000000 00:00 0
2b1e50597000-2b1e50797000 rw-p 00000000 00:00 0
2b1e50797000-2b1e58797000 rw-p 00000000 00:00 0
2b1e58797000-2b1e58798000 ---p 00000000 00:00 0
2b1e58798000-2b1e58998000 rw-p 00000000 00:00 0
2b1e58998000-2b1e60998000 rw-p 00000000 00:00 0
2b1e60998000-2b1e60999000 ---p 00000000 00:00 0
2b1e60999000-2b1e60b99000 rw-p 00000000 00:00 0
2b1e60b99000-2b1e68b99000 rw-p 00000000 00:00 0
2b1e68b99000-2b1e68b9a000 ---p 00000000 00:00 0
2b1e68b9a000-2b1e68d9a000 rw-p 00000000 00:00 0
2b1e68d9a000-2b1e70d9a000 rw-p 00000000 00:00 0
2b1e70d9a000-2b1e70d9b000 ---p 00000000 00:00 0
2b1e70d9b000-2b1e70f9b000 rw-p 00000000 00:00 0
2b1e70f9b000-2b1e70f9c000 ---p 00000000 00:00 0
2b1e70f9c000-2b1e7119c000 rw-p 00000000 00:00 0
2b1e7119c000-2b1e8119c000 rw-p 00000000 00:00 0
2b1e8119c000-2b1e8119d000 ---p 00000000 00:00 0
2b1e8119d000-2b1e8139d000 rw-p 00000000 00:00 0
2b1e8139d000-2b1e8939d000 rw-p 00000000 00:00 0
2b1e8939d000-2b1e8939e000 ---p 00000000 00:00 0
2b1e8939e000-2b1e8959e000 rw-p 00000000 00:00 0
2b1e8959e000-2b1e9159e000 rw-p 00000000 00:00 0
2b1e9159e000-2b1e9159f000 ---p 00000000 00:00 0
2b1e9159f000-2b1e9179f000 rw-p 00000000 00:00 0
2b1e9179f000-2b1e9979f000 rw-p 00000000 00:00 0
2b1e9979f000-2b1e997a0000 ---p 00000000 00:00 0
2b1e997a0000-2b1e999a0000 rw-p 00000000 00:00 0
2b1e999a0000-2b1ea19a0000 rw-p 00000000 00:00 0
2b1ea19a0000-2b1ea19a1000 ---p 00000000 00:00 0
2b1ea19a1000-2b1ea1ba1000 rw-p 00000000 00:00 0
2b1ea1ba1000-2b1ea9ba1000 rw-p 00000000 00:00 0
2b1ea9ba1000-2b1ea9ba2000 ---p 00000000 00:00 0
2b1ea9ba2000-2b1ea9da2000 rw-p 00000000 00:00 0
2b1ea9da2000-2b1eb1da2000 rw-p 00000000 00:00 0
2b1eb1da2000-2b1eb1da3000 ---p 00000000 00:00 0
2b1eb1da3000-2b1eb1fa3000 rw-p 00000000 00:00 0
2b1eb1fa3000-2b1eb9fa3000 rw-p 00000000 00:00 0
2b1eb9fa3000-2b1eb9fa4000 ---p 00000000 00:00 0
2b1eb9fa4000-2b1eba1a4000 rw-p 00000000 00:00 0
2b1eba1a4000-2b1ec21a4000 rw-p 00000000 00:00 0
2b1ec21a4000-2b1ec21a5000 ---p 00000000 00:00 0
2b1ec21a5000-2b1ec23a5000 rw-p 00000000 00:00 0
2b1ec23a5000-2b1eca3a5000 rw-p 00000000 00:00 0
2b1eca3a5000-2b1eca3a6000 ---p 00000000 00:00 0
2b1eca3a6000-2b1eca5a6000 rw-p 00000000 00:00 0
2b1eca5a6000-2b1ed25a6000 rw-p 00000000 00:00 0
2b1ed25a6000-2b1ed25a7000 ---p 00000000 00:00 0
2b1ed25a7000-2b1ed27a7000 rw-p 00000000 00:00 0
2b1ed27a7000-2b1eda7a7000 rw-p 00000000 00:00 0
2b1eda7a7000-2b1eda7a8000 ---p 00000000 00:00 0
2b1eda7a8000-2b1eda9a8000 rw-p 00000000 00:00 0
2b1eda9a8000-2b1ee29a8000 rw-p 00000000 00:00 0
2b1ee29a8000-2b1ee29a9000 ---p 00000000 00:00 0
2b1ee29a9000-2b1ee2ba9000 rw-p 00000000 00:00 0
2b1ee2ba9000-2b1ef2ba9000 rw-p 00000000 00:00 0
2b1ef2ba9000-2b1ef2be9000 rw-p 00000000 00:00 0
2b1ef2be9000-2b1ef2c00000 r-xp 00000000 08:08 2493202                    /usr/lib64/python3.6/lib-dynload/_datetime.cpython-36m-x86_64-linux-gnu.so
2b1ef2c00000-2b1ef2e00000 ---p 00017000 08:08 2493202                    /usr/lib64/python3.6/lib-dynload/_datetime.cpython-36m-x86_64-linux-gnu.so
2b1ef2e00000-2b1ef2e01000 r--p 00017000 08:08 2493202                    /usr/lib64/python3.6/lib-dynload/_datetime.cpython-36m-x86_64-linux-gnu.so
2b1ef2e01000-2b1ef2e04000 rw-p 00018000 08:08 2493202                    /usr/lib64/python3.6/lib-dynload/_datetime.cpython-36m-x86_64-linux-gnu.so
2b1ef2e04000-2b1ef2e44000 rw-p 00000000 00:00 0
2b1ef2e44000-2b1ef2e60000 r-xp 00000000 08:08 2493216                    /usr/lib64/python3.6/lib-dynload/_pickle.cpython-36m-x86_64-linux-gnu.so
2b1ef2e60000-2b1ef305f000 ---p 0001c000 08:08 2493216                    /usr/lib64/python3.6/lib-dynload/_pickle.cpython-36m-x86_64-linux-gnu.so
2b1ef305f000-2b1ef3060000 r--p 0001b000 08:08 2493216                    /usr/lib64/python3.6/lib-dynload/_pickle.cpython-36m-x86_64-linux-gnu.so
2b1ef3060000-2b1ef3064000 rw-p 0001c000 08:08 2493216                    /usr/lib64/python3.6/lib-dynload/_pickle.cpython-36m-x86_64-linux-gnu.so
2b1ef3064000-2b1ef3164000 rw-p 00000000 00:00 0
2b1ef3164000-2b1ef3185000 r-xp 00000000 00:3a 171429731                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_tests.cpython-36m-x86_64-linux-gnu.so
2b1ef3185000-2b1ef3385000 ---p 00021000 00:3a 171429731                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_tests.cpython-36m-x86_64-linux-gnu.so
2b1ef3385000-2b1ef3386000 r--p 00021000 00:3a 171429731                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_tests.cpython-36m-x86_64-linux-gnu.so
2b1ef3386000-2b1ef3388000 rw-p 00022000 00:3a 171429731                  /home/asinn/.local/lib/python3.6/site-packages/numpy/core/_multiarray_tests.cpython-36m-x86_64-linux-gnu.so
2b1ef3388000-2b1ef33c8000 rw-p 00000000 00:00 0
2b1ef33c8000-2b1ef33e4000 r-xp 00000000 08:08 2493199                    /usr/lib64/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so
2b1ef33e4000-2b1ef35e3000 ---p 0001c000 08:08 2493199                    /usr/lib64/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so
2b1ef35e3000-2b1ef35e4000 r--p 0001b000 08:08 2493199                    /usr/lib64/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so
2b1ef35e4000-2b1ef35e8000 rw-p 0001c000 08:08 2493199                    /usr/lib64/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so
2b1ef35e8000-2b1ef35ef000 r-xp 00000000 08:08 1049704                    /usr/lib64/libffi.so.6.0.1
2b1ef35ef000-2b1ef37ee000 ---p 00007000 08:08 1049704                    /usr/lib64/libffi.so.6.0.1
2b1ef37ee000-2b1ef37ef000 r--p 00006000 08:08 1049704                    /usr/lib64/libffi.so.6.0.1
2b1ef37ef000-2b1ef37f0000 rw-p 00007000 08:08 1049704                    /usr/lib64/libffi.so.6.0.1
2b1ef37f0000-2b1ef3830000 rw-p 00000000 00:00 0
2b1ef3830000-2b1ef3833000 r-xp 00000000 00:3a 169058466                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/lapack_lite.cpython-36m-x86_64-linux-gnu.so
2b1ef3833000-2b1ef3a32000 ---p 00003000 00:3a 169058466                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/lapack_lite.cpython-36m-x86_64-linux-gnu.so
2b1ef3a32000-2b1ef3a33000 r--p 00002000 00:3a 169058466                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/lapack_lite.cpython-36m-x86_64-linux-gnu.so
2b1ef3a33000-2b1ef3a34000 rw-p 00003000 00:3a 169058466                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/lapack_lite.cpython-36m-x86_64-linux-gnu.so
2b1ef3a34000-2b1ef3a35000 rw-p 00005000 00:3a 169058466                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/lapack_lite.cpython-36m-x86_64-linux-gnu.so
2b1ef3a35000-2b1ef3a36000 rw-p 00006000 00:3a 169058466                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/lapack_lite.cpython-36m-x86_64-linux-gnu.so
2b1ef3a36000-2b1ef3a60000 r-xp 00000000 00:3a 169058469                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/_umath_linalg.cpython-36m-x86_64-linux-gnu.so
2b1ef3a60000-2b1ef3c5f000 ---p 0002a000 00:3a 169058469                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/_umath_linalg.cpython-36m-x86_64-linux-gnu.so
2b1ef3c5f000-2b1ef3c60000 r--p 00029000 00:3a 169058469                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/_umath_linalg.cpython-36m-x86_64-linux-gnu.so
2b1ef3c60000-2b1ef3c61000 rw-p 0002a000 00:3a 169058469                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/_umath_linalg.cpython-36m-x86_64-linux-gnu.so
2b1ef3c61000-2b1ef3c62000 rw-p 00000000 00:00 0
2b1ef3c62000-2b1ef3c64000 rw-p 00031000 00:3a 169058469                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/_umath_linalg.cpython-36m-x86_64-linux-gnu.so
2b1ef3c64000-2b1ef3c65000 rw-p 00033000 00:3a 169058469                  /home/asinn/.local/lib/python3.6/site-packages/numpy/linalg/_umath_linalg.cpython-36m-x86_64-linux-gnu.so
2b1ef3c65000-2b1ef3d25000 rw-p 00000000 00:00 0
2b1ef3d25000-2b1ef3d7a000 r-xp 00000000 08:08 2493204                    /usr/lib64/python3.6/lib-dynload/_decimal.cpython-36m-x86_64-linux-gnu.so
2b1ef3d7a000-2b1ef3f7a000 ---p 00055000 08:08 2493204                    /usr/lib64/python3.6/lib-dynload/_decimal.cpython-36m-x86_64-linux-gnu.so
2b1ef3f7a000-2b1ef3f7b000 r--p 00055000 08:08 2493204                    /usr/lib64/python3.6/lib-dynload/_decimal.cpython-36m-x86_64-linux-gnu.so
2b1ef3f7b000-2b1ef3f84000 rw-p 00056000 08:08 2493204                    /usr/lib64/python3.6/lib-dynload/_decimal.cpython-36m-x86_64-linux-gnu.so
2b1ef3f84000-2b1ef3fc4000 rw-p 00000000 00:00 0
2b1ef3fc4000-2b1ef3fd9000 r-xp 00000000 00:3a 166797876                  /home/asinn/.local/lib/python3.6/site-packages/numpy/fft/_pocketfft_internal.cpython-36m-x86_64-linux-gnu.so
2b1ef3fd9000-2b1ef41d9000 ---p 00015000 00:3a 166797876                  /home/asinn/.local/lib/python3.6/site-packages/numpy/fft/_pocketfft_internal.cpython-36m-x86_64-linux-gnu.so
2b1ef41d9000-2b1ef41da000 r--p 00015000 00:3a 166797876                  /home/asinn/.local/lib/python3.6/site-packages/numpy/fft/_pocketfft_internal.cpython-36m-x86_64-linux-gnu.so
2b1ef41da000-2b1ef41db000 rw-p 00016000 00:3a 166797876                  /home/asinn/.local/lib/python3.6/site-packages/numpy/fft/_pocketfft_internal.cpython-36m-x86_64-linux-gnu.so
2b1ef41db000-2b1ef421b000 rw-p 00000000 00:00 0
2b1ef421b000-2b1ef4293000 r-xp 00000000 00:3a 96340531                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/mtrand.cpython-36m-x86_64-linux-gnu.so
2b1ef4293000-2b1ef4492000 ---p 00078000 00:3a 96340531                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/mtrand.cpython-36m-x86_64-linux-gnu.so
2b1ef4492000-2b1ef4493000 r--p 00077000 00:3a 96340531                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/mtrand.cpython-36m-x86_64-linux-gnu.so
2b1ef4493000-2b1ef44b9000 rw-p 00078000 00:3a 96340531                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/mtrand.cpython-36m-x86_64-linux-gnu.so
2b1ef44b9000-2b1ef44bb000 rw-p 00000000 00:00 0
2b1ef44bb000-2b1ef44e1000 r-xp 00000000 00:3a 96340540                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/bit_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef44e1000-2b1ef46e0000 ---p 00026000 00:3a 96340540                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/bit_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef46e0000-2b1ef46e1000 r--p 00025000 00:3a 96340540                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/bit_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef46e1000-2b1ef46e6000 rw-p 00026000 00:3a 96340540                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/bit_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef46e6000-2b1ef471d000 r-xp 00000000 00:3a 96340544                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_common.cpython-36m-x86_64-linux-gnu.so
2b1ef471d000-2b1ef491c000 ---p 00037000 00:3a 96340544                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_common.cpython-36m-x86_64-linux-gnu.so
2b1ef491c000-2b1ef491d000 r--p 00036000 00:3a 96340544                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_common.cpython-36m-x86_64-linux-gnu.so
2b1ef491d000-2b1ef491f000 rw-p 00037000 00:3a 96340544                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_common.cpython-36m-x86_64-linux-gnu.so
2b1ef491f000-2b1ef4920000 rw-p 00000000 00:00 0
2b1ef4920000-2b1ef4925000 r-xp 00000000 08:08 2493227                    /usr/lib64/python3.6/lib-dynload/binascii.cpython-36m-x86_64-linux-gnu.so
2b1ef4925000-2b1ef4b24000 ---p 00005000 08:08 2493227                    /usr/lib64/python3.6/lib-dynload/binascii.cpython-36m-x86_64-linux-gnu.so
2b1ef4b24000-2b1ef4b25000 r--p 00004000 08:08 2493227                    /usr/lib64/python3.6/lib-dynload/binascii.cpython-36m-x86_64-linux-gnu.so
2b1ef4b25000-2b1ef4b26000 rw-p 00005000 08:08 2493227                    /usr/lib64/python3.6/lib-dynload/binascii.cpython-36m-x86_64-linux-gnu.so
2b1ef4b26000-2b1ef4b29000 r-xp 00000000 08:08 2493209                    /usr/lib64/python3.6/lib-dynload/_hmacopenssl.cpython-36m-x86_64-linux-gnu.so
2b1ef4b29000-2b1ef4d28000 ---p 00003000 08:08 2493209                    /usr/lib64/python3.6/lib-dynload/_hmacopenssl.cpython-36m-x86_64-linux-gnu.so
2b1ef4d28000-2b1ef4d29000 r--p 00002000 08:08 2493209                    /usr/lib64/python3.6/lib-dynload/_hmacopenssl.cpython-36m-x86_64-linux-gnu.so
2b1ef4d29000-2b1ef4d2a000 rw-p 00003000 08:08 2493209                    /usr/lib64/python3.6/lib-dynload/_hmacopenssl.cpython-36m-x86_64-linux-gnu.so
2b1ef4d2a000-2b1ef4d6a000 rw-p 00000000 00:00 0
2b1ef4d6a000-2b1ef4dbc000 r-xp 00000000 00:3a 96340534                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_bounded_integers.cpython-36m-x86_64-linux-gnu.so
2b1ef4dbc000-2b1ef4fbb000 ---p 00052000 00:3a 96340534                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_bounded_integers.cpython-36m-x86_64-linux-gnu.so
2b1ef4fbb000-2b1ef4fbc000 r--p 00051000 00:3a 96340534                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_bounded_integers.cpython-36m-x86_64-linux-gnu.so
2b1ef4fbc000-2b1ef4fbd000 rw-p 00052000 00:3a 96340534                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_bounded_integers.cpython-36m-x86_64-linux-gnu.so
2b1ef4fbd000-2b1ef4fbe000 rw-p 00000000 00:00 0
2b1ef4fbe000-2b1ef4fd4000 r-xp 00000000 00:3a 96340538                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_mt19937.cpython-36m-x86_64-linux-gnu.so
2b1ef4fd4000-2b1ef51d3000 ---p 00016000 00:3a 96340538                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_mt19937.cpython-36m-x86_64-linux-gnu.so
2b1ef51d3000-2b1ef51d4000 r--p 00015000 00:3a 96340538                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_mt19937.cpython-36m-x86_64-linux-gnu.so
2b1ef51d4000-2b1ef51d6000 rw-p 00016000 00:3a 96340538                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_mt19937.cpython-36m-x86_64-linux-gnu.so
2b1ef51d6000-2b1ef51e9000 r-xp 00000000 00:3a 96340484                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_philox.cpython-36m-x86_64-linux-gnu.so
2b1ef51e9000-2b1ef53e8000 ---p 00013000 00:3a 96340484                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_philox.cpython-36m-x86_64-linux-gnu.so
2b1ef53e8000-2b1ef53e9000 r--p 00012000 00:3a 96340484                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_philox.cpython-36m-x86_64-linux-gnu.so
2b1ef53e9000-2b1ef53eb000 rw-p 00013000 00:3a 96340484                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_philox.cpython-36m-x86_64-linux-gnu.so
2b1ef53eb000-2b1ef53fa000 r-xp 00000000 00:3a 96340527                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_pcg64.cpython-36m-x86_64-linux-gnu.so
2b1ef53fa000-2b1ef55f9000 ---p 0000f000 00:3a 96340527                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_pcg64.cpython-36m-x86_64-linux-gnu.so
2b1ef55f9000-2b1ef55fa000 r--p 0000e000 00:3a 96340527                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_pcg64.cpython-36m-x86_64-linux-gnu.so
2b1ef55fa000-2b1ef55fc000 rw-p 0000f000 00:3a 96340527                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_pcg64.cpython-36m-x86_64-linux-gnu.so
2b1ef55fc000-2b1ef5608000 r-xp 00000000 00:3a 96340536                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_sfc64.cpython-36m-x86_64-linux-gnu.so
2b1ef5608000-2b1ef5807000 ---p 0000c000 00:3a 96340536                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_sfc64.cpython-36m-x86_64-linux-gnu.so
2b1ef5807000-2b1ef5808000 r--p 0000b000 00:3a 96340536                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_sfc64.cpython-36m-x86_64-linux-gnu.so
2b1ef5808000-2b1ef5809000 rw-p 0000c000 00:3a 96340536                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_sfc64.cpython-36m-x86_64-linux-gnu.so
2b1ef5809000-2b1ef58a1000 r-xp 00000000 00:3a 96340535                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef58a1000-2b1ef5aa0000 ---p 00098000 00:3a 96340535                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef5aa0000-2b1ef5aa1000 r--p 00097000 00:3a 96340535                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef5aa1000-2b1ef5ac5000 rw-p 00098000 00:3a 96340535                   /home/asinn/.local/lib/python3.6/site-packages/numpy/random/_generator.cpython-36m-x86_64-linux-gnu.so
2b1ef5ac5000-2b1ef5c47000 rw-p 00000000 00:00 0
2b1ef5c47000-2b1ef5d06000 r-xp 00000000 08:08 2493243                    /usr/lib64/python3.6/lib-dynload/unicodedata.cpython-36m-x86_64-linux-gnu.so
2b1ef5d06000-2b1ef5f06000 ---p 000bf000 08:08 2493243                    /usr/lib64/python3.6/lib-dynload/unicodedata.cpython-36m-x86_64-linux-gnu.so
2b1ef5f06000-2b1ef5f07000 r--p 000bf000 08:08 2493243                    /usr/lib64/python3.6/lib-dynload/unicodedata.cpython-36m-x86_64-linux-gnu.so
2b1ef5f07000-2b1ef5f22000 rw-p 000c0000 08:08 2493243                    /usr/lib64/python3.6/lib-dynload/unicodedata.cpython-36m-x86_64-linux-gnu.so
2b1ef5f22000-2b1ef5f36000 r-xp 00000000 08:08 2493220                    /usr/lib64/python3.6/lib-dynload/_socket.cpython-36m-x86_64-linux-gnu.so
2b1ef5f36000-2b1ef6135000 ---p 00014000 08:08 2493220                    /usr/lib64/python3.6/lib-dynload/_socket.cpython-36m-x86_64-linux-gnu.so
2b1ef6135000-2b1ef6136000 r--p 00013000 08:08 2493220                    /usr/lib64/python3.6/lib-dynload/_socket.cpython-36m-x86_64-linux-gnu.so
2b1ef6136000-2b1ef613b000 rw-p 00014000 08:08 2493220                    /usr/lib64/python3.6/lib-dynload/_socket.cpython-36m-x86_64-linux-gnu.so
2b1ef613b000-2b1ef6146000 r-xp 00000000 08:08 2493225                    /usr/lib64/python3.6/lib-dynload/array.cpython-36m-x86_64-linux-gnu.so
2b1ef6146000-2b1ef6345000 ---p 0000b000 08:08 2493225                    /usr/lib64/python3.6/lib-dynload/array.cpython-36m-x86_64-linux-gnu.so
2b1ef6345000-2b1ef6346000 r--p 0000a000 08:08 2493225                    /usr/lib64/python3.6/lib-dynload/array.cpython-36m-x86_64-linux-gnu.so
2b1ef6346000-2b1ef6349000 rw-p 0000b000 08:08 2493225                    /usr/lib64/python3.6/lib-dynload/array.cpython-36m-x86_64-linux-gnu.so
2b1ef6349000-2b1ef635d000 r-xp 00000000 08:08 6292458                    /usr/lib64/python3.6/site-packages/llvmlite/binding/libllvmlite.so
2b1ef635d000-2b1ef655d000 ---p 00014000 08:08 6292458                    /usr/lib64/python3.6/site-packages/llvmlite/binding/libllvmlite.so
2b1ef655d000-2b1ef655e000 r--p 00014000 08:08 6292458                    /usr/lib64/python3.6/site-packages/llvmlite/binding/libllvmlite.so
2b1ef655e000-2b1ef655f000 rw-p 00015000 08:08 6292458                    /usr/lib64/python3.6/site-packages/llvmlite/binding/libllvmlite.so
2b1ef655f000-2b1ef8d07000 r-xp 00000000 08:08 6032334                    /usr/lib64/llvm4.0/lib/libLLVM-4.0.so
2b1ef8d07000-2b1ef8f07000 ---p 027a8000 08:08 6032334                    /usr/lib64/llvm4.0/lib/libLLVM-4.0.so
2b1ef8f07000-2b1ef91da000 r--p 027a8000 08:08 6032334                    /usr/lib64/llvm4.0/lib/libLLVM-4.0.so
2b1ef91da000-2b1ef91df000 rw-p 02a7b000 08:08 6032334                    /usr/lib64/llvm4.0/lib/libLLVM-4.0.so
2b1ef91df000-2b1ef9239000 rw-p 00000000 00:00 0
2b1ef9239000-2b1ef926e000 r-xp 00000000 08:08 1050641                    /usr/lib64/libedit.so.0.0.42
2b1ef926e000-2b1ef946d000 ---p 00035000 08:08 1050641                    /usr/lib64/libedit.so.0.0.42
2b1ef946d000-2b1ef9470000 r--p 00034000 08:08 1050641                    /usr/lib64/libedit.so.0.0.42
2b1ef9470000-2b1ef9471000 rw-p 00037000 08:08 1050641                    /usr/lib64/libedit.so.0.0.42
2b1ef9471000-2b1ef9476000 rw-p 00000000 00:00 0
2b1ef9476000-2b1ef947d000 r-xp 00000000 08:08 1049250                    /usr/lib64/librt-2.17.so
2b1ef947d000-2b1ef967c000 ---p 00007000 08:08 1049250                    /usr/lib64/librt-2.17.so
2b1ef967c000-2b1ef967d000 r--p 00006000 08:08 1049250                    /usr/lib64/librt-2.17.so
2b1ef967d000-2b1ef967e000 rw-p 00007000 08:08 1049250                    /usr/lib64/librt-2.17.so
2b1ef967e000-2b1ef9681000 r-xp 00000000 08:08 6294121                    /usr/lib64/python3.6/site-packages/numba/typeconv/_typeconv.cpython-36m-x86_64-linux-gnu.so
2b1ef9681000-2b1ef9880000 ---p 00003000 08:08 6294121                    /usr/lib64/python3.6/site-packages/numba/typeconv/_typeconv.cpython-36m-x86_64-linux-gnu.so
2b1ef9880000-2b1ef9881000 r--p 00002000 08:08 6294121                    /usr/lib64/python3.6/site-packages/numba/typeconv/_typeconv.cpython-36m-x86_64-linux-gnu.so
2b1ef9881000-2b1ef9882000 rw-p 00003000 08:08 6294121                    /usr/lib64/python3.6/site-packages/numba/typeconv/_typeconv.cpython-36m-x86_64-linux-gnu.so
2b1ef9882000-2b1ef9885000 r-xp 00000000 08:08 6292652                    /usr/lib64/python3.6/site-packages/numba/_dynfunc.cpython-36m-x86_64-linux-gnu.so
2b1ef9885000-2b1ef9a84000 ---p 00003000 08:08 6292652                    /usr/lib64/python3.6/site-packages/numba/_dynfunc.cpython-36m-x86_64-linux-gnu.so
2b1ef9a84000-2b1ef9a85000 r--p 00002000 08:08 6292652                    /usr/lib64/python3.6/site-packages/numba/_dynfunc.cpython-36m-x86_64-linux-gnu.so
2b1ef9a85000-2b1ef9a86000 rw-p 00003000 08:08 6292652                    /usr/lib64/python3.6/site-packages/numba/_dynfunc.cpython-36m-x86_64-linux-gnu.so
2b1ef9a86000-2b1ef9a9e000 r-xp 00000000 08:08 6292657                    /usr/lib64/python3.6/site-packages/numba/_helperlib.cpython-36m-x86_64-linux-gnu.so
2b1ef9a9e000-2b1ef9c9d000 ---p 00018000 08:08 6292657                    /usr/lib64/python3.6/site-packages/numba/_helperlib.cpython-36m-x86_64-linux-gnu.so
2b1ef9c9d000-2b1ef9c9e000 r--p 00017000 08:08 6292657                    /usr/lib64/python3.6/site-packages/numba/_helperlib.cpython-36m-x86_64-linux-gnu.so
2b1ef9c9e000-2b1ef9c9f000 rw-p 00018000 08:08 6292657                    /usr/lib64/python3.6/site-packages/numba/_helperlib.cpython-36m-x86_64-linux-gnu.so
2b1ef9c9f000-2b1ef9ca4000 r-xp 00000000 08:08 6293442                    /usr/lib64/python3.6/site-packages/numba/runtime/_nrt_python.cpython-36m-x86_64-linux-gnu.so
2b1ef9ca4000-2b1ef9ea3000 ---p 00005000 08:08 6293442                    /usr/lib64/python3.6/site-packages/numba/runtime/_nrt_python.cpython-36m-x86_64-linux-gnu.so
2b1ef9ea3000-2b1ef9ea4000 r--p 00004000 08:08 6293442                    /usr/lib64/python3.6/site-packages/numba/runtime/_nrt_python.cpython-36m-x86_64-linux-gnu.so
2b1ef9ea4000-2b1ef9ea5000 rw-p 00005000 08:08 6293442                    /usr/lib64/python3.6/site-packages/numba/runtime/_nrt_python.cpython-36m-x86_64-linux-gnu.so
2b1ef9ea5000-2b1ef9eae000 r-xp 00000000 08:08 6292649                    /usr/lib64/python3.6/site-packages/numba/_dispatcher.cpython-36m-x86_64-linux-gnu.so
2b1ef9eae000-2b1efa0ad000 ---p 00009000 08:08 6292649                    /usr/lib64/python3.6/site-packages/numba/_dispatcher.cpython-36m-x86_64-linux-gnu.so
2b1efa0ad000-2b1efa0ae000 r--p 00008000 08:08 6292649                    /usr/lib64/python3.6/site-packages/numba/_dispatcher.cpython-36m-x86_64-linux-gnu.so
2b1efa0ae000-2b1efa0af000 rw-p 00009000 08:08 6292649                    /usr/lib64/python3.6/site-packages/numba/_dispatcher.cpython-36m-x86_64-linux-gnu.so
2b1efa0af000-2b1efa0b3000 r-xp 00000000 08:08 6293366                    /usr/lib64/python3.6/site-packages/numba/npyufunc/_internal.cpython-36m-x86_64-linux-gnu.so
2b1efa0b3000-2b1efa2b2000 ---p 00004000 08:08 6293366                    /usr/lib64/python3.6/site-packages/numba/npyufunc/_internal.cpython-36m-x86_64-linux-gnu.so
2b1efa2b2000-2b1efa2b3000 r--p 00003000 08:08 6293366                    /usr/lib64/python3.6/site-packages/numba/npyufunc/_internal.cpython-36m-x86_64-linux-gnu.so
2b1efa2b3000-2b1efa2b4000 rw-p 00004000 08:08 6293366                    /usr/lib64/python3.6/site-packages/numba/npyufunc/_internal.cpython-36m-x86_64-linux-gnu.so
2b1efa2b4000-2b1efa2b6000 r-xp 00000000 08:08 6293332                    /usr/lib64/python3.6/site-packages/numba/jitclass/_box.cpython-36m-x86_64-linux-gnu.so
2b1efa2b6000-2b1efa4b5000 ---p 00002000 08:08 6293332                    /usr/lib64/python3.6/site-packages/numba/jitclass/_box.cpython-36m-x86_64-linux-gnu.so
2b1efa4b5000-2b1efa4b6000 r--p 00001000 08:08 6293332                    /usr/lib64/python3.6/site-packages/numba/jitclass/_box.cpython-36m-x86_64-linux-gnu.so
2b1efa4b6000-2b1efa4b7000 rw-p 00002000 08:08 6293332                    /usr/lib64/python3.6/site-packages/numba/jitclass/_box.cpython-36m-x86_64-linux-gnu.so
2b1efc000000-2b1efc021000 rw-p 00000000 00:00 0
2b1efc021000-2b1f00000000 ---p 00000000 00:00 0
7ffff9c18000-7ffff9c3a000 rw-p 00000000 00:00 0                          [stack]
7ffff9d91000-7ffff9d93000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
zsh: abort      python3
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
