### PR TITLE
CI: Fix HIP GPG Key

### DIFF
--- a/.github/workflows/setup/hip.sh
+++ b/.github/workflows/setup/hip.sh
@@ -16,8 +16,8 @@
 set -eu -o pipefail
 
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
-wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key \
-  | sudo apt-key add -
+curl -O https://repo.radeon.com/rocm/rocm.gpg.key
+sudo apt-key add rocm.gpg.key
 echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 


### PR DESCRIPTION
Split downloading and adding.
```
Warning: apt-key output should not be parsed (stdout is not a terminal)
gpg: no valid OpenPGP data found.
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
