### PR TITLE
[mini] gpu synchronize after beam particle sort per slice

### DIFF
--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -65,6 +65,7 @@ MultiBeam::findParticlesInEachSlice (int nlev, int ibox, amrex::Box bx,
         }
         bins.emplace_back(bins_per_level);
     }
+    amrex::Gpu::Device::synchronize();
     return bins;
 }
 


### PR DESCRIPTION
As @AlexanderSinn and I found out, we need a synchronization after the sorting per slice. 
Otherwise, on slower GPUs (e.g., my laptop) the insitu diagnostics #753 have still unsorted bins with random numbers in the first slice, causing out of memory accesses. 

This PR fixes this issue.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
