### PR TITLE
enable zmin, zmax for fixed weight beam

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -362,6 +362,12 @@ which are valid only for certain beam types, are introduced further below under
 * ``<beam name>.position_std`` (3 `float`)
     The rms size of the of the beam in `x, y, z`, separated by a space.
 
+* ``<beam name>.zmin`` (`float`) (default `-infinity`)
+    Minimum in `z` at which particles are injected.
+
+* ``<beam name>.zmax`` (`float`) (default `infinity`)
+    Maximum in `z` at which particles are injected.
+
 * ``<beam name>.element`` (`string`) optional (default `electron`)
     The Physical Element of the plasma. Sets charge, mass and, if available,
     the specific Ionization Energy of each state.
@@ -406,6 +412,7 @@ Option: ``fixed_weight``
 * ``<beam name>.total_charge`` (`float`)
     Total charge of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
     The absolute value of this parameter is used when initializing the beam.
+    Note that ``<beam name>.zmin`` and ``<beam name>.zmax`` can reduce the total charge.
 
 * ``<beam name>.duz_per_uz0_dzeta`` (`float`) optional (default `0.`)
     Relative correlated energy spread per :math:`\zeta`.
@@ -429,12 +436,6 @@ Option: ``fixed_ppc``
 
 * ``<beam name>.ppc`` (3 `int`) (default `1 1 1`)
     Number of particles per cell in `x`-, `y`-, and `z`-direction to generate the beam.
-
-* ``<beam name>.zmin`` (`float`)
-    Minimum in `z` at which particles are injected.
-
-* ``<beam name>.zmax`` (`float`)
-    Maximum in `z` at which particles are injected.
 
 * ``<beam name>.radius`` (`float`)
     Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -131,8 +131,8 @@ public:
 
 private:
     std::string m_name; /**< name of the species */
-    amrex::Real m_zmin; /**< Min longitudinal position of the can beam */
-    amrex::Real m_zmax; /**< Max longitudinal position of the can beam */
+    amrex::Real m_zmin; /**< Min longitudinal particle position of the beam */
+    amrex::Real m_zmax; /**< Max longitudinal particle position of the beam */
     amrex::Real m_radius; /**< Radius of the can beam */
     amrex::IntVect m_ppc {1, 1, 1}; /**< Number of particles per cell in each direction */
     /** Average x position of the fixed-weight beam depending on z */

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -94,7 +94,8 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom, bool do_insitu)
         amrex::ParmParse pp(m_name);
         amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
         bool can = false;
-        amrex::Real zmin = 0, zmax = 0;
+        amrex::Real zmin = -std::numeric_limits<amrex::Real>::infinity();
+        amrex::Real zmax = std::numeric_limits<amrex::Real>::infinity();
         std::string profile = "gaussian";
         queryWithParser(pp, "profile", profile);
         if (profile == "can") {
@@ -102,6 +103,8 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom, bool do_insitu)
             getWithParser(pp, "zmin", zmin);
             getWithParser(pp, "zmax", zmax);
         } else if (profile == "gaussian") {
+            queryWithParser(pp, "zmin", zmin);
+            queryWithParser(pp, "zmax", zmax);
         } else {
             amrex::Abort("Only gaussian and can are supported with fixed_weight beam injection");
         }

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -49,7 +49,7 @@ namespace
     {
         BeamParticleContainer::ParticleType& p = pstruct[ip];
         // Set particle AoS
-        p.id()   = pid + ip;
+        p.id()   = pid > 0 ? pid + ip : pid;
         p.cpu()  = procID;
         p.pos(0) = x;
         p.pos(1) = y;
@@ -305,6 +305,9 @@ InitBeamFixedWeight (int num_to_add,
                 get_momentum(u[0],u[1],u[2], engine, z, duz_per_uz0_dzeta);
 
                 const amrex::Real z_central = z + pos_mean_z;
+                int valid_id = pid;
+                if (z_central < zmin || z_central > zmax) valid_id = -1;
+
                 const amrex::Real cental_x_pos = pos_mean_x(z_central);
                 const amrex::Real cental_y_pos = pos_mean_y(z_central);
 
@@ -313,21 +316,21 @@ InitBeamFixedWeight (int num_to_add,
                 {
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
                                        z_central, u[0], u[1], u[2], weight,
-                                       pid, procID, i, phys_const.c);
+                                       valid_id, procID, i, phys_const.c);
                 } else {
                     weight /= 4;
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
                                        z_central, u[0], u[1], u[2], weight,
-                                       pid, procID, 4*i, phys_const.c);
+                                       valid_id, procID, 4*i, phys_const.c);
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos+y,
                                        z_central, -u[0], u[1], u[2], weight,
-                                       pid, procID, 4*i+1, phys_const.c);
+                                       valid_id, procID, 4*i+1, phys_const.c);
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos-y,
                                        z_central, u[0], -u[1], u[2], weight,
-                                       pid, procID, 4*i+2, phys_const.c);
+                                       valid_id, procID, 4*i+2, phys_const.c);
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos-x, cental_y_pos-y,
                                        z_central, -u[0], -u[1], u[2], weight,
-                                       pid, procID, 4*i+3, phys_const.c);
+                                       valid_id, procID, 4*i+3, phys_const.c);
                 }
             });
     }

--- a/src/particles/BoxSort.cpp
+++ b/src/particles/BoxSort.cpp
@@ -33,9 +33,7 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
     AMREX_FOR_1D ( np, i,
     {
         int dst_box = assign_grid(particle_ptr[i]);
-
         if (particle_ptr[i].id() < 0) dst_box = num_boxes; // if pid is invalid, remove particle
-
         if (dst_box < 0) {
             // particle has left domain transversely, stick it at the end and invalidate
             dst_box = num_boxes;
@@ -55,6 +53,7 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
     AMREX_FOR_1D ( np, i,
     {
         int dst_box = assign_grid(particle_ptr[i]);
+        if (particle_ptr[i].id() < 0) dst_box = num_boxes; // if pid is invalid, remove particle
         if (dst_box < 0) dst_box = num_boxes;
         p_dst_indices[i] += p_box_offsets[dst_box];
     });

--- a/src/particles/BoxSort.cpp
+++ b/src/particles/BoxSort.cpp
@@ -33,6 +33,9 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
     AMREX_FOR_1D ( np, i,
     {
         int dst_box = assign_grid(particle_ptr[i]);
+
+        if (particle_ptr[i].id() < 0) dst_box = num_boxes; // if pid is invalid, remove particle
+
         if (dst_box < 0) {
             // particle has left domain transversely, stick it at the end and invalidate
             dst_box = num_boxes;


### PR DESCRIPTION
This PR adds the capability to restrict fixed weight beams longitudinally. 

Previously, this was only possible for can beams, now it is added for Gaussian beams. Therefore, it is queried also for a Gaussian beam (note that it is get for a can beam) with a default of zmin = -infinity, zmax= inifinity.

The box sorter needed to be updated, as it would otherwise still count the invalid particles. 

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
