### PR TITLE
fix sign error in explicit solver

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -759,8 +759,8 @@ Hipace::ExplicitSolveBxBy (const int lev)
                 const amrex::Real cdy_jxy = - dy_jxy / n0 / pc.q_e / pc.c / pc.c;
                 const amrex::Real cdy_jz  = - dy_jz  / n0 / pc.q_e / pc.c ;
                 const amrex::Real cdy_psi =   dy_psi * pc.q_e / (pc.m_e * pc.c * pc.c);
-                const amrex::Real cdz_jxb = - dz_jxb / n0 / pc.q_e / pc.c;
-                const amrex::Real cdz_jyb = - dz_jyb / n0 / pc.q_e / pc.c;
+                const amrex::Real cdz_jxb = + dz_jxb / n0 / pc.q_e / pc.c;
+                const amrex::Real cdz_jyb = + dz_jyb / n0 / pc.q_e / pc.c;
                 const amrex::Real cez     =   ez(i,j,k) / E0;
                 const amrex::Real cbz     =   bz(i,j,k) * pc.c / E0;
                 const amrex::Real casq    =   use_laser ? a(i,j,k)*a(i,j,k) : 0._rt;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -759,8 +759,8 @@ Hipace::ExplicitSolveBxBy (const int lev)
                 const amrex::Real cdy_jxy = - dy_jxy / n0 / pc.q_e / pc.c / pc.c;
                 const amrex::Real cdy_jz  = - dy_jz  / n0 / pc.q_e / pc.c ;
                 const amrex::Real cdy_psi =   dy_psi * pc.q_e / (pc.m_e * pc.c * pc.c);
-                const amrex::Real cdz_jxb = + dz_jxb / n0 / pc.q_e / pc.c;
-                const amrex::Real cdz_jyb = + dz_jyb / n0 / pc.q_e / pc.c;
+                const amrex::Real cdz_jxb =   dz_jxb / n0 / pc.q_e / pc.c;
+                const amrex::Real cdz_jyb =   dz_jyb / n0 / pc.q_e / pc.c;
                 const amrex::Real cez     =   ez(i,j,k) / E0;
                 const amrex::Real cbz     =   bz(i,j,k) * pc.c / E0;
                 const amrex::Real casq    =   use_laser ? a(i,j,k)*a(i,j,k) : 0._rt;


### PR DESCRIPTION
The explicit solver had the signs swapped of the `d/dz jx_beam` and `d/dz jy_beam` Therms.

Beam:
```
beams.names= beam
beam.profile = gaussian
beam.injection_type = fixed_weight
beam.do_symmetrize = 0
beam.num_particles = 10000000
beam.density = 5
beam.u_mean = 100 0 500
beam.u_std = 0. 0. 0.
beam.position_mean = 0. 0. 2
beam.position_std = 0.4 0.4 0.4
```

Dev Explicit
![image](https://user-images.githubusercontent.com/64009254/164704881-c8a4e4c1-3179-4002-b81a-44071977932c.png)

Dev PC
![image](https://user-images.githubusercontent.com/64009254/164704894-5cbf35fd-1c69-49f6-bc64-2ea8e10d8e27.png)

PR Explicit
![image](https://user-images.githubusercontent.com/64009254/164704906-938ded7c-6d6b-4cfc-b852-b5bf5e560d7c.png)

PR PC
![image](https://user-images.githubusercontent.com/64009254/164704930-7272ffdf-c590-4f01-bda9-cc8d9ea92e64.png)

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
