### PR TITLE
In-situ diagnostics

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -330,6 +330,11 @@ parameters for each beam are specified via ``<beam name>.<beam property> = ...``
     The names of the particle beams, separated by a space.
     To run without beams, choose the name ``no_beam``.
 
+* ``beams.insitu_freq`` (`int`) optional (default ``-1``)
+    Frequency of in-situ diagnostics, computing the main per-slice beam quantities for the main beam parameters (width, energy spread, emittance, etc.).
+    The data is written to a text file, 1 file per time step.
+    When <0, the in-situ diagnostics are not activated.
+
 General beam parameters
 ^^^^^^^^^^^^^^^^^^^^^^^
 The general beam parameters are applicable to all particle beam types. More specialized beam parameters,
@@ -380,6 +385,9 @@ which are valid only for certain beam types, are introduced further below under
 * ``<beam name>.finest_level`` (`int`) optional (default `0`)
     Finest level of mesh refinement that the beam interacts with. The beam deposits its current only
     up to its finest level. The beam will be pushed by the fields of the finest level.
+
+* ``<beam name>.insitu_sep`` (`string`) optional (default ``" "``)
+    Separator used in the text file of in-situ diagnostics.
 
 Option: ``fixed_weight``
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -332,7 +332,12 @@ parameters for each beam are specified via ``<beam name>.<beam property> = ...``
 
 * ``beams.insitu_freq`` (`int`) optional (default ``-1``)
     Frequency of in-situ diagnostics, computing the main per-slice beam quantities for the main beam parameters (width, energy spread, emittance, etc.).
-    The data is written to a text file, 1 file per time step.
+    The data is written to a text file:
+      * 1 file per time step.
+      * 1 line per file.
+      * [time step], [physical time], [all quantities for slice 0], [all quantities for slice 1], ..., [all quantities for slice nz-1]
+      * all quantities are: [number of macro-particles], sum(w), <x>, <x^2>, <y>, <y^2>, <ux>, <ux^2>, <uy>, <uy^2>, <x*ux>, <y*uy>, <ga>, <ga^2>, np
+        where "<>" stands for averaging over all particles in the current slice, "w" stands for weight, "ux" is the momentum in the x direction, "ga" is the Lorentz factor.
     When <0, the in-situ diagnostics are not activated.
 
 General beam parameters

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -159,6 +159,7 @@ public:
      *
      * \param[in] islice_coarse slice number
      * \param[in] ibox index of the current box to be calculated
+     * \param[in] step current time step
      * \param[in] bins an amrex::DenseBins object that orders particles by slice
      */
     void SolveOneSlice (int islice_coarse, const int ibox, int step,

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -161,7 +161,7 @@ public:
      * \param[in] ibox index of the current box to be calculated
      * \param[in] bins an amrex::DenseBins object that orders particles by slice
      */
-    void SolveOneSlice (int islice_coarse, const int ibox,
+    void SolveOneSlice (int islice_coarse, const int ibox, int step,
                         const amrex::Vector<amrex::Vector<BeamBins>>& bins);
 
     /** \brief Full evolve on 1 subslice with explicit solver

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -488,7 +488,7 @@ Hipace::Evolve ()
             m_predcorr_avg_B_error /= (bx.bigEnd(Direction::z) + 1 - bx.smallEnd(Direction::z));
 
             WriteDiagnostics(step, it, OpenPMDWriterCallType::fields);
-
+            m_multi_beam.InSituWriteToFile(step);
             Notify(step, it, bins[lev]);
         }
 
@@ -513,6 +513,7 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox,
 {
     HIPACE_PROFILE("Hipace::SolveOneSlice()");
 
+    m_multi_beam.InSituComputeDiags(islice_coarse, bins[0]);
     // setup laser
     m_laser.PrepareLaserSlice(Geom(0), islice_coarse);
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -516,7 +516,8 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox, int step,
 
     if ( m_multi_beam.doInSitu(step) ) {
         m_multi_beam.InSituComputeDiags(islice_coarse, bins[0],
-                                        boxArray(0)[ibox].smallEnd(Direction::z));
+                                        boxArray(0)[ibox].smallEnd(Direction::z),
+                                        m_box_sorters, ibox);
     }
     // setup laser
     m_laser.PrepareLaserSlice(Geom(0), islice_coarse);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -491,7 +491,7 @@ Hipace::Evolve ()
             Notify(step, it, bins[lev]);
         }
 
-        if ( m_multi_beam.doInSitu(step) ) m_multi_beam.InSituWriteToFile(step);
+        if ( m_multi_beam.doInSitu(step) ) m_multi_beam.InSituWriteToFile(step, m_physical_time);
 
         // printing and resetting predictor corrector loop diagnostics
         if (m_verbose>=2) amrex::AllPrint()<<"Rank "<<rank<<": avg. number of iterations "

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -154,8 +154,6 @@ private:
     std::vector<amrex::Real> m_insitu_rdata;
     /** Per-slice integer beam properties */
     std::vector<int> m_insitu_idata;
-    amrex::Gpu::DeviceVector<amrex::Real> m_insitu_device_rdata;
-    amrex::Gpu::DeviceVector<int> m_insitu_device_idata;
     /** Separator when writing to file */
     std::string m_insitu_sep = " ";
 };

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -99,7 +99,7 @@ public:
                                   const bool species_specified);
 #endif
 
-    void InSituComputeDiags (int islice, const BeamBins& bins, int islice0);
+    void InSituComputeDiags (int islice, const BeamBins& bins, int islice0, const int box_offset);
     void InSituWriteToFile (int step, amrex::Real time);
     std::string get_name () const {return m_name;}
     amrex::Real m_charge; /**< charge of each particle of this species */
@@ -148,8 +148,12 @@ private:
     int m_insitu_inp {1};
     /** Number of real beam properties for in-situ reduced diagnostics.
      * 0: Average energy
-     * 1: Average position */
-    int m_insitu_rnp {2};
+     * 1: Average position in x *
+     * 2: Average position in y *
+     * 3: Emittance in x *
+     * 4: Emittance in y *
+     * 5: rms energy spread */
+    int m_insitu_rnp {6};
     /** Per-slice real beam properties */
     std::vector<amrex::Real> m_insitu_rdata;
     /** Per-slice integer beam properties */

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -99,7 +99,17 @@ public:
                                   const bool species_specified);
 #endif
 
+    /** Compute reduced beam diagnostics of current slice, store in member variable
+     * \param[in] islice current slice, on which diags are computed.
+     * \param[in] bins Binning object to get particles on current slice
+     * \param[in] islice0 index of the leftmost slice of this box, to select the correct bin
+     * \param[in] box_offset Index of first particle of the current box.
+     */
     void InSituComputeDiags (int islice, const BeamBins& bins, int islice0, const int box_offset);
+    /** Dump in-situ reduced diagnostics to file.
+     * \param[in] step current time step
+     * \param[in] time physical time
+     */
     void InSituWriteToFile (int step, amrex::Real time);
     std::string get_name () const {return m_name;}
     amrex::Real m_charge; /**< charge of each particle of this species */
@@ -142,23 +152,24 @@ private:
     /** Coordinates used in input file, are converted to Hipace Coordinates x y z respectively */
     amrex::Array<std::string, AMREX_SPACEDIM> m_file_coordinates_xyz;
     int m_num_iteration {0}; /**< the iteration of the openPMD beam */
-    std::string m_species_name ; /**< the name of the particle species in the beam file */
-    /** Number of real beam properties for in-situ reduced diagnostics.
+    std::string m_species_name; /**< the name of the particle species in the beam file */
+    /** Number of real beam properties for in-situ per-slice reduced diagnostics. */
+    int m_insitu_rnp {13};
+    /** Number of integer beam properties for in-situ reduced diagnostics. */
+    int m_insitu_inp {1};
+    /** Per-slice real beam properties:
      *      0,   1,     2,   3,     4,    5,      6,    7,      8,      9,     10,   11,     12
-     * sum(w), <x>, <x^2>, <y>, <y^2>, <ux>, <ux^2>, <uy>, <uy^2>, <x*ux>, <y*uy>, <ga>, <ga^2>
-     * Per-slice emittance: sqrt( (<x^2>-<x>^2) * (<ux^2>-<uxm>^2) - (<x*ux>-<x><ux>)^2 ).
+     * sum(w), [x], [x^2], [y], [y^2], [ux], [ux^2], [uy], [uy^2], [x*ux], [y*uy], [ga], [ga^2]
+     * where [] means average over all particles within slice.
+     * Per-slice emittance: sqrt( ([x^2]-[x]^2) * ([ux^2]-[uxm]^2) - ([x*ux]-[x][ux])^2 ).
      * Projected emittance: Same as above AFTER averaging all these quantities over slices.
-     * Energy spread: sqrt(<ga^2>-<ga>^2), and same as above.
+     * Energy spread: sqrt([ga^2]-[ga]^2), and same as above.
      * sum(w) should never be 0. When it is, it is replaced by 1 to avoid nans and these
      * diags are incorrect.
      */
