### PR TITLE
Fix adaptive time step

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -93,7 +93,8 @@ Hipace::Hipace () :
     m_fields(this),
     m_multi_beam(this),
     m_multi_plasma(this),
-    m_diags(this->maxLevel()+1)
+    m_diags(this->maxLevel()+1),
+    m_adaptive_time_step(m_multi_beam.get_nbeams())
 {
     amrex::ParmParse pp;// Traditionally, max_step and stop_time do not have prefix.
     queryWithParser(pp, "max_step", m_max_step);

--- a/src/utils/AdaptiveTimeStep.H
+++ b/src/utils/AdaptiveTimeStep.H
@@ -18,7 +18,7 @@ class AdaptiveTimeStep
 private:
 
     /** container including dt, min_gamma, sum of weights and the sum of weights times gamma */
-    amrex::Real m_timestep_data[5] = {0., 1e30, 0., 0., 0.};
+    amrex::Vector<amrex::Vector<amrex::Real>> m_timestep_data;
 
     /** Whether to use an adaptive time step */
     bool m_do_adaptive_time_step = false;

--- a/src/utils/AdaptiveTimeStep.H
+++ b/src/utils/AdaptiveTimeStep.H
@@ -27,7 +27,7 @@ private:
 
 public:
     /** Constructor */
-    explicit AdaptiveTimeStep ();
+    explicit AdaptiveTimeStep (const int nbeams);
 
 #ifdef AMREX_USE_MPI
     /** sends the calculated initial time step to the rank downstream

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -32,6 +32,22 @@ AdaptiveTimeStep::AdaptiveTimeStep ()
         queryWithParser(ppa, "nt_per_betatron", m_nt_per_betatron);
     }
     DeprecatedInput("hipace", "do_adaptive_time_step", "dt = adaptive");
+
+    amrex::Vector<std::string> beam_names;
+    amrex::ParmParse ppb("beams");
+    getWithParser(ppb, "names", beam_names);
+    if (beam_names[0] == "no_beam") return;
+    const int nbeams = beam_names.size();
+
+    for (int ibeam = 0; ibeam < nbeams; ibeam++) {
+        amrex::Vector<amrex::Real> ts_data;
+        ts_data.resize(5, 0.);
+        ts_data[1] = 1e30; // {0., 1e30, 0., 0., 0.};
+        m_timestep_data.emplace_back(ts_data);
+    }
+
+
+
 }
 
 #ifdef AMREX_USE_MPI
@@ -76,16 +92,21 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
     // Extract properties associated with physical size of the box
     const PhysConst phys_const = get_phys_const();
 
-    // first box resets time step data
-    if (it == amrex::ParallelDescriptor::NProcs()-1) {
-        m_timestep_data[WhichDouble::SumWeights] = 0.;
-        m_timestep_data[WhichDouble::SumWeightsTimesUz] = 0.;
-        m_timestep_data[WhichDouble::SumWeightsTimesUzSquared] = 0.;
-        m_timestep_data[WhichDouble::MinUz] = 1e30;
-    }
+    const int nbeams = beams.get_nbeams();
 
-    for (int ibeam = 0; ibeam < beams.get_nbeams(); ibeam++) {
+    amrex::Vector<amrex::Real> new_dts;
+    new_dts.resize(nbeams);
+
+    for (int ibeam = 0; ibeam < nbeams; ibeam++) {
         const auto& beam = beams.getBeam(ibeam);
+
+        // first box resets time step data
+        if (it == amrex::ParallelDescriptor::NProcs()-1) {
+            m_timestep_data[ibeam][WhichDouble::SumWeights] = 0.;
+            m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUz] = 0.;
+            m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared] = 0.;
+            m_timestep_data[ibeam][WhichDouble::MinUz] = 1e30;
+        }
 
         const uint64_t box_offset = initial ? 0 : a_box_sorter_vec[ibeam].boxOffsetsPtr()[it];
         const uint64_t numParticleOnTile = initial ? beam.numParticles()
@@ -97,19 +118,19 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
         const auto uzp = soa.GetRealData(BeamIdx::uz).data() + box_offset;
         const auto wp = soa.GetRealData(BeamIdx::w).data() + box_offset;
 
-        amrex::Gpu::DeviceScalar<amrex::Real> gpu_min_uz(m_timestep_data[WhichDouble::MinUz]);
+        amrex::Gpu::DeviceScalar<amrex::Real> gpu_min_uz(m_timestep_data[ibeam][WhichDouble::MinUz]);
         amrex::Real* p_min_uz = gpu_min_uz.dataPtr();
 
         amrex::Gpu::DeviceScalar<amrex::Real> gpu_sum_weights(
-                m_timestep_data[WhichDouble::SumWeights]);
+                m_timestep_data[ibeam][WhichDouble::SumWeights]);
         amrex::Real* p_sum_weights = gpu_sum_weights.dataPtr();
 
         amrex::Gpu::DeviceScalar<amrex::Real> gpu_sum_weights_times_uz(
-            m_timestep_data[WhichDouble::SumWeightsTimesUz]);
+            m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUz]);
         amrex::Real* p_sum_weights_times_uz = gpu_sum_weights_times_uz.dataPtr();
 
         amrex::Gpu::DeviceScalar<amrex::Real> gpu_sum_weights_times_uz_squared(
-            m_timestep_data[WhichDouble::SumWeightsTimesUzSquared]);
+            m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared]);
         amrex::Real* p_sum_weights_times_uz_squared =
             gpu_sum_weights_times_uz_squared.dataPtr();
 
@@ -127,11 +148,11 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
         }
         );
         /* adding beam particle information to time step info */
-        m_timestep_data[WhichDouble::SumWeights] = gpu_sum_weights.dataValue();
-        m_timestep_data[WhichDouble::SumWeightsTimesUz] = gpu_sum_weights_times_uz.dataValue();
-        m_timestep_data[WhichDouble::SumWeightsTimesUzSquared] =
+        m_timestep_data[ibeam][WhichDouble::SumWeights] = gpu_sum_weights.dataValue();
+        m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUz] = gpu_sum_weights_times_uz.dataValue();
+        m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared] =
                                                gpu_sum_weights_times_uz_squared.dataValue();
