### PR TITLE
Generalize beam tilt to any function of z

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -355,7 +355,9 @@ which are valid only for certain beam types, are introduced further below under
     ``from_file`` reads a beam from openPMD files.
 
 * ``<beam name>.position_mean`` (3 `float`)
-    The mean position of the beam in `x, y, z`, separated by a space.
+    The mean position of the beam in ``x, y, z``, separated by a space. For fixed_weight beams the
+    x and y directions can be functions of ``z``. To generate a tilted beam use
+    ``<beam name>.position_mean = "x_center+(z-z_ center)*dx_per_dzeta" "y_center+(z-z_ center)*dy_per_dzeta" "z_center"``.
 
 * ``<beam name>.position_std`` (3 `float`)
     The rms size of the of the beam in `x, y, z`, separated by a space.
@@ -404,14 +406,6 @@ Option: ``fixed_weight``
 * ``<beam name>.total_charge`` (`float`)
     Total charge of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
     The absolute value of this parameter is used when initializing the beam.
-
-* ``<beam name>.dx_per_dzeta`` (`float`)  optional (default `0.`)
-    Tilt of the beam in the x direction. The tilt is introduced with respect to the center of the
-    beam.
-
-* ``<beam name>.dy_per_dzeta`` (`float`)  optional (default `0.`)
-    Tilt of the beam in the y direction. The tilt is introduced with respect to the center of the
-    beam.
 
 * ``<beam name>.duz_per_uz0_dzeta`` (`float`) optional (default `0.`)
     Relative correlated energy spread per :math:`\zeta`.

--- a/examples/beam_in_vacuum/inputs_normalized_transverse
+++ b/examples/beam_in_vacuum/inputs_normalized_transverse
@@ -27,9 +27,8 @@ beam.num_particles = 10000
 beam.density = 200.
 beam.u_mean = 20. 10. 20
 beam.u_std = 100. 100. 15.
-beam.position_mean = 0. 0. 0
+beam.position_mean = "z*0.2" "0." "0"
 beam.position_std = 0.1 0.1 1.41
-beam.dx_per_dzeta = 0.2
 
 beam2.injection_type = fixed_weight
 beam2.num_particles = 3000

--- a/examples/linear_wake/inputs_ion_motion_SI
+++ b/examples/linear_wake/inputs_ion_motion_SI
@@ -39,9 +39,8 @@ beam.charge = -q_e
 beam.u_mean = 10 20 100
 beam.u_std = 0 0 0
 beam.profile = gaussian
-beam.position_mean = 0.25*kp_inv 0 2*kp_inv
+beam.position_mean = "0.25*kp_inv" "(z-2*kp_inv)*0.2" "2*kp_inv"
 beam.position_std = 0.4*kp_inv 0.4*kp_inv 1.41*kp_inv
-beam.dy_per_dzeta = 0.2
 
 plasmas.sort_bin_size = 8
 plasmas.names = elec ions

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -11,6 +11,7 @@
 
 #include "profiles/GetInitialDensity.H"
 #include "profiles/GetInitialMomentum.H"
+#include "utils/Parser.H"
 #include <AMReX_AmrParticles.H>
 #include <AMReX_Particles.H>
 #include <AMReX_AmrCore.H>
@@ -66,12 +67,12 @@ public:
     /** Initialize a beam with a fix number of particles, and fixed weight */
     void InitBeamFixedWeight (int num_to_add,
                               const GetInitialMomentum& get_momentum,
-                              const amrex::RealVect pos_mean,
+                              const amrex::ParserExecutor<1>& pos_mean_x,
+                              const amrex::ParserExecutor<1>& pos_mean_y,
+                              const amrex::Real pos_mean_z,
                               const amrex::RealVect pos_std,
                               const amrex::Real total_charge,
                               const bool do_symmetrize,
-                              const amrex::Real dx_per_dzeta,
-                              const amrex::Real dy_per_dzeta,
                               const bool can, const amrex::Real zmin, const amrex::Real zmax);
 
 #ifdef HIPACE_USE_OPENPMD
@@ -134,12 +135,12 @@ private:
     amrex::Real m_zmax; /**< Max longitudinal position of the can beam */
     amrex::Real m_radius; /**< Radius of the can beam */
     amrex::IntVect m_ppc {1, 1, 1}; /**< Number of particles per cell in each direction */