-    int m_insitu_rnp {13};
-    /** Number of integer beam properties for in-situ reduced diagnostics.
-     * 0: number of particles in this slice */
-    int m_insitu_inp {1};
-    /** Per-slice real beam properties */
     std::vector<amrex::Real> m_insitu_rdata;
-    /** Per-slice integer beam properties */
+    /** Per-slice integer beam properties:
+     * 0: number of particles in this slice */
     std::vector<int> m_insitu_idata;
     /** Separator when writing to file */
     std::string m_insitu_sep = " ";

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -25,6 +25,8 @@ struct BeamIdx
     };
 };
 
+using BeamBins = amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>::ParticleType>;
+
 /** \brief Container for particles of 1 beam species. */
 class BeamParticleContainer
     : public amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>
@@ -97,6 +99,8 @@ public:
                                   const bool species_specified);
 #endif
 
+    void InSituComputeDiags (int islice, const BeamBins& bins);
+    void InSituWriteToFile (int step);
     std::string get_name () const {return m_name;}
     amrex::Real m_charge; /**< charge of each particle of this species */
     amrex::Real m_mass; /**< mass of each particle of this species */
@@ -139,6 +143,20 @@ private:
     amrex::Array<std::string, AMREX_SPACEDIM> m_file_coordinates_xyz;
     int m_num_iteration {0}; /**< the iteration of the openPMD beam */
     std::string m_species_name ; /**< the name of the particle species in the beam file */
+    int m_insitu_freq {-1};
+    /** Number of integer beam properties for in-situ reduced diagnostics.
+     * 0: number of particles in this slice */
+    int m_insitu_inp {1};
+    /** Number of real beam properties for in-situ reduced diagnostics.
+     * 0: Average energy
+     * 1: Average position */
+    int m_insitu_rnp {2};
+    /** Per-slice real beam properties */
+    std::vector<amrex::Real> m_insitu_rdata;
+    /** Per-slice integer beam properties */
+    std::vector<int> m_insitu_idata;
+    /** Separator when writing to file */
+    std::string m_insitu_sep = " ";
 };
 
 #endif

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -44,9 +44,11 @@ public:
     void ReadParameters ();
 
     /** \brief Allocate beam particle data and initialize particles with requested beam profile
+     * \param[in] geom Geometry object for the whole domain
+     * \param[in] do_insitu Whether in-situ diagnostics are activated for this species
      * \return physical time at which the simulation will start
      */
-    amrex::Real InitData (const amrex::Geometry& geom);
+    amrex::Real InitData (const amrex::Geometry& geom, bool do_insitu);
 
     /** Initialize a beam with a fix number of particles per cell */
     void InitBeamFixedPPC (

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -100,7 +100,7 @@ public:
 #endif
 
     void InSituComputeDiags (int islice, const BeamBins& bins, int islice0);
-    void InSituWriteToFile (int step);
+    void InSituWriteToFile (int step, amrex::Real time);
     std::string get_name () const {return m_name;}
     amrex::Real m_charge; /**< charge of each particle of this species */
     amrex::Real m_mass; /**< mass of each particle of this species */
@@ -154,6 +154,8 @@ private:
     std::vector<amrex::Real> m_insitu_rdata;
     /** Per-slice integer beam properties */
     std::vector<int> m_insitu_idata;
+    amrex::Gpu::DeviceVector<amrex::Real> m_insitu_device_rdata;
+    amrex::Gpu::DeviceVector<int> m_insitu_device_idata;
     /** Separator when writing to file */
     std::string m_insitu_sep = " ";
 };

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -99,7 +99,7 @@ public:
                                   const bool species_specified);
 #endif
 
-    void InSituComputeDiags (int islice, const BeamBins& bins);
+    void InSituComputeDiags (int islice, const BeamBins& bins, int islice0);
     void InSituWriteToFile (int step);
     std::string get_name () const {return m_name;}
     amrex::Real m_charge; /**< charge of each particle of this species */
