### PR TITLE
Increase MPI message size limit for beam particles

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1171,8 +1171,13 @@ Hipace::Wait (const int step, int it, bool only_ghost)
         MPI_Status status;
         const int loc_pcomm_z_tag = only_ghost ? pcomm_z_tag_ghost : pcomm_z_tag;
         // Each rank receives data from upstream, except rank m_numprocs_z-1 who receives from 0
-        MPI_Recv(recv_buffer, buffer_size,
-                 amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
+
+        // Make datatype the same size as one particle, so MAX_INT particles can be sent
+        MPI_Datatype one_particle_size{};
+        MPI_Type_contiguous(psize, amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
+                            &one_particle_size);
+
+        MPI_Recv(recv_buffer, np_total, one_particle_size,
                  (m_rank_z+1)%m_numprocs_z, loc_pcomm_z_tag, m_comm_z, &status);
 
         int offset_beam = 0;
@@ -1386,7 +1391,13 @@ Hipace::Notify (const int step, const int it,
         const int loc_pcomm_z_tag = only_ghost ? pcomm_z_tag_ghost : pcomm_z_tag;
         MPI_Request* loc_psend_request = only_ghost ? &m_psend_request_ghost : &m_psend_request;
         // Each rank sends data downstream, except rank 0 who sends data to m_numprocs_z-1
-        MPI_Isend(psend_buffer, buffer_size, amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
+
+        // Make datatype the same size as one particle, so MAX_INT particles can be sent
+        MPI_Datatype one_particle_size{};
+        MPI_Type_contiguous(psize, amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
+                            &one_particle_size);
+
+        MPI_Isend(psend_buffer, np_total, one_particle_size,
                   (m_rank_z-1+m_numprocs_z)%m_numprocs_z, loc_pcomm_z_tag, m_comm_z, loc_psend_request);
     }
 #endif

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1176,6 +1176,7 @@ Hipace::Wait (const int step, int it, bool only_ghost)
         MPI_Datatype one_particle_size{};
         MPI_Type_contiguous(psize, amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
                             &one_particle_size);
+        MPI_Type_commit(&one_particle_size);
 
         MPI_Recv(recv_buffer, np_total, one_particle_size,
                  (m_rank_z+1)%m_numprocs_z, loc_pcomm_z_tag, m_comm_z, &status);
@@ -1396,6 +1397,7 @@ Hipace::Notify (const int step, const int it,
         MPI_Datatype one_particle_size{};
         MPI_Type_contiguous(psize, amrex::ParallelDescriptor::Mpi_typemap<char>::type(),
                             &one_particle_size);
+        MPI_Type_commit(&one_particle_size);
 
         MPI_Isend(psend_buffer, np_total, one_particle_size,
                   (m_rank_z-1+m_numprocs_z)%m_numprocs_z, loc_pcomm_z_tag, m_comm_z, loc_psend_request);


### PR DESCRIPTION
MPI is limited by the number of elements it can send. In this PR the datatype was changed from char to one that is the same size as one beam particle. This way the total buffer size is always divisible by that size. The increase in supported massage size should be 64x for double precision and 36x for single precision. Now the number of beam particles is only limited by MAX_INT which is also a limitation in the indexing and in dense bins. This should support 2e9 Particles (128 GB in fp64; 72 GB in fp32).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable