### PR TITLE
use GetUStd per plasma instead of on MultiPlasma in explicit solver

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -797,7 +797,7 @@ Hipace::ExplicitSolveBxBy (const int lev)
         for (const PlasmaParticleContainer& plasma : m_multi_plasma.m_all_plasmas) {
 
             // getting the constant of motion for finite temperatures
-            const amrex::RealVect u_std = m_multi_plasma.GetUStd();
+            const amrex::RealVect u_std = plasma.GetUStd();
             const amrex::Real const_of_motion = - plasma.m_mass * pc.c * pc.c / plasma.m_charge *
                 sqrt(1. + u_std[0]*u_std[0] + u_std[1]*u_std[1] + u_std[2]*u_std[2]);
 

--- a/src/particles/MultiPlasma.H
+++ b/src/particles/MultiPlasma.H
@@ -117,9 +117,6 @@ public:
      */
     void TileSort (amrex::Box bx, amrex::Geometry geom);
 
-    /** returns u_std of the plasma distribution */
-    amrex::RealVect GetUStd () const;
-
     /** returns a Vector of names of the plasmas */
     const amrex::Vector<std::string>& GetNames() const {return m_names;}
 

--- a/src/particles/MultiPlasma.cpp
+++ b/src/particles/MultiPlasma.cpp
@@ -167,23 +167,6 @@ MultiPlasma::TileSort (amrex::Box bx, amrex::Geometry geom)
     }
 }
 
-amrex::RealVect
-MultiPlasma::GetUStd () const
-{
-    amrex::RealVect u_std = {0.,0.,0.};
-
-    for (auto& plasma : m_all_plasmas) {
-        u_std = plasma.GetUStd();
-        if (m_nplasmas > 1) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( (std::abs(u_std[0]) + std::abs(u_std[1])
-                                               + std::abs(u_std[2])) < 1e-7,
-                "Cannot use explicit solver + multiple plasma species + non-zero temperature");
-        }
-    }
-
-    return u_std;
-}
-
 void
 MultiPlasma::doCoulombCollision (int lev, amrex::Box bx, amrex::Geometry geom)
 {


### PR DESCRIPTION
Previously, the momentum deviation of the plasma in the explicit solver was gathered from the multi_plasma (see https://github.com/Hi-PACE/hipace/pull/637#discussion_r802619986). After multiple plasma were allowed in #735, the momentum should be gathered per plasma species. 
This is fixed in this PR. It allows for different temperatures of the the plasma species (also, it was previously asserted that only 1 plasma species and a finite temperature were allowed).

 The PR was tested with a two temperature (40 and 10 eV, respectively) two plasma species (electrons and Helium ions) simulation producing the following output:
 ```
Rank 0 started  step 0 at time = 0 with dt = 4
plasma plasma u 0.008847488194 0.008847488194 0.008847488194
plasma ions u 0.004423744097 0.004423744097 0.004423744097
```


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