@@ -143,7 +143,6 @@ private:
     amrex::Array<std::string, AMREX_SPACEDIM> m_file_coordinates_xyz;
     int m_num_iteration {0}; /**< the iteration of the openPMD beam */
     std::string m_species_name ; /**< the name of the particle species in the beam file */
-    int m_insitu_freq {-1};
     /** Number of integer beam properties for in-situ reduced diagnostics.
      * 0: number of particles in this slice */
     int m_insitu_inp {1};

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -143,17 +143,19 @@ private:
     amrex::Array<std::string, AMREX_SPACEDIM> m_file_coordinates_xyz;
     int m_num_iteration {0}; /**< the iteration of the openPMD beam */
     std::string m_species_name ; /**< the name of the particle species in the beam file */
+    /** Number of real beam properties for in-situ reduced diagnostics.
+     *      0,   1,     2,   3,     4,    5,      6,    7,      8,      9,     10,   11,     12
+     * sum(w), <x>, <x^2>, <y>, <y^2>, <ux>, <ux^2>, <uy>, <uy^2>, <x*ux>, <y*uy>, <ga>, <ga^2>
+     * Per-slice emittance: sqrt( (<x^2>-<x>^2) * (<ux^2>-<uxm>^2) - (<x*ux>-<x><ux>)^2 ).
+     * Projected emittance: Same as above AFTER averaging all these quantities over slices.
+     * Energy spread: sqrt(<ga^2>-<ga>^2), and same as above.
+     * sum(w) should never be 0. When it is, it is replaced by 1 to avoid nans and these
+     * diags are incorrect.
+     */
+    int m_insitu_rnp {13};
     /** Number of integer beam properties for in-situ reduced diagnostics.
      * 0: number of particles in this slice */
     int m_insitu_inp {1};
