### PR TITLE
Add beam jz-rho contribution, optionally

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -126,6 +126,10 @@ General parameters
     :math:`\omega_p` the plasma angular frequency and :math:`\gamma` is an average of Lorentz
     factors of the slowest particles in all beams.
 
+* ``hipace.do_beam_jz_minus_rho`` (`bool`) optional (default `0`)
+    Whether the beam contribution to jz - c*rho is calculated and used when solving for Psi (used to caculate the transverse fields Ex-By and Ey+Bx).
+    if 0, this term is assumed to be 0 (a good approximation for an ultra-relativistic beam in the z direction with small transverse momentum).
+
 Field solver parameters
 -----------------------
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -127,7 +127,7 @@ General parameters
     factors of the slowest particles in all beams.
 
 * ``hipace.do_beam_jz_minus_rho`` (`bool`) optional (default `0`)
-    Whether the beam contribution to jz - c*rho is calculated and used when solving for Psi (used to caculate the transverse fields Ex-By and Ey+Bx).
+    Whether the beam contribution to :math:`j_z-c\rho` is calculated and used when solving for Psi (used to caculate the transverse fields Ex-By and Ey+Bx).
     if 0, this term is assumed to be 0 (a good approximation for an ultra-relativistic beam in the z direction with small transverse momentum).
 
 Field solver parameters

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -267,6 +267,8 @@ public:
     static amrex::Real m_predcorr_B_mixing_factor;
     /** Whether the beams deposit Jx and Jy */
     static bool m_do_beam_jx_jy_deposition;
+    /** Whether the jz-c*rho contribution is computed and used. If not, jz-c*rho=0 is assumed */
+    static bool m_do_beam_jz_minus_rho;
     /** Whether to call amrex::Gpu::synchronize() around all profiler region */
     static int m_do_device_synchronize;
     /** Whether to use tiling for particle operations */

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -267,7 +267,7 @@ public:
     static amrex::Real m_predcorr_B_mixing_factor;
     /** Whether the beams deposit Jx and Jy */
     static bool m_do_beam_jx_jy_deposition;
-    /** Whether the jz-c*rho contribution is computed and used. If not, jz-c*rho=0 is assumed */
+    /** Whether the jz-c*rho contribution of the beam is computed and used. If not, jz-c*rho=0 is assumed */
     static bool m_do_beam_jz_minus_rho;
     /** Whether to call amrex::Gpu::synchronize() around all profiler region */
     static int m_do_device_synchronize;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -49,6 +49,7 @@ amrex::Real Hipace::m_predcorr_B_error_tolerance = 4e-2;
 int Hipace::m_predcorr_max_iterations = 30;
 amrex::Real Hipace::m_predcorr_B_mixing_factor = 0.05;
 bool Hipace::m_do_beam_jx_jy_deposition = true;
+bool Hipace::m_do_beam_jz_minus_rho = false;
 int Hipace::m_do_device_synchronize = 0;
 int Hipace::m_beam_injection_cr = 1;
 amrex::Real Hipace::m_external_ExmBy_slope = 0.;
@@ -126,6 +127,7 @@ Hipace::Hipace () :
                                      "To avoid output, please use output_period = -1.");
     queryWithParser(pph, "beam_injection_cr", m_beam_injection_cr);
     queryWithParser(pph, "do_beam_jx_jy_deposition", m_do_beam_jx_jy_deposition);
+    queryWithParser(pph, "do_beam_jz_minus_rho", m_do_beam_jz_minus_rho);
     queryWithParser(pph, "do_device_synchronize", m_do_device_synchronize);
     queryWithParser(pph, "external_ExmBy_slope", m_external_ExmBy_slope);
     queryWithParser(pph, "external_Ez_slope", m_external_Ez_slope);
@@ -522,11 +524,11 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox,
                 // guess.
                 m_fields.setVal(0., lev, WhichSlice::This,
                     "ExmBy", "EypBx", "Ez", "Bz", "jx", "jx_beam", "jy", "jy_beam",
-                    "jz", "jz_beam", "rho", "Psi", "jxx", "jxy", "jyy");
+                    "jz", "jz_beam", "rho", "rho_beam", "Psi", "jxx", "jxy", "jyy");
             } else {
                 m_fields.setVal(0., lev, WhichSlice::This,
                     "ExmBy", "EypBx", "Ez", "Bx", "By", "Bz", "jx", "jx_beam", "jy", "jy_beam",
-                    "jz", "jz_beam", "rho", "Psi", "jxx", "jxy", "jyy");
+                    "jz", "jz_beam", "rho", "rho_beam", "Psi", "jxx", "jxy", "jyy");
             }
 
             if (!m_explicit) {
@@ -558,12 +560,13 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox,
             if (!m_fields.m_extended_solve) m_fields.FillBoundary(Geom(lev).periodicity(), lev,
                 WhichSlice::This, "jx", "jx_beam", "jy", "jy_beam", "jz", "jz_beam", "rho");
 
-            m_fields.SolvePoissonExmByAndEypBx(Geom(), m_comm_xy, lev, islice);
-
             m_grid_current.DepositCurrentSlice(m_fields, geom[lev], lev, islice);
             m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice_local, bins[lev],
                                              m_box_sorters, ibox, m_do_beam_jx_jy_deposition,
-                                             WhichSlice::This);
+                                             WhichSlice::This, m_do_beam_jz_minus_rho);
+
+            m_fields.SolvePoissonExmByAndEypBx(Geom(), m_comm_xy, lev, islice);
+
             m_fields.AddBeamCurrents(lev, WhichSlice::This);
 
             if (!m_fields.m_extended_solve) m_fields.FillBoundary(Geom(lev).periodicity(), lev,

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -558,19 +558,20 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox,
 
             // need to exchange jx jy jz jx_beam jy_beam jz_beam rho
             if (!m_fields.m_extended_solve) m_fields.FillBoundary(Geom(lev).periodicity(), lev,
-                WhichSlice::This, "jx", "jx_beam", "jy", "jy_beam", "jz", "jz_beam", "rho");
+                WhichSlice::This, "jx", "jx_beam", "jy", "jy_beam", "jz", "jz_beam", "rho", "rho_beam");
 
-            m_grid_current.DepositCurrentSlice(m_fields, geom[lev], lev, islice);
             m_multi_beam.DepositCurrentSlice(m_fields, geom, lev, islice_local, bins[lev],
                                              m_box_sorters, ibox, m_do_beam_jx_jy_deposition,
                                              WhichSlice::This, m_do_beam_jz_minus_rho);
 
             m_fields.SolvePoissonExmByAndEypBx(Geom(), m_comm_xy, lev, islice);
 
+            m_grid_current.DepositCurrentSlice(m_fields, geom[lev], lev, islice);
+
             m_fields.AddBeamCurrents(lev, WhichSlice::This);
 
             if (!m_fields.m_extended_solve) m_fields.FillBoundary(Geom(lev).periodicity(), lev,
-                WhichSlice::This, "jx", "jx_beam", "jy", "jy_beam", "jz", "jz_beam", "rho");
+                WhichSlice::This, "jx", "jx_beam", "jy", "jy_beam", "jz", "jz_beam", "rho", "rho_beam");
 
             m_fields.SolvePoissonEz(Geom(), lev, islice);
             m_fields.SolvePoissonBz(Geom(), lev, islice);
@@ -904,7 +905,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice_local, const int lev
         // exchange ExmBy EypBx Ez Bx By Bz
         m_fields.FillBoundary(Geom(lev).periodicity(), lev, WhichSlice::This,
             "ExmBy", "EypBx", "Ez", "Bx", "By", "Bz", "jx", "jx_beam", "jy", "jy_beam",
-            "jz", "jz_beam", "rho", "Psi", "jxx", "jxy", "jyy");
+            "jz", "jz_beam", "rho", "rho_beam", "Psi", "jxx", "jxy", "jyy");
         amrex::ParallelContext::pop();
     }
 
