### PR TITLE
[mini] make sure beam weights are >=0

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -369,11 +369,12 @@ which are valid only for certain beam types, are introduced further below under
     The mass of beam particles. Can also be set with ``<beam name>.element``. Must be `>0`.
 
 * ``<beam name>.charge`` (`float`) optional (default `-q_e`)
-    The charge of a beam particles. Can also be set with ``<beam name>.element``.
+    The charge of a beam particle. Can also be set with ``<beam name>.element``.
 
 * ``<beam name>.density`` (`float`)
     Peak density of the beam. Note: When ``<beam name>.injection_type == fixed_weight``
     either ``total_charge`` or ``density`` must be specified.
+    The absolute value of this parameter is used when initializing the beam.
 
 * ``<beam name>.profile`` (`string`)
     Beam profile.
@@ -402,6 +403,7 @@ Option: ``fixed_weight``
 
 * ``<beam name>.total_charge`` (`float`)
     Total charge of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
+    The absolute value of this parameter is used when initializing the beam.
 
 * ``<beam name>.dx_per_dzeta`` (`float`)  optional (default `0.`)
     Tilt of the beam in the x direction. The tilt is introduced with respect to the center of the
@@ -446,6 +448,7 @@ Option: ``fixed_ppc``
 
 * ``<beam name>.min_density`` (`float`) optional (default `0`)
     Minimum density. Particles with a lower density are not injected.
+    The absolute value of this parameter is used when initializing the beam.
 
 * ``<beam name>.random_ppc`` (3 `bool`) optional (default `0 0 0`)
     Whether the position in `(x y z)` of the particles is randomized within the cell.

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -79,6 +79,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom, bool do_insitu)
         amrex::Array<amrex::Real, AMREX_SPACEDIM> position_mean{0., 0., 0.};
         queryWithParser(pp, "position_mean", position_mean);
         queryWithParser(pp, "min_density", m_min_density);
+        m_min_density = std::abs(m_min_density);
         amrex::Vector<int> random_ppc {false, false, false};
         queryWithParser(pp, "random_ppc", random_ppc);
         const GetInitialDensity get_density(m_name);

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -59,7 +59,7 @@ namespace
         arrdata[BeamIdx::ux  ][ip] = ux * speed_of_light;
         arrdata[BeamIdx::uy  ][ip] = uy * speed_of_light;
         arrdata[BeamIdx::uz  ][ip] = uz * speed_of_light;
-        arrdata[BeamIdx::w][ip] = weight;
+        arrdata[BeamIdx::w][ip] = std::abs(weight);
     }
 }
 

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -13,6 +13,7 @@ GetInitialDensity::GetInitialDensity (const std::string& name)
     amrex::ParmParse pp(name);
     std::string profile;
     getWithParser(pp, "density", m_density);
+    m_density = std::abs(m_density);
     getWithParser(pp, "profile", profile);
 
     if        (profile == "gaussian") {


### PR DESCRIPTION
We suspect the code was not safe in terms of beam charge: if the used specified a negative total beam charge, the weights could be negative, causing UB. This PR aims at clarifying this.