-    /** Number of real beam properties for in-situ reduced diagnostics.
-     * 0: Average energy
-     * 1: Average position in x *
-     * 2: Average position in y *
-     * 3: Emittance in x *
-     * 4: Emittance in y *
-     * 5: rms energy spread */
-    int m_insitu_rnp {6};
     /** Per-slice real beam properties */
     std::vector<amrex::Real> m_insitu_rdata;
     /** Per-slice integer beam properties */

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -246,7 +246,10 @@ BeamParticleContainer::InSituComputeDiags (int islice, const BeamBins& bins, int
         [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
         {
             const int ip = indices[cell_start+i];
-            if (pos_structs[ip].id() < 0) return;
+            if (pos_structs[ip].id() < 0) {
+                return{0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt,
+                    0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0};
+            }
             const amrex::Real gamma = std::sqrt(1.0_rt + uxp[ip]*uxp[ip]*clightsq
                                                        + uyp[ip]*uyp[ip]*clightsq
                                                        + uzp[ip]*uzp[ip]*clightsq);
@@ -323,6 +326,6 @@ BeamParticleContainer::InSituWriteToFile (int step, amrex::Real time)
     // close file
     ofs.close();
 
-    for (int i=0; i<m_insitu_rdata.size(); i++) m_insitu_rdata[i] = 0._rt;
-    for (int i=0; i<m_insitu_idata.size(); i++) m_insitu_idata[i] = 0._rt;
+    for (int i=0; i<(int) m_insitu_rdata.size(); i++) m_insitu_rdata[i] = 0._rt;
+    for (int i=0; i<(int) m_insitu_idata.size(); i++) m_insitu_idata[i] = 0._rt;
 }

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -217,22 +217,20 @@ BeamParticleContainer::InSituComputeDiags (int islice, const BeamBins& bins, int
     BeamBins::index_type const cell_stop = offsets[islice-islice0+1];
     int const num_particles = cell_stop-cell_start;
 
-    amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
-    amrex::ReduceData<amrex::Real, amrex::Real> reduce_data(reduce_op);
+    amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
+    amrex::ReduceData<int, amrex::Real, amrex::Real> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
 
     reduce_op.eval(
         num_particles, reduce_data,
         [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
         {
-            return {1._rt,2._rt};
+            return {1,1._rt,2._rt};
         });
-    // amrex::Gpu::Device::synchronize();
     ReduceTuple a = reduce_data.value();
-    m_insitu_idata[m_insitu_inp*islice  ] = num_particles;
-    m_insitu_rdata[m_insitu_rnp*islice  ] = amrex::get<0>(a);
-    m_insitu_rdata[m_insitu_rnp*islice+1] = amrex::get<1>(a);
-
+    m_insitu_idata[m_insitu_inp*islice  ] = amrex::get<0>(a);
+    m_insitu_rdata[m_insitu_rnp*islice  ] = amrex::get<1>(a);
+    m_insitu_rdata[m_insitu_rnp*islice+1] = amrex::get<2>(a);
 }
 
 void

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -65,7 +65,7 @@ BeamParticleContainer::ReadParameters ()
 }
 
 amrex::Real
-BeamParticleContainer::InitData (const amrex::Geometry& geom)
+BeamParticleContainer::InitData (const amrex::Geometry& geom, bool do_insitu)
 {
     using namespace amrex::literals;
     PhysConst phys_const = get_phys_const();
@@ -163,7 +163,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 
     }
 
-    {
+    if (do_insitu) {
         // Allocate memory for in-situ diagnostics
         int nslices = geom.Domain().length(2);
         m_insitu_rdata.resize(nslices*m_insitu_rnp, 0.);
@@ -211,6 +211,9 @@ BeamParticleContainer::InSituComputeDiags (int islice, const BeamBins& bins, int
     HIPACE_PROFILE("BeamParticleContainer::InSituComputeDiags");
 
     using namespace amrex::literals;
+
+    AMREX_ALWAYS_ASSERT(m_insitu_rdata.size()>0 && m_insitu_idata.size()>0);
+
     PhysConst const phys_const = get_phys_const();
     const amrex::Real clightsq = 1.0_rt/(phys_const.c*phys_const.c);
 

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -84,7 +84,7 @@ public:
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
 
     void InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0);
-    void InSituWriteToFile (int step);
+    void InSituWriteToFile (int step, amrex::Real time);
     /** Loop over species and init them
      * \param[in] geom Simulation geometry
      * \return physical time at which the simulation will start

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -83,13 +83,6 @@ public:
         const amrex::Box bx, const amrex::Vector<BeamBins>& bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
 
-    /** FIXME
-     * \param[in] islice
-     * \param[in] bins Vector (over species) of particles sorted by slices
-     * \param[in] islice0
-     * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
-     * \param[in] ibox index of the current box
-     */
     /** Compute reduced beam diagnostics of current slice, store in member variable.
      * \param[in] islice current slice, on which diags are computed.
      * \param[in] bins Binning object to get particles on current slice.

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -83,6 +83,8 @@ public:
         const amrex::Box bx, const amrex::Vector<BeamBins>& bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
 
+    void InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins);
+    void InSituWriteToFile (int step);
     /** Loop over species and init them
      * \param[in] geom Simulation geometry
      * \return physical time at which the simulation will start

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -90,6 +90,14 @@ public:
      * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
      * \param[in] ibox index of the current box
      */
+    /** Compute reduced beam diagnostics of current slice, store in member variable.
+     * \param[in] islice current slice, on which diags are computed.
+     * \param[in] bins Binning object to get particles on current slice.
+     * \param[in] islice0 index of the leftmost slice of this box, to select the correct bin.
+     * \param[in] a_box_sorter_vec Vector (over beams and boxes) of BoxSorter objects, with info on
+     *            particle indices in current box.
+     * \param[in] ibox index of box currently being computed.
+     */
     void InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0,
                              const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
     void InSituWriteToFile (int step, amrex::Real time);

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -83,7 +83,15 @@ public:
         const amrex::Box bx, const amrex::Vector<BeamBins>& bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
 
-    void InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0);
+    /** FIXME
+     * \param[in] islice
+     * \param[in] bins Vector (over species) of particles sorted by slices
+     * \param[in] islice0
+     * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
+     * \param[in] ibox index of the current box
+     */
+    void InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0,
+                             const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
     void InSituWriteToFile (int step, amrex::Real time);
     /** Loop over species and init them
      * \param[in] geom Simulation geometry

--- a/src/particles/MultiBeam.H
+++ b/src/particles/MultiBeam.H
@@ -83,7 +83,7 @@ public:
         const amrex::Box bx, const amrex::Vector<BeamBins>& bins,
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox);
 
-    void InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins);
+    void InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0);
     void InSituWriteToFile (int step);
     /** Loop over species and init them
      * \param[in] geom Simulation geometry
@@ -163,6 +163,8 @@ public:
      * \param[in] beam_names names of all beams.
      */
     void MultiFromFileMacro (const amrex::Vector<std::string> beam_names);
+    bool doInSitu (int step);
+    int m_insitu_freq {-1};
 private:
 
     amrex::Vector<BeamParticleContainer> m_all_beams; /**< contains all beam containers */

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -31,7 +31,7 @@ MultiBeam::InitData (const amrex::Geometry& geom)
 {
     amrex::Real ptime {0.};
     for (auto& beam : m_all_beams) {
-        ptime = beam.InitData(geom);
+        ptime = beam.InitData(geom, m_insitu_freq>0);
     }
     return ptime;
 }

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -231,10 +231,12 @@ MultiBeam::MultiFromFileMacro (const amrex::Vector<std::string> beam_names)
 }
 
 void
-MultiBeam::InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0)
+MultiBeam::InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0,
+                               const amrex::Vector<BoxSorter>& a_box_sorter_vec, const int ibox)
 {
     for (int i = 0; i < m_nbeams; ++i) {
-        m_all_beams[i].InSituComputeDiags(islice, bins[i], islice0);
+        m_all_beams[i].InSituComputeDiags(islice, bins[i], islice0,
+                                          a_box_sorter_vec[i].boxOffsetsPtr()[ibox]);
     }
 }
 

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -239,10 +239,10 @@ MultiBeam::InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, 
 }
 
 void