@@ -992,7 +993,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice_local, const int lev
             // exchange Bx By
             m_fields.FillBoundary(Geom(lev).periodicity(), lev, WhichSlice::This,
                 "ExmBy", "EypBx", "Ez", "Bx", "By", "Bz", "jx", "jx_beam", "jy", "jy_beam",
-                "jz", "jz_beam", "rho", "Psi", "jxx", "jxy", "jyy");
+                "jz", "jz_beam", "rho", "rho_beam", "Psi", "jxx", "jxy", "jyy");
             amrex::ParallelContext::pop();
         }
 

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -37,7 +37,7 @@ static std::array<std::map<std::string, int>, 5> Comps
         {{
                 {"ExmBy", 0}, {"EypBx", 1}, {"Ez", 2}, {"Bx", 3}, {"By", 4}, {"Bz", 5}, {"jx", 6},
                 {"jx_beam", 7}, {"jy", 8}, {"jy_beam", 9}, {"jz", 10}, {"jz_beam", 11}, {"rho", 12},
-                {"Psi", 13}, {"jxx", 14}, {"jxy", 15}, {"jyy", 16}, {"N", 17}
+                {"rho_beam", 13}, {"Psi", 14}, {"jxx", 15}, {"jxy", 16}, {"jyy", 17}, {"N", 18}
             }},
         /* WhichSlice::Previous1 */
         {{

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -302,12 +302,12 @@ LinCombination (const amrex::IntVect box_grow, amrex::MultiFab dst,
             [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 const bool inside = box_i_lo<=i && i<=box_i_hi && box_j_lo<=j && j<=box_j_hi;
+                const amrex::Real tmp =
+                    inside ? factor_a * src_a_array(i,j,k) + factor_b * src_b_array(i,j,k) : 0._rt;
                 if (do_add) {
-                    dst_array(i,j,k) +=
-                        inside ? factor_a * src_a_array(i,j,k) + factor_b * src_b_array(i,j,k) : 0._rt;
+                    dst_array(i,j,k) += tmp;
                 } else {
-                    dst_array(i,j,k) =
-                        inside ? factor_a * src_a_array(i,j,k) + factor_b * src_b_array(i,j,k) : 0._rt;
+                    dst_array(i,j,k) = tmp;
                 }
             });
     }

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -674,7 +674,7 @@ Fields::SolvePoissonExmByAndEypBx (amrex::Vector<amrex::Geometry> const& geom,
                    1._rt/(phys_const.c*phys_const.ep0), getField(lev, WhichSlice::This, "jz"),
                    -1._rt/(phys_const.ep0), getField(lev, WhichSlice::This, "rho"));
     // Add beam rho-Jz/c contribution to the RHS
-    if (m_do_beam_jz_minus_rho) {
+    if (Hipace::m_do_beam_jz_minus_rho) {
         LinCombination(m_source_nguard, getStagingArea(lev),
                        1._rt/(phys_const.c*phys_const.ep0), getField(lev, WhichSlice::This, "jz_beam"),
                        -1._rt/(phys_const.ep0), getField(lev, WhichSlice::This, "rho_beam"), true);

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -276,6 +276,7 @@ struct guarded_field {
  * \param[in] src_a first source
  * \param[in] factor_b factor before src_b
  * \param[in] src_b second source
+ * \param[in] do_add whether to overwrite (=) or to add (+=) dst.
  */
 template<class FVA, class FVB>
 void
@@ -673,10 +674,11 @@ Fields::SolvePoissonExmByAndEypBx (amrex::Vector<amrex::Geometry> const& geom,
                    1._rt/(phys_const.c*phys_const.ep0), getField(lev, WhichSlice::This, "jz"),
                    -1._rt/(phys_const.ep0), getField(lev, WhichSlice::This, "rho"));
     // Add beam rho-Jz/c contribution to the RHS
-    LinCombination(m_source_nguard, getStagingArea(lev),
-                   1._rt/(phys_const.c*phys_const.ep0), getField(lev, WhichSlice::This, "jz_beam"),
-                   -1._rt/(phys_const.ep0), getField(lev, WhichSlice::This, "rho_beam"), true);
-
+    if (m_do_beam_jz_minus_rho) {
+        LinCombination(m_source_nguard, getStagingArea(lev),
+                       1._rt/(phys_const.c*phys_const.ep0), getField(lev, WhichSlice::This, "jz_beam"),
+                       -1._rt/(phys_const.ep0), getField(lev, WhichSlice::This, "rho_beam"), true);
+    }
     SetBoundaryCondition(geom, lev, "Psi", islice);
     m_poisson_solver[lev]->SolvePoissonEquation(lhs);
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -37,6 +37,8 @@ public:
      * \param[in] ibox index of the current box
      * \param[in] do_beam_jx_jy_deposition whether the beam deposits Jx and Jy
      * \param[in] which_slice defines if this or the next slice is handled
+     * \param[in] do_beam_jz_minus_rho whether jz_beam-rho_beam is computed and used in the simulation.
+     *            Otherwise, it is assumed to be 0. If true, rho_beam needs to be deposited.
      */
     void DepositCurrentSlice (
         Fields& fields, amrex::Vector<amrex::Geometry> const& geom, const int lev, int islice,

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -42,7 +42,7 @@ public:
         Fields& fields, amrex::Vector<amrex::Geometry> const& geom, const int lev, int islice,
         const amrex::Vector<BeamBins>& bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox,
-        const bool do_beam_jx_jy_deposition, const int which_slice);
+        const bool do_beam_jx_jy_deposition, const int which_slice, const bool do_beam_jz_minus_rho=false);
 
     /** Loop over all beam species and build and return the indices of particles sorted per slice
      * \param[in] lev MR level

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -40,14 +40,14 @@ MultiBeam::DepositCurrentSlice (
     Fields& fields, amrex::Vector<amrex::Geometry> const& geom, const int lev, int islice,
     const amrex::Vector<BeamBins>& bins,
     const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox,
-    const bool do_beam_jx_jy_deposition, const int which_slice)
+    const bool do_beam_jx_jy_deposition, const int which_slice, const bool do_beam_jz_minus_rho)
 
 {
     for (int i=0; i<m_nbeams; i++) {
         const int nghost = m_all_beams[i].numParticles() - m_n_real_particles[i];
         ::DepositCurrentSlice(m_all_beams[i], fields, geom, lev, islice,
                               a_box_sorter_vec[i].boxOffsetsPtr()[ibox], bins[i],
-                              do_beam_jx_jy_deposition, which_slice, nghost);
+                              do_beam_jx_jy_deposition, which_slice, nghost, do_beam_jz_minus_rho);
     }
 }
 

--- a/src/particles/deposition/BeamDepositCurrent.H
+++ b/src/particles/deposition/BeamDepositCurrent.H
@@ -27,6 +27,8 @@
  * \param[in] nghost number of ghost particles, all at the end of the particle array.
  *            Use for depositing transverse currents in the Next slice when processing
  *            islice = 0.
+ * \param[in] do_beam_jz_minus_rho whether jz_beam-rho_beam is computed and used in the simulation.
+ *            Otherwise, it is assumed to be 0. If true, rho_beam needs to be deposited.
  */
 void
 DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,

--- a/src/particles/deposition/BeamDepositCurrent.H
+++ b/src/particles/deposition/BeamDepositCurrent.H
@@ -33,7 +33,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
                      amrex::Vector<amrex::Geometry> const& gm, int const lev, const int islice,
                      int const offset, const BeamBins& bins,
                      const bool do_beam_jx_jy_deposition, const int which_slice,
-                     int nghost=0);
+                     int nghost=0, const bool do_beam_jz_minus_rho=false);
 
 
 #endif //  BEAMDEPOSITCURRENT_H_

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -60,7 +60,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
 
     // Offset for converting positions to indexes
     amrex::Real const x_pos_offset = GetPosOffset(0, gm[lev], jxb_fab.box());
-    const amrex::Real y_pos_offset = GetPosOffset(1, gm[lev], jxb_fab.box());
+    amrex::Real const y_pos_offset = GetPosOffset(1, gm[lev], jxb_fab.box());
     amrex::Real const z_pos_offset = GetPosOffset(2, gm[lev], jxb_fab.box());
 
     amrex::Real lev_weight_fac = 1.;

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -19,8 +19,8 @@
 void
 DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
                      amrex::Vector<amrex::Geometry> const& gm, int const lev ,const int islice,
-                     int const offset, const BeamBins& bins,
-                     const bool do_beam_jx_jy_deposition, const int which_slice, int nghost)
+                     int const offset, const BeamBins& bins, const bool do_beam_jx_jy_deposition,
+                     const int which_slice, int nghost, const bool do_beam_jz_minus_rho)
 {
     HIPACE_PROFILE("DepositCurrentSlice_BeamParticleContainer()");
     // Extract properties associated with physical size of the box
@@ -37,6 +37,10 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Hipace::m_depos_order_z == 0,
         "Only order 0 deposition is allowed for beam per-slice deposition");
 
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        !(which_slice != WhichSlice::This && do_beam_jz_minus_rho),
+        "depositing jz and rho beam in a slice that is not This");
+
     // Extract the fields currents
     amrex::MultiFab& S = fields.getSlices(lev, which_slice);
     // we deposit to the beam currents, because the explicit solver