-        m_timestep_data[WhichDouble::MinUz] = std::min(m_timestep_data[WhichDouble::MinUz],
+        m_timestep_data[ibeam][WhichDouble::MinUz] = std::min(m_timestep_data[ibeam][WhichDouble::MinUz],
                                                gpu_min_uz.dataValue());
     }
 
@@ -139,36 +160,39 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
     // from the full beam information
     if (it == 0 || initial)
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_timestep_data[WhichDouble::SumWeights] != 0,
-            "The sum of all weights is 0! Probably no beam particles are initialized");
-        const amrex::Real mean_uz = m_timestep_data[WhichDouble::SumWeightsTimesUz]
-                                       /m_timestep_data[WhichDouble::SumWeights];
-        const amrex::Real sigma_uz = sqrt(m_timestep_data[WhichDouble::SumWeightsTimesUzSquared]
-                                          /m_timestep_data[WhichDouble::SumWeights] - mean_uz);
-        const amrex::Real sigma_uz_dev = mean_uz - 4.*sigma_uz;
-        const amrex::Real max_supported_uz = 1e30;
-        const amrex::Real chosen_min_uz = std::min( std::max(sigma_uz_dev,
-                                          m_timestep_data[WhichDouble::MinUz]), max_supported_uz);
+        for (int ibeam = 0; ibeam < nbeams; ibeam++) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_timestep_data[ibeam][WhichDouble::SumWeights] != 0,
+                "The sum of all weights is 0! Probably no beam particles are initialized");
+            const amrex::Real mean_uz = m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUz]
+                                           /m_timestep_data[ibeam][WhichDouble::SumWeights];
+            const amrex::Real sigma_uz = sqrt(m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared]
+                                              /m_timestep_data[ibeam][WhichDouble::SumWeights] - mean_uz);
+            const amrex::Real sigma_uz_dev = mean_uz - 4.*sigma_uz;
+            const amrex::Real max_supported_uz = 1e30;
+            const amrex::Real chosen_min_uz = std::min( std::max(sigma_uz_dev,
+                                              m_timestep_data[ibeam][WhichDouble::MinUz]), max_supported_uz);
 
-        if (Hipace::m_verbose >=2 ){
-            amrex::Print()<<"Minimum gamma to calculate new time step: " << chosen_min_uz << "\n";
+            if (Hipace::m_verbose >=2 ){
+                amrex::Print()<<"Minimum gamma of beam " << ibeam << " to calculate new time step: "
+                              << chosen_min_uz << "\n";
+            }
+
+            if (chosen_min_uz < 1) {
+                amrex::Print()<<"WARNING: beam particles of beam "<< ibeam <<
+                                " have non-relativistic velocities!";
+            }
+
+            new_dts[ibeam] = dt;
+            if (chosen_min_uz > 1) // and density above min density
+            {
+                const amrex::Real omega_p = std::sqrt(plasma_density * phys_const.q_e*phys_const.q_e
+                                              / ( phys_const.ep0*phys_const.m_e ));
+                amrex::Real omega_betatron = omega_p / std::sqrt(2.*chosen_min_uz);
+                new_dts[ibeam] = 2.*MathConst::pi/omega_betatron / m_nt_per_betatron;
+            }
         }
