### PR TITLE
[DO NOT MERGE] Optionally cut off additional cells of the poisson source

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -167,6 +167,11 @@ Modeling ion motion is not yet supported by the explicit solver
     Extends the area of the FFT Poisson solver to the ghost cells. This can reduce artifacts
     originating from the boundary for long simulations.
 
+* ``fields.source_cutoff`` (`int`) optional (default `0`)
+    Parameter for ``extended_solve``. Cutoff additional cells near the domain boundary from
+    the source terms of the solvers. Can help to further reduce noise for very long boxes.
+    Note: for the explicit solver this cutoff region is like vacuum and not unperturbed plasma.
+
 * ``fields.open_boundary`` (`bool`) optional (default `0`)
     Uses a Taylor approximation of the Greens function to solve the Poisson equations with
     open boundary conditions. It's recommended to use this together with

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -752,7 +752,7 @@ Hipace::ExplicitSolveBxBy (const int lev)
 
     for ( amrex::MFIter mfi(slicemf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi ){
 
-        amrex::Box const& bx = mfi.tilebox();
+        amrex::Box const& bx = mfi.growntilebox(m_fields.m_source_nguard);
 
         amrex::Array4<amrex::Real> const mult = Mult.array(mfi);
         amrex::Array4<amrex::Real> const s = S.array(mfi);

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -408,6 +408,8 @@ public:
     static amrex::IntVect m_slices_nguards;
     /** Number of guard cells for poisson solver MultiFab */
     static amrex::IntVect m_poisson_nguards;
+    /** Number of guard cells where sources for poisson equation are included */
+    amrex::IntVect m_source_nguard;
     /** If the poisson solver should include the guard cells */
     bool m_extended_solve = false;
 
@@ -424,8 +426,8 @@ private:
     amrex::Gpu::DeviceVector<amrex::Real> m_rel_z_vec;
     /** Number of guard cells where ExmBy and EypBx are calculated */
     amrex::IntVect m_exmby_eypbx_nguard;
-    /** Number of guard cells where sources for poisson equation are included */
-    amrex::IntVect m_source_nguard;
+    /** Number of extra cells where sources for poisson equation are not included */
+    int m_source_cutoff = 0;
     /** If lev_0 should be solved with open boundary conditions */
     bool m_open_boundary = false;
     /** If the explicit solver is being used */

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -26,6 +26,9 @@ Fields::Fields (Hipace const* a_hipace)
     amrex::ParmParse ppf("fields");
     queryWithParser(ppf, "do_dirichlet_poisson", m_do_dirichlet_poisson);
     queryWithParser(ppf, "extended_solve", m_extended_solve);
+    if (m_extended_solve) {
+        queryWithParser(ppf, "source_cutoff", m_source_cutoff);
+    }
     queryWithParser(ppf, "open_boundary", m_open_boundary);
 }
 
@@ -49,7 +52,7 @@ Fields::AllocData (
             // one cell less for transverse derivative
             m_exmby_eypbx_nguard = m_slices_nguards - amrex::IntVect{1, 1, 0};
             // cut off anything near edge of charge/current deposition
-            m_source_nguard = -m_slices_nguards;
+            m_source_nguard = -m_slices_nguards-amrex::IntVect{m_source_cutoff, m_source_cutoff, 0};
         } else {
             // Need 1 extra guard cell transversally for transverse derivative
             int nguards_xy = std::max(1, Hipace::m_depos_order_xy);


### PR DESCRIPTION
```
fields.extended_solve = true
fields.source_cutoff = 10
```

Parameter for `extended_solve`. Cutoff additional cells near the domain boundary from
the source terms of the solvers. Can help to further reduce noise for very long boxes.
Note: for the explicit solver this cutoff region is like vacuum and not unperturbed plasma.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