-MultiBeam::InSituWriteToFile (int step)
+MultiBeam::InSituWriteToFile (int step, amrex::Real time)
 {
     for (auto& beam : m_all_beams) {
-        beam.InSituWriteToFile(step);
+        beam.InSituWriteToFile(step, time);
     }
 }
 

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -228,3 +228,19 @@ MultiBeam::MultiFromFileMacro (const amrex::Vector<std::string> beam_names)
         }
     }
 }
+
+void
+MultiBeam::InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins)
+{
+    for (int i = 0; i < m_nbeams; ++i) {
+        m_all_beams[i].InSituComputeDiags(islice, bins[i]);
+    }
+}
+
+void
+MultiBeam::InSituWriteToFile (int step)
+{
+    for (auto& beam : m_all_beams) {
+        beam.InSituWriteToFile(step);
+    }
+}

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -17,6 +17,7 @@ MultiBeam::MultiBeam (amrex::AmrCore* /*amr_core*/)
     amrex::ParmParse pp("beams");
     getWithParser(pp, "names", m_names);
     if (m_names[0] == "no_beam") return;
+    queryWithParser(pp, "insitu_freq", m_insitu_freq);
     m_nbeams = m_names.size();
     MultiFromFileMacro(m_names);
     for (int i = 0; i < m_nbeams; ++i) {
@@ -230,10 +231,10 @@ MultiBeam::MultiFromFileMacro (const amrex::Vector<std::string> beam_names)
 }
 
 void
-MultiBeam::InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins)
+MultiBeam::InSituComputeDiags (int islice, const amrex::Vector<BeamBins>& bins, int islice0)
 {
     for (int i = 0; i < m_nbeams; ++i) {
-        m_all_beams[i].InSituComputeDiags(islice, bins[i]);
+        m_all_beams[i].InSituComputeDiags(islice, bins[i], islice0);
     }
 }
 
@@ -243,4 +244,11 @@ MultiBeam::InSituWriteToFile (int step)
     for (auto& beam : m_all_beams) {
         beam.InSituWriteToFile(step);
     }
+}
+
+bool
+MultiBeam::doInSitu (int step)
+{
+    if (m_insitu_freq < 0) return false;
+    return step % m_insitu_freq == 0;
 }


### PR DESCRIPTION
This PR proposes in-situ diagnostics for the beam: for every slice, the main beam parameters are calculated within the loop over slices. The output is dumped to 1 text file per time step, at the end of the time step. The quantities calculated are
```
   0,   1,     2,   3,     4,    5,      6,    7,      8,      9,     10,   11,     12,  13
sum(w), <x>, <x^2>, <y>, <y^2>, <ux>, <ux^2>, <uy>, <uy^2>, <x*ux>, <y*uy>, <ga>, <ga^2>, np
```
These quantities should be sufficient to compute all the main beam parameters, in particle per-slice **and** projected emittance:
 - Per-slice emittance: `sqrt( ([x^2]-[x]^2) * ([ux^2]-[ux]^2) - ([x*ux]-[x][ux])^2 )`.
 - Projected emittance: Same as above AFTER averaging all these quantities over slices.
 - Energy spread: `sqrt([ga^2]-[ga]^2)`, and same as above.
