### PR TITLE
add minimal plasma density, deprecate parabolic curvature

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -237,6 +237,10 @@ plasma parameters for each plasma are specified via ``<plasma name>.<plasma prop
     of every timestep. If specified as a command line parameter, quotation marks must be added:
     ``"<plasma name>.density(x,y,z)" = "1."``.
 
+* ``<plasma name>.min_density`` (`float`) optional (default `0`)
+    Minimal density at which particles are still injected.
+    Useful for parsed functions to avoid redundant plasma particles with close to 0 weight.
+
 * ``<plasma name>.density_table_file`` (`string`) optional (default "")
     Alternative to ``<plasma name>.density(x,y,z)``. Specify the name of a text file containing
     multiple densities for different positions. File syntax: ``<position> <density function>`` for
@@ -259,10 +263,6 @@ plasma parameters for each plasma are specified via ``<plasma name>.<plasma prop
 * ``<plasma name>.hollow_core_radius`` (`float`) optional (default `0.`)
     Inner radius of a hollow core plasma. The hollow core radius must be smaller than the plasma
     radius itself.
-
-* ``<plasma name>.parabolic_curvature`` (`float`) optional (default `0.`)
-    Curvature of a parabolic plasma profile. The plasma density is set to
-    :math:`\mathrm{plasma.density(x,y,z)} * (1 + \mathrm{plasma.parabolic\_curvature}*r^2)`.
 
 * ``<plasma name>.max_qsa_weighting_factor`` (`float`) optional (default `35.`)
     The maximum allowed weighting factor :math:`\gamma /(\psi+1)` before particles are considered

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -238,7 +238,7 @@ plasma parameters for each plasma are specified via ``<plasma name>.<plasma prop
     ``"<plasma name>.density(x,y,z)" = "1."``.
 
 * ``<plasma name>.min_density`` (`float`) optional (default `0`)
-    Minimal density at which particles are still injected.
+    Minimal density below which particles are not injected.
     Useful for parsed functions to avoid redundant plasma particles with close to 0 weight.
 
 * ``<plasma name>.density_table_file`` (`string`) optional (default "")

--- a/src/particles/PlasmaParticleContainer.H
+++ b/src/particles/PlasmaParticleContainer.H
@@ -120,6 +120,7 @@ public:
 
     amrex::Parser m_parser; /**< owns data for m_density_func */
     amrex::ParserExecutor<3> m_density_func; /**< Density function for the plasma */
+    amrex::Real m_min_density {0.}; /**< minimal density at which particles are injected */
     bool m_use_density_table; /**< if a density value table was specified */
     /** plasma density value table, key: position=c*time, value=density funciton string */
     std::map<amrex::Real, std::string> m_density_table;
@@ -129,8 +130,6 @@ public:
     amrex::Real m_max_qsa_weighting_factor {35.};
     amrex::Real m_radius {std::numeric_limits<amrex::Real>::infinity()}; /**< radius of the plasma */
     amrex::Real m_hollow_core_radius {0.}; /**< hollow core radius of the plasma */
-    /** defines the curvature of a parabolic plasma profile */
-    amrex::Real m_parabolic_curvature {0.};
     amrex::IntVect m_ppc {0,0,1}; /**< Number of particles per cell in each direction */
     amrex::RealVect m_u_mean {0,0,0}; /**< Avg momentum in each direction normalized by m*c */
     amrex::RealVect m_u_std {0,0,0}; /**< Thermal momentum in each direction normalized by m*c */

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -81,12 +81,10 @@ PlasmaParticleContainer::ReadParameters ()
                     "The same functionality can be obtained with the parser using "
                     "density(x,y,z) = <density> * (1 + <parabolic_curvature>*(x^2 + y^2) )" );
 
-
     bool density_func_specified = queryWithParser(pp, "density(x,y,z)", density_func_str);
     m_density_func = makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"});
 
     queryWithParser(pp, "min_density", m_min_density);
-
 
     std::string density_table_file_name{};
     m_use_density_table = queryWithParser(pp, "density_table_file", density_table_file_name);

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -77,9 +77,16 @@ PlasmaParticleContainer::ReadParameters ()
 
     std::string density_func_str = "0.";
     DeprecatedInput(m_name, "density", "density(x,y,z)");
+    DeprecatedInput(m_name, "parabolic_curvature", "density(x,y,z)",
+                    "The same functionality can be obtained with the parser using "
+                    "density(x,y,z) = <density> * (1 + <parabolic_curvature>*(x^2 + y^2) )" );
+
 
     bool density_func_specified = queryWithParser(pp, "density(x,y,z)", density_func_str);
     m_density_func = makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"});
