### PR TITLE
add do_device_synchronize to sphinx documentation

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -84,10 +84,10 @@ General parameters
       * ``hipace.do_device_synchronize = 0``, synchronization happens only when necessary.
 
       * ``hipace.do_device_synchronize = 1``, synchronizes most functions (all that are profiled
-        via `HIPACE_PROFILE`)
+        via ``HIPACE_PROFILE``)
 
       * ``hipace.do_device_synchronize = 2`` additionally synchronizes low-level functions (all that
-        are profiled via `HIPACE_DETAIL_PROFILE`)
+        are profiled via ``HIPACE_DETAIL_PROFILE``)
 
 * ``hipace.depos_order_xy`` (`int`) optional (default `2`)
     Transverse particle shape order. Currently, `0,1,2,3` are implemented.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -78,6 +78,17 @@ General parameters
         if ionization occurred. It also adds additional information if beams
         are read in from file.
 
+* ``hipace.do_device_synchronize`` (`int`) optional (default `0`)
+    Level of synchronization on GPU.
+
+      * ``hipace.do_device_synchronize = 0``, synchronization happens only when necessary.
+
+      * ``hipace.do_device_synchronize = 1``, synchronizes most functions (all that are profiled
+        via `HIPACE_PROFILE`)
+
+      * ``hipace.do_device_synchronize = 2`` additionally synchronizes low-level functions (all that
+        are profiled via `HIPACE_DETAIL_PROFILE`)
+
 * ``hipace.depos_order_xy`` (`int`) optional (default `2`)
     Transverse particle shape order. Currently, `0,1,2,3` are implemented.
 


### PR DESCRIPTION
This small PR adds the `do_device_synchronize` input parameter to the sphinx documentation.


![docu](https://user-images.githubusercontent.com/65728274/165076239-d1d7dd46-2730-470a-b871-9cf5214c8269.png)

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