-    /** Average position of the Gaussian beam. Only used for a fixed-weight beam */
-    amrex::RealVect m_position_mean {0., 0., 0.};
+    /** Average x position of the fixed-weight beam depending on z */
+    amrex::Parser m_pos_mean_x_parser;
+    /** Average y position of the fixed-weight beam depending on z */
+    amrex::Parser m_pos_mean_y_parser;
     /** Width of the Gaussian beam. Only used for a fixed-weight beam */
     amrex::RealVect m_position_std {0., 0., 0.};
-    amrex::Real m_dx_per_dzeta {0.}; /**< tilt in x direction */
-    amrex::Real m_dy_per_dzeta {0.}; /**< tilt in y direction */
     amrex::Real m_duz_per_uz0_dzeta {0.}; /**< relative energy spread per dzeta */
     /** injection type, fixed_width or fixed_ppc */
     std::string m_injection_type;

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -298,34 +298,35 @@ InitBeamFixedWeight (int num_to_add,
             {
                 const amrex::Real x = amrex::RandomNormal(0, pos_std[0], engine);
                 const amrex::Real y = amrex::RandomNormal(0, pos_std[1], engine);
-                const amrex::Real z = (can
+                const amrex::Real z = can
                     ? zmin + amrex::Random(engine) * (zmax - zmin)
-                    : amrex::RandomNormal(0, pos_std[2], engine)) + pos_mean_z;
+                    : amrex::RandomNormal(0, pos_std[2], engine);
                 amrex::Real u[3] = {0.,0.,0.};
                 get_momentum(u[0],u[1],u[2], engine, z, duz_per_uz0_dzeta);
 
-                const amrex::Real cental_x_pos = pos_mean_x(z);
-                const amrex::Real cental_y_pos = pos_mean_y(z);
+                const amrex::Real z_central = z + pos_mean_z;
+                const amrex::Real cental_x_pos = pos_mean_x(z_central);
+                const amrex::Real cental_y_pos = pos_mean_y(z_central);
 
                 amrex::Real weight = total_charge / num_to_add / phys_const.q_e;
                 if (!do_symmetrize)
                 {
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
-                                       z, u[0], u[1], u[2], weight,
+                                       z_central, u[0], u[1], u[2], weight,
                                        pid, procID, i, phys_const.c);
                 } else {
                     weight /= 4;
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
-                                       z, u[0], u[1], u[2], weight,
+                                       z_central, u[0], u[1], u[2], weight,
                                        pid, procID, 4*i, phys_const.c);
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos+y,
-                                       z, -u[0], u[1], u[2], weight,
+                                       z_central, -u[0], u[1], u[2], weight,
                                        pid, procID, 4*i+1, phys_const.c);
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos-y,
-                                       z, u[0], -u[1], u[2], weight,
+                                       z_central, u[0], -u[1], u[2], weight,
                                        pid, procID, 4*i+2, phys_const.c);
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
-                                       z, -u[0], -u[1], u[2], weight,
+                                       z_central, -u[0], -u[1], u[2], weight,
                                        pid, procID, 4*i+3, phys_const.c);
                 }
             });

--- a/tests/gaussian_weight.1Rank.sh
+++ b/tests/gaussian_weight.1Rank.sh
@@ -28,8 +28,7 @@ TEST_NAME="${FILE_NAME%.*}"
 # Run the simulation
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         plasmas.sort_bin_size = 8 \
-        beam.dx_per_dzeta=0.1 \
-        beam.dy_per_dzeta=-0.2 \
+        beam.position_mean = "(z-2)*0.1" "1+(z-2)*(-0.2)" "2" \
         beam.duz_per_uz0_dzeta = 0.01 \
         beam.position_std = 0.1 0.1 2. \
         hipace.file_prefix=$TEST_NAME

--- a/tests/gaussian_weight.1Rank.sh
+++ b/tests/gaussian_weight.1Rank.sh
@@ -28,7 +28,7 @@ TEST_NAME="${FILE_NAME%.*}"
 # Run the simulation
 mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         plasmas.sort_bin_size = 8 \
-        beam.position_mean = "(z-2)*0.1" "1+(z-2)*(-0.2)" "2" \
+        beam.position_mean = '"(z-2)*0.1" "1+(z-2)*(-0.2)" "2"' \
         beam.duz_per_uz0_dzeta = 0.01 \
         beam.position_std = 0.1 0.1 2. \
         hipace.file_prefix=$TEST_NAME


### PR DESCRIPTION
For fixed_weight beams `<beam>.position_mean` in the x and y direction can be function of ``z``. To generate a tilted beam use
```
<beam name>.position_mean = "x_center+(z-z_ center)*dx_per_dzeta" "y_center+(z-z_ center)*dy_per_dzeta" "z_center"
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable