### PR TITLE
Checksum: Back to openPMD-viewer default

### DIFF
--- a/tests/checksum/backend/openpmd_backend.py
+++ b/tests/checksum/backend/openpmd_backend.py
@@ -17,7 +17,7 @@ class Backend:
         ''' Constructor: store the dataset object
         '''
 
-        self.dataset = OpenPMDTimeSeries(filename, backend='h5py')
+        self.dataset = OpenPMDTimeSeries(filename)
 
     def fields_list(self):
         ''' Return the list of fields defined on the grid


### PR DESCRIPTION
Switch back to openPMD-viewer default backend of openPMD-api, since openPMD-viewer 1.4.0 fixed the performance regression introduced in 1.3.0:
https://github.com/openPMD/openPMD-viewer/releases/tag/1.4.0

Follow-up to #725

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