@@ -44,6 +48,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     amrex::MultiFab jx_beam(S, amrex::make_alias, Comps[which_slice]["jx_beam"], 1);
     amrex::MultiFab jy_beam(S, amrex::make_alias, Comps[which_slice]["jy_beam"], 1);
     amrex::MultiFab jz_beam(S, amrex::make_alias, Comps[which_slice]["jz_beam"], 1);
+    amrex::MultiFab rho_beam(S, amrex::make_alias, Comps[which_slice]["rho_beam"], 1);
 
     // Extract FabArray for this box (because there is currently no transverse
     // parallelization, the index we want in the slice multifab is always 0.
@@ -51,6 +56,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     amrex::FArrayBox& jxb_fab = jx_beam[0];
     amrex::FArrayBox& jyb_fab = jy_beam[0];
     amrex::FArrayBox& jzb_fab = jz_beam[0];
+    amrex::FArrayBox& rhob_fab = rho_beam[0];
 
     // Offset for converting positions to indexes
     amrex::Real const x_pos_offset = GetPosOffset(0, gm[lev], jxb_fab.box());
@@ -70,21 +76,21 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
 
     // Call deposition function in each box
     if        (Hipace::m_depos_order_xy == 0){
-        doDepositionShapeN<0, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, x_pos_offset, y_pos_offset,
+        doDepositionShapeN<0, 0>( beam, jxb_fab, jyb_fab, jzb_fab, rhob_fab, dx, x_pos_offset, y_pos_offset,
                                   z_pos_offset, q, islice, bins, offset, do_beam_jx_jy_deposition,
-                                  which_slice, nghost);
+                                  which_slice, nghost, do_beam_jz_minus_rho);
     } else if (Hipace::m_depos_order_xy == 1){
-        doDepositionShapeN<1, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, x_pos_offset, y_pos_offset,
+        doDepositionShapeN<1, 0>( beam, jxb_fab, jyb_fab, jzb_fab, rhob_fab, dx, x_pos_offset, y_pos_offset,
                                   z_pos_offset, q, islice, bins, offset, do_beam_jx_jy_deposition,
-                                  which_slice, nghost);
+                                  which_slice, nghost, do_beam_jz_minus_rho);
     } else if (Hipace::m_depos_order_xy == 2){
-        doDepositionShapeN<2, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, x_pos_offset, y_pos_offset,
+        doDepositionShapeN<2, 0>( beam, jxb_fab, jyb_fab, jzb_fab, rhob_fab, dx, x_pos_offset, y_pos_offset,
                                   z_pos_offset, q, islice, bins, offset, do_beam_jx_jy_deposition,
-                                  which_slice, nghost);
+                                  which_slice, nghost, do_beam_jz_minus_rho);
     } else if (Hipace::m_depos_order_xy == 3){
-        doDepositionShapeN<3, 0>( beam, jxb_fab, jyb_fab, jzb_fab, dx, x_pos_offset, y_pos_offset,
+        doDepositionShapeN<3, 0>( beam, jxb_fab, jyb_fab, jzb_fab, rhob_fab, dx, x_pos_offset, y_pos_offset,
                                   z_pos_offset, q, islice, bins, offset, do_beam_jx_jy_deposition,
-                                  which_slice, nghost);
+                                  which_slice, nghost, do_beam_jz_minus_rho);
     } else {
         amrex::Abort("unknown deposition order");
     }

