### PR TITLE
Split up explicit and predictor-corrector solver

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -162,6 +162,24 @@ public:
     void SolveOneSlice (int islice_coarse, const int ibox,
                         const amrex::Vector<amrex::Vector<BeamBins>>& bins);
 
+    /** \brief Full evolve on 1 slice with explicit solver
+     *
+     * \param[in] islice_coarse slice number
+     * \param[in] ibox index of the current box to be calculated
+     * \param[in] bins an amrex::DenseBins object that orders particles by slice
+     */
+    void ExplicitSolveOneSlice (int islice_coarse, const int ibox,
+                                const amrex::Vector<amrex::Vector<BeamBins>>& bins);
+
+    /** \brief Full evolve on 1 slice with predictor-corrector solver
+     *
+     * \param[in] islice_coarse slice number
+     * \param[in] ibox index of the current box to be calculated
+     * \param[in] bins an amrex::DenseBins object that orders particles by slice
+     */
+    void PredictorCorrectorSolveOneSlice (int islice_coarse, const int ibox,
+                                          const amrex::Vector<amrex::Vector<BeamBins>>& bins);
+
     /** \brief Reset plasma and field slice quantities to initial value.
      *
      * Typically done at the beginning of each iteration.

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -162,23 +162,31 @@ public:
     void SolveOneSlice (int islice_coarse, const int ibox,
                         const amrex::Vector<amrex::Vector<BeamBins>>& bins);
 
-    /** \brief Full evolve on 1 slice with explicit solver
+    /** \brief Full evolve on 1 subslice with explicit solver
      *
-     * \param[in] islice_coarse slice number
+     * \param[in] lev MR level
      * \param[in] ibox index of the current box to be calculated
-     * \param[in] bins an amrex::DenseBins object that orders particles by slice
+     * \param[in] bx current transverse box
+     * \param[in] islice longitudinal slice
+     * \param[in] islice_local local index of the slice
+     * \param[in] beam_bin an amrex::DenseBins object that orders particles by slice
      */
-    void ExplicitSolveOneSlice (int islice_coarse, const int ibox,
-                                const amrex::Vector<amrex::Vector<BeamBins>>& bins);
+    void ExplicitSolveOneSubSlice (const int lev, const int ibox, const amrex::Box& bx,
+                                   const int islice, const int islice_local,
+                                   const amrex::Vector<BeamBins>& beam_bin);
 
-    /** \brief Full evolve on 1 slice with predictor-corrector solver
+    /** \brief Full evolve on 1 subslice with predictor-corrector solver
      *
-     * \param[in] islice_coarse slice number
+     * \param[in] lev MR level
      * \param[in] ibox index of the current box to be calculated
-     * \param[in] bins an amrex::DenseBins object that orders particles by slice
+     * \param[in] bx current transverse box
+     * \param[in] islice longitudinal slice
+     * \param[in] islice_local local index of the slice
+     * \param[in] beam_bin an amrex::DenseBins object that orders particles by slice
      */
-    void PredictorCorrectorSolveOneSlice (int islice_coarse, const int ibox,
-                                          const amrex::Vector<amrex::Vector<BeamBins>>& bins);
+    void PredictorCorrectorSolveOneSubSlice (const int lev, const int ibox, const amrex::Box& bx,
+                                             const int islice, const int islice_local,
+                                             const amrex::Vector<BeamBins>& beam_bin);
 
     /** \brief Reset plasma and field slice quantities to initial value.
      *


### PR DESCRIPTION
Split up SolveOneSlice function and field allocation to be explicit and predictor-corrector solver specific. This adds some duplicate code but might be more readable.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