+
+    queryWithParser(pp, "min_density", m_min_density);
+
 
     std::string density_table_file_name{};
     m_use_density_table = queryWithParser(pp, "density_table_file", density_table_file_name);
@@ -108,7 +115,6 @@ PlasmaParticleContainer::ReadParameters ()
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_hollow_core_radius < m_radius,
                                      "The hollow core plasma radius must not be smaller than the "
                                      "plasma radius itself");
-    queryWithParser(pp, "parabolic_curvature", m_parabolic_curvature);
     queryWithParser(pp, "max_qsa_weighting_factor", m_max_qsa_weighting_factor);
     amrex::Vector<amrex::Real> tmp_vector;
     if (queryWithParser(pp, "ppc", tmp_vector)){

--- a/src/particles/PlasmaParticleContainerInit.cpp
+++ b/src/particles/PlasmaParticleContainerInit.cpp
@@ -49,6 +49,12 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
         amrex::Gpu::DeviceVector<unsigned int> offsets(tile_box.numPts());
         unsigned int* poffset = offsets.dataPtr();
 
+        UpdateDensityFunction();
+        auto density_func = m_density_func;
+        const amrex::Real c_light = get_phys_const().c;
+        const amrex::Real c_t = c_light * Hipace::m_physical_time;
+        const amrex::Real min_density = m_min_density;
+
         amrex::ParallelFor(tile_box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
@@ -65,7 +71,8 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 if (x >= a_bounds.hi(0) || x < a_bounds.lo(0) ||
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                     rsq > a_radius*a_radius ||
-                    rsq < a_hollow_core_radius*a_hollow_core_radius) continue;
+                    rsq < a_hollow_core_radius*a_hollow_core_radius ||
+                    density_func(x, y, c_t) < min_density) continue;
 
                 int ix = i - lo.x;
                 int iy = j - lo.y;
@@ -103,13 +110,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
         int pid = ParticleType::NextID();
         ParticleType::NextID(pid + num_to_add);
 
-        UpdateDensityFunction();
-        auto density_func = m_density_func;
-        amrex::Real c_light = get_phys_const().c;
-        amrex::Real c_t = c_light * Hipace::m_physical_time;
-
-        const amrex::Real parabolic_curvature = m_parabolic_curvature;
-
         const int init_ion_lev = m_init_ion_lev;
 
         amrex::ParallelForRNG(tile_box,
@@ -142,7 +142,8 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 if (x >= a_bounds.hi(0) || x < a_bounds.lo(0) ||
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                     rsq > a_radius*a_radius ||
-                    rsq < a_hollow_core_radius*a_hollow_core_radius) continue;
+                    rsq < a_hollow_core_radius*a_hollow_core_radius ||
+                    density_func(x, y, c_t) < min_density) continue;
 
                 const amrex::Real rp = std::sqrt(x*x + y*y);
 
@@ -156,10 +157,8 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 p.pos(1) = y;
                 p.pos(2) = z;
 
-                amrex::Real base_density = (1. + parabolic_curvature*rp*rp) * scale_fac;
-
-                arrdata[PlasmaIdx::w        ][pidx] = base_density * density_func(x, y, c_t);
-                arrdata[PlasmaIdx::w0       ][pidx] = base_density;
+                arrdata[PlasmaIdx::w        ][pidx] = scale_fac * density_func(x, y, c_t);
+                arrdata[PlasmaIdx::w0       ][pidx] = scale_fac;
                 arrdata[PlasmaIdx::ux       ][pidx] = u[0] * c_light;
                 arrdata[PlasmaIdx::uy       ][pidx] = u[1] * c_light;
                 arrdata[PlasmaIdx::psi      ][pidx] = sqrt(1.+u[0]*u[0]+u[1]*u[1]+u[2]*u[2])-u[2];

--- a/src/utils/DeprecatedInput.H
+++ b/src/utils/DeprecatedInput.H
@@ -13,7 +13,7 @@
 #include <AMReX_Parser.H>
 
 inline void
-DeprecatedInput(std::string const& pp_name, char const * const str,
+DeprecatedInput (std::string const& pp_name, char const * const str,
                 std::string const& replacement, std::string const& msg="")
 {
     amrex::ParmParse pp(pp_name);


### PR DESCRIPTION
This PR adds a minimum plasma density. This is especially useful with parsed density functions, which otherwise inject many particles with close to 0 weight, which still take computational time and block memory.

At the same time, the parabolic curvature is deprecated, as it can be easily re-created with the much more flexible parsed density profile. 

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