--- a/src/particles/deposition/BeamDepositCurrentInner.H
+++ b/src/particles/deposition/BeamDepositCurrentInner.H
@@ -36,6 +36,7 @@
  * \param[in,out] jx_fab array of current density jx, on the box corresponding to ptile
  * \param[in,out] jy_fab array of current density jy, on the box corresponding to ptile
  * \param[in,out] jz_fab array of current density jz, on the box corresponding to ptile
+ * \param[in,out] rho_fab array of charge density, on the box corresponding to ptile
  * \param[in] dx cell size in each dimension
  * \param[in] x_pos_offset offset for converting positions to indexes
  * \param[in] y_pos_offset offset for converting positions to indexes
@@ -49,6 +50,8 @@
  * \param[in] nghost number of ghost particles, all at the end of the particle array.
  *            Use for depositing transverse currents in the Next slice when processing
  *            islice = 0.
+ * \param[in] do_beam_jz_minus_rho whether jz_beam-rho_beam is computed and used in the simulation.
+ *            Otherwise, it is assumed to be 0. If true, rho_beam needs to be deposited.
  */
 template <int depos_order_xy, int depos_order_z>
 void doDepositionShapeN (const BeamParticleContainer& ptile,

--- a/src/particles/deposition/BeamDepositCurrentInner.H
+++ b/src/particles/deposition/BeamDepositCurrentInner.H
@@ -55,6 +55,7 @@ void doDepositionShapeN (const BeamParticleContainer& ptile,
                          amrex::FArrayBox& jx_fab,
                          amrex::FArrayBox& jy_fab,
                          amrex::FArrayBox& jz_fab,
+                         amrex::FArrayBox& rho_fab,
                          amrex::Real const * const AMREX_RESTRICT dx,
                          amrex::Real x_pos_offset,
                          amrex::Real y_pos_offset,
@@ -65,7 +66,8 @@ void doDepositionShapeN (const BeamParticleContainer& ptile,
                          int box_offset,
                          const bool do_beam_jx_jy_deposition,
                          const int which_slice,
-                         int nghost=0)
+                         int nghost=0,
+                         const bool do_beam_jz_minus_rho=false)
 {
     using namespace amrex::literals;
 
@@ -98,14 +100,16 @@ void doDepositionShapeN (const BeamParticleContainer& ptile,
     amrex::Array4<amrex::Real> const& jx_arr = jx_fab.array();
     amrex::Array4<amrex::Real> const& jy_arr = jy_fab.array();
     amrex::Array4<amrex::Real> const& jz_arr = jz_fab.array();
+    amrex::Array4<amrex::Real> const& rho_arr = rho_fab.array();
 
     constexpr int CELL = amrex::IndexType::CELL;
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         jx_fab.box().type() == amrex::IntVect(CELL, CELL, CELL) &&
         jy_fab.box().type() == amrex::IntVect(CELL, CELL, CELL) &&
-        jz_fab.box().type() == amrex::IntVect(CELL, CELL, CELL),
-        "jx, jy, and jz must be nodal in all directions."
+        jz_fab.box().type() == amrex::IntVect(CELL, CELL, CELL) &&
+        rho_fab.box().type() == amrex::IntVect(CELL, CELL, CELL),
+        "jx, jy, jz and rho must be nodal in all directions."
         );
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -180,7 +184,7 @@ void doDepositionShapeN (const BeamParticleContainer& ptile,
             l_cell = 0;
             amrex::ignore_unused(l_cell);
 
-            // Deposit current into jx_arr, jy_arr, jz_arr
+            // Deposit current into jx_arr, jy_arr, jz_arr, rho_arr
             for (int iz=0; iz<=depos_order_z; iz++){
                 for (int iy=0; iy<=depos_order_xy; iy++){
                     for (int ix=0; ix<=depos_order_xy; ix++){
@@ -196,6 +200,11 @@ void doDepositionShapeN (const BeamParticleContainer& ptile,
                             amrex::Gpu::Atomic::Add(
                                 &jz_arr(j_cell+ix, k_cell+iy, z_slice),
                                 sx_cell[ix]*sy_cell[iy]*sz_cell[iz]*wqz);
+                            if (do_beam_jz_minus_rho) {
+                                amrex::Gpu::Atomic::Add(
+                                    &rho_arr(j_cell+ix, k_cell+iy, z_slice),
+                                    sx_cell[ix]*sy_cell[iy]*sz_cell[iz]*wq);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
So far, we assume that jz_beam = c*rho_beam, which is not too bad if the beam is ultra-relativistic, but is an unnecessary approximation. This PR proposes to compute `jz_beam - c*rho_beam` and use it when calculating ExmBy. It should be more accurate when close to depletion.
 
running `examples/blowout_wake/inputs_normalized` with and without this option gives the result below. For a beam with only uz=2000 (ux and uy = 0), the initial difference is on the order of 1.e-7, but after 10 iterations (dt=5) the difference is about 1.e-5.

![Screenshot 2022-04-20 at 15 26 07](https://user-images.githubusercontent.com/26292713/164240816-c7901c08-d708-4780-b293-004f3d2180df.png)

Note: same is observed with explicit solver.