-
-        if (chosen_min_uz < 1) {
-            amrex::Print()<<"WARNING: beam particles have non-relativistic velocities!";
-        }
-
-        amrex::Real new_dt = dt;
-        if (chosen_min_uz > 1) // and density above min density
-        {
-            const amrex::Real omega_p = std::sqrt(plasma_density * phys_const.q_e*phys_const.q_e
-                                          / ( phys_const.ep0*phys_const.m_e ));
-            amrex::Real omega_betatron = omega_p / std::sqrt(2.*chosen_min_uz);
-            new_dt = 2.*MathConst::pi/omega_betatron / m_nt_per_betatron;
-        }
-
         /* set the new time step */
-        dt = new_dt;
+        dt = *std::min_element(new_dts.begin(), new_dts.end());
 
     }
 }

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -48,8 +48,6 @@ AdaptiveTimeStep::AdaptiveTimeStep ()
         m_timestep_data.emplace_back(ts_data);
     }
 
-
-
 }
 
 #ifdef AMREX_USE_MPI
@@ -171,11 +169,13 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
             const amrex::Real mean_uz = m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUz]
                                            /m_timestep_data[ibeam][WhichDouble::SumWeights];
             const amrex::Real sigma_uz = sqrt(m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared]
-                                              /m_timestep_data[ibeam][WhichDouble::SumWeights] - mean_uz*mean_uz);
+                                              /m_timestep_data[ibeam][WhichDouble::SumWeights]
+                                              - mean_uz*mean_uz);
             const amrex::Real sigma_uz_dev = mean_uz - 4.*sigma_uz;
             const amrex::Real max_supported_uz = 1e30;
-            const amrex::Real chosen_min_uz = std::min( std::max(sigma_uz_dev,
-                                              m_timestep_data[ibeam][WhichDouble::MinUz]), max_supported_uz);
+            const amrex::Real chosen_min_uz = std::min(std::max(sigma_uz_dev,
+                                                       m_timestep_data[ibeam][WhichDouble::MinUz]),
+                                                       max_supported_uz);
 
             if (Hipace::m_verbose >=2 ){
                 amrex::Print()<<"Minimum gamma of beam " << ibeam << " to calculate new time step: "

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -22,7 +22,7 @@ struct WhichDouble {
     enum Comp { Dt=0, MinUz, SumWeights, SumWeightsTimesUz, SumWeightsTimesUzSquared, N };
 };
 
-AdaptiveTimeStep::AdaptiveTimeStep ()
+AdaptiveTimeStep::AdaptiveTimeStep (const int nbeams)
 {
     amrex::ParmParse ppa("hipace");
     std::string str_dt = "";
@@ -32,13 +32,6 @@ AdaptiveTimeStep::AdaptiveTimeStep ()
         queryWithParser(ppa, "nt_per_betatron", m_nt_per_betatron);
     }
     DeprecatedInput("hipace", "do_adaptive_time_step", "dt = adaptive");
-
-    // get number of beams
-    amrex::Vector<std::string> beam_names;
-    amrex::ParmParse ppb("beams");
-    getWithParser(ppb, "names", beam_names);
-    if (beam_names[0] == "no_beam") return;
-    const int nbeams = beam_names.size();
 
     // create time step data container per beam
     for (int ibeam = 0; ibeam < nbeams; ibeam++) {


### PR DESCRIPTION
This PR fixes 3 errors/bugs in the calculation of the adaptive time step.

The time step is calculated by using the uz of `max( mean_uz - 4*sigma_uz, min(uz) )`

1. there was a typo in the calculation of `sigma_uz`: the second `^2` in `sigma_uz = sqrt( <uz^2> - <uz>^2 )` was missing. Thus, always min(uz) was used, so single particles would affect the time step.
2. uz was calculated from all beams at once. This lead to unwanted behavior if beams had vastly different energies, because it blew up sigma_uz. Now, the time step is calculated per beam, and the minimum of all beams is used.
3. The mass was not taken into account, leading to wrong results for non-electron-mass beams, like a time step 1836 times too small for a proton beam. 


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
