### PR TITLE
Extend MultiGrid solver to complex number system

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -969,8 +969,8 @@ Hipace::ExplicitSolveBxBy (const int lev)
             m_hpmg = std::make_unique<hpmg::MultiGrid>(slice_geom);
         }
         const int max_iters = 200;
-        m_hpmg->solve(BxBy[0], S[0], Mult[0], m_MG_tolerance_rel, m_MG_tolerance_abs,
-                      max_iters, m_MG_verbose);
+        m_hpmg->solve1(BxBy[0], S[0], Mult[0], m_MG_tolerance_rel, m_MG_tolerance_abs,
+                       max_iters, m_MG_verbose);
     }
     amrex::ParallelContext::pop();
 }

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -84,7 +84,7 @@ public:
      * is not supposed to be a public function.  It's made public due to a
      * CUDA limitation. */
     void bottomsolve ();
-    /** brief Private funciton used by solve1 and solve2.  It's made public
+    /** \brief Private function used by solve1 and solve2.  It's made public
      * due to a CUDA limitation. */
     void solve_doit (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
                      amrex::FArrayBox const& acoef,

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -17,8 +17,17 @@ namespace hpmg {
 /** \brief Multigrid solver
  *
  * This solves `-acoef * sol + Lap(sol) = rhs` with homogeneous Dirichlet BC
- * on a 2D slice.  sol and rhs have two components, whereas acoef has only
- * one component. */
+ * on a 2D slice.  It can solve two types of linear systems.
+ *
+ * (1) sol and rhs have two components, whereas acoef has only one
+ *     component.  For Type I, call solve1(...).
+ *
+ * (2) acoef, sol, rhs are complex numbers, and the real part of acoef is a
+ *     scalar constant.  The system is equivalent to
+ *       -acoef_real * sol_real + acoef_imag * sol_imag + Lap(sol_real) = rhs_real
+ *       -acoef_imag * sol_real - acoef_real * sol_imag + Lap(sol_imag) = rhs_imag
+ *     For Type II, call solve2(...).
+ */
 class MultiGrid
 {
 public:
@@ -32,7 +41,7 @@ public:
     /** \brief Dtor */
     ~MultiGrid ();
 
-    /** \brief Solve the equation given the initial guess, right hand side,
+    /** \brief Solve the Type I equation given the initial guess, right hand side,
      * and the coefficient.
      *
      * \param[in,out] sol the initial guess and final solution
@@ -43,9 +52,26 @@ public:
      * \param[in] nummaxiter maximum number of iterations
      * \param[in] verbose verbosity level
      */
-    void solve (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs, amrex::FArrayBox const& acoef,
-                amrex::Real const tol_rel, amrex::Real const tol_abs, int const nummaxiter,
-                int const verbose);
+    void solve1 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs, amrex::FArrayBox const& acoef,
+                 amrex::Real const tol_rel, amrex::Real const tol_abs, int const nummaxiter,
+                 int const verbose);
+
+    /** \brief Solve the Type II equation given the initial guess, right hand side,
+     * and the coefficient.
+     *
+     * \param[in,out] sol the initial guess and final solution
+     * \param[in] rhs right hand side
+     * \param[in] acoef_real the real part of the coefficient
+     * \param[in] acoef_imag the imaginary part of the coefficient
+     * \param[in] tol_rel relative tolerance
+     * \param[in] tol_abs absolute tolerance
+     * \param[in] nummaxiter maximum number of iterations
+     * \param[in] verbose verbosity level
+     */
+    void solve2 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
+                 amrex::Real const acoef_real, amrex::FArrayBox const& acoef_imag,
+                 amrex::Real const tol_rel, amrex::Real const tol_abs,
+                 int const nummaxiter, int const verbose);
 
     /** \brief Average down the coefficient.  Ideally, this function is not
      * supposed to be a public function.  It's made public due to a CUDA
@@ -58,8 +84,19 @@ public:
      * is not supposed to be a public function.  It's made public due to a
      * CUDA limitation. */
     void bottomsolve ();
+    /** brief Private funciton used by solve1 and solve2.  It's made public
+     * due to a CUDA limitation. */
+    void solve_doit (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
+                     amrex::FArrayBox const& acoef,
+                     amrex::Real const tol_rel, amrex::Real const tol_abs,
+                     int const nummaxiter, int const verbose);
 
 private:
+
+    static constexpr int m_num_system_types = 2;
+    int m_system_type = 0;
+
+    amrex::Real m_acf_real = amrex::Real(0.); // Only used by Type II.
 
     /** 2D slice domain */
     amrex::Vector<amrex::Box> m_domain;
@@ -108,10 +145,10 @@ private:
     cudaGraph_t m_cuda_graph_acf = NULL;
     cudaGraphExec_t m_cuda_graph_exe_acf = NULL;
 
-    /** CUDA graphs for the V-cycle */
-    bool m_cuda_graph_vcycle_created = false;
-    cudaGraph_t m_cuda_graph_vcycle = NULL;
-    cudaGraphExec_t m_cuda_graph_exe_vcycle = NULL;
+    /** CUDA graphs for the V-cycle*/
+    bool m_cuda_graph_vcycle_created[m_num_system_types] = {false,false};
+    cudaGraph_t m_cuda_graph_vcycle[m_num_system_types] = {NULL,NULL};
+    cudaGraphExec_t m_cuda_graph_exe_vcycle[m_num_system_types] = {NULL,NULL};
 #endif
 };
 

--- a/src/mg_solver/HpMultiGrid.cpp
+++ b/src/mg_solver/HpMultiGrid.cpp
@@ -67,16 +67,16 @@ namespace {
 constexpr int n_cell_single = 32; // switch to single block when box is smaller than this
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-Real residual (int i, int j, int n, int ilo, int jlo, int ihi, int jhi,
-               Array4<Real> const& phi, Real rhs, Real acf, Real facx, Real facy)
+Real laplacian (int i, int j, int n, int ilo, int jlo, int ihi, int jhi,
+                Array4<Real> const& phi, Real facx, Real facy)
 {
-    Real lap;
+    Real lap = Real(-2.)*(facx+facy)*phi(i,j,0,n);
     if (i == ilo) {
-        lap = facx * (Real(4./3.)*phi(i+1,j,0,n) - Real(2.)*phi(i,j,0,n));
+        lap += facx * (Real(4./3.)*phi(i+1,j,0,n) - Real(2.)*phi(i,j,0,n));
     } else if (i == ihi) {
-        lap = facx * (Real(4./3.)*phi(i-1,j,0,n) - Real(2.)*phi(i,j,0,n));
+        lap += facx * (Real(4./3.)*phi(i-1,j,0,n) - Real(2.)*phi(i,j,0,n));
     } else {
-        lap = facx * (phi(i-1,j,0,n) + phi(i+1,j,0,n));
+        lap += facx * (phi(i-1,j,0,n) + phi(i+1,j,0,n));
     }
     if (j == jlo) {
         lap += facy * (Real(4./3.)*phi(i,j+1,0,n) - Real(2.)*phi(i,j,0,n));
@@ -85,13 +85,40 @@ Real residual (int i, int j, int n, int ilo, int jlo, int ihi, int jhi,
     } else {
         lap += facy * (phi(i,j-1,0,n) + phi(i,j+1,0,n));
     }
-    return rhs + (acf+Real(2.)*(facx+facy))*phi(i,j,0,n) - lap;
+    return lap;
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+Real residual1 (int i, int j, int n, int ilo, int jlo, int ihi, int jhi,
+                Array4<Real> const& phi, Real rhs, Real acf, Real facx, Real facy)
+{
+    Real lap = laplacian(i,j,n,ilo,jlo,ihi,jhi,phi,facx,facy);
+    return rhs + acf*phi(i,j,0,n) - lap;
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+Real residual2r (int i, int j, int ilo, int jlo, int ihi, int jhi,
+                 Array4<Real> const& phi, Real rhs, Real acf_r, Real acf_i,
+                 Real facx, Real facy)
+{
+    Real lap = laplacian(i,j,0,ilo,jlo,ihi,jhi,phi,facx,facy);
+    return rhs + acf_r*phi(i,j,0,0) - acf_i*phi(i,j,0,1) - lap;
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+Real residual2i (int i, int j, int ilo, int jlo, int ihi, int jhi,
+                 Array4<Real> const& phi, Real rhs, Real acf_r, Real acf_i,
+                 Real facx, Real facy)
+{
+    Real lap = laplacian(i,j,1,ilo,jlo,ihi,jhi,phi,facx,facy);
+    return rhs + acf_i*phi(i,j,0,0) + acf_r*phi(i,j,0,1) - lap;
 }
 
 // res = rhs - L(phi)
 void compute_residual (Box const& box, Array4<Real> const& res,
                        Array4<Real> const& phi, Array4<Real const> const& rhs,
-                       Array4<Real const> const& acf, Real dx, Real dy)
+                       Array4<Real const> const& acf, Real dx, Real dy,
+                       int system_type, Real acf_real)
 {
     int const ilo = box.smallEnd(0);
     int const jlo = box.smallEnd(1);
@@ -99,16 +126,26 @@ void compute_residual (Box const& box, Array4<Real> const& res,
     int const jhi = box.bigEnd(1);
     Real facx = Real(1.)/(dx*dx);
     Real facy = Real(1.)/(dy*dy);
-    hpmg::ParallelFor(box, 2, [=] AMREX_GPU_DEVICE (int i, int j, int, int n) noexcept
-    {
-        res(i,j,0,n) = residual(i, j, n, ilo, jlo, ihi, jhi, phi, rhs(i,j,0,n),
-                                acf(i,j,0), facx, facy);
-    });
+    if (system_type == 1) {
+        hpmg::ParallelFor(box, 2, [=] AMREX_GPU_DEVICE (int i, int j, int, int n) noexcept
+        {
+            res(i,j,0,n) = residual1(i, j, n, ilo, jlo, ihi, jhi, phi, rhs(i,j,0,n),
+                                     acf(i,j,0), facx, facy);
+        });
+    } else {
+        hpmg::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+        {
+            res(i,j,0,0) = residual2r(i, j, ilo, jlo, ihi, jhi, phi, rhs(i,j,0,0),
+                                      acf_real, acf(i,j,0), facx, facy);
+            res(i,j,0,1) = residual2i(i, j, ilo, jlo, ihi, jhi, phi, rhs(i,j,0,1),
+                                      acf_real, acf(i,j,0), facx, facy);
+        });
+    }
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void gs (int i, int j, int n, int ilo, int jlo, int ihi, int jhi,
-         Array4<Real> const& phi, Real rhs, Real acf, Real facx, Real facy)
+void gs1 (int i, int j, int n, int ilo, int jlo, int ihi, int jhi,
+          Array4<Real> const& phi, Real rhs, Real acf, Real facx, Real facy)
 {
     Real lap;
     Real c0 = -(acf+Real(2.)*(facx+facy));
@@ -133,9 +170,18 @@ void gs (int i, int j, int n, int ilo, int jlo, int ihi, int jhi,
     phi(i,j,0,n) = (rhs - lap) / c0;
 }
 
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void gs2 (int i, int j, int ilo, int jlo, int ihi, int jhi,
+          Array4<Real> const& phi, Real rhs_r, Real rhs_i,
+          Real ar, Real ai, Real facx, Real facy)
+{
+    gs1(i,j,0,ilo,jlo,ihi,jhi,phi, rhs_r-ai*phi(i,j,0,1), ar, facx, facy);
+    gs1(i,j,1,ilo,jlo,ihi,jhi,phi, rhs_i+ai*phi(i,j,0,0), ar, facx, facy);
+}
+
 void gsrb (int icolor, Box const& box, Array4<Real> const& phi,
            Array4<Real const> const& rhs, Array4<Real const> const& acf,
-           Real dx, Real dy)
+           Real dx, Real dy, int system_type, Real acf_real)
 {
     int const ilo = box.smallEnd(0);
     int const jlo = box.smallEnd(1);
@@ -143,12 +189,22 @@ void gsrb (int icolor, Box const& box, Array4<Real> const& phi,
     int const jhi = box.bigEnd(1);
     Real facx = Real(1.)/(dx*dx);
     Real facy = Real(1.)/(dy*dy);
-    hpmg::ParallelFor(box, 2, [=] AMREX_GPU_DEVICE (int i, int j, int, int n) noexcept
-    {
-        if ((i+j+icolor)%2 == 0) {
-            gs(i, j, n, ilo, jlo, ihi, jhi, phi, rhs(i,j,0,n), acf(i,j,0), facx, facy);
-        }
-    });
+    if (system_type == 1) {
+        hpmg::ParallelFor(box, 2, [=] AMREX_GPU_DEVICE (int i, int j, int, int n) noexcept
+        {
+            if ((i+j+icolor)%2 == 0) {
+                gs1(i, j, n, ilo, jlo, ihi, jhi, phi, rhs(i,j,0,n), acf(i,j,0), facx, facy);
+            }
+        });
+    } else {
+        hpmg::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+        {
+            if ((i+j+icolor)%2 == 0) {
+                gs2(i, j, ilo, jlo, ihi, jhi, phi, rhs(i,j,0,0), rhs(i,j,0,1),
+                    acf_real, acf(i,j,0), facx, facy);
+            }
+        });
+    }
 }
 
 void restriction (Box const& box, Array4<Real> const& crse, Array4<Real const> const& fine)
@@ -172,6 +228,175 @@ void interpolation (Box const& box, Array4<Real> const& fine, Array4<Real const>
         fine(i,j,0,n) += crse(ic,jc,0,n);
     });
 }
+
+#if defined(AMREX_USE_GPU)
+
+#if defined(AMREX_USE_DPCPP)
+#define HPMG_SYNCTHREADS item.barrier(sycl::access::fence_space::global_and_local)
+#else
+#define HPMG_SYNCTHREADS __syncthreads()
+#endif
+
+template <int NS, typename FGS, typename FRES>
+void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
+                      Array4<Real> const* res, Array4<Real> const* cor,
+                      Array4<Real> const* rescor, int nlevs,
+                      FGS&& fgs, FRES&& fres)
+{
+    static_assert(n_cell_single*n_cell_single <= 1024, "n_cell_single is too big");
+#if defined(AMREX_USE_DPCPP)
+    amrex::launch(1, 1024, Gpu::gpuStream(),
+    [=] (sycl::nd_item<1> const& item) noexcept
+#else
+    amrex::launch_global<1024><<<1, 1024, 0, Gpu::gpuStream()>>>(
+    [=] AMREX_GPU_DEVICE () noexcept
+#endif
+    {
+        Real facx = Real(1.)/(dx0*dx0);
+        Real facy = Real(1.)/(dy0*dy0);
+        int lenx = cor[0].end.x - cor[0].begin.x;
+        int leny = cor[0].end.y - cor[0].begin.y;
+        int ncells = lenx*leny;
+#if defined(AMREX_USE_DPCPP)
+        const int icell = item.get_local_linear_id();
+#else
+        const int icell = threadIdx.x;
+#endif
+
+        for (int ilev = 0; ilev < nlevs-1; ++ilev) {
+            if (icell < ncells) {
+                cor[ilev].p[icell] = Real(0.);
+                cor[ilev].p[icell+ncells] = Real(0.);
+            }
+            HPMG_SYNCTHREADS;
+
+            for (int is = 0; is < 4; ++is) {
+                if (icell < ncells) {
+                    int j = icell /   lenx;
+                    int i = icell - j*lenx;
+                    j += cor[ilev].begin.y;
+                    i += cor[ilev].begin.x;
+                    if ((i+j+is)%2 == 0) {
+                        fgs(i, j,
+                            cor[ilev].begin.x, cor[ilev].begin.y,
+                            cor[ilev].end.x-1, cor[ilev].end.y-1,
+                            cor[ilev],
+                            res[ilev](i,j,0,0),
+                            res[ilev](i,j,0,1),
+                            acf[ilev](i,j,0), facx, facy);
+                    }
+                }
+                HPMG_SYNCTHREADS;
+            }
+
+            if (icell < ncells) {
+                int j = icell /   lenx;
+                int i = icell - j*lenx;
+                j += cor[ilev].begin.y;
+                i += cor[ilev].begin.x;
+                fres(i, j,
+                     rescor[ilev](i,j,0,0),
+                     rescor[ilev](i,j,0,1),
+                     cor[ilev].begin.x, cor[ilev].begin.y,
+                     cor[ilev].end.x-1, cor[ilev].end.y-1,
+                     cor[ilev],
+                     res[ilev](i,j,0,0),
+                     res[ilev](i,j,0,1),
+                     acf[ilev](i,j,0), facx, facy);
+            }
+            HPMG_SYNCTHREADS;
+
+            lenx = cor[ilev+1].end.x - cor[ilev+1].begin.x;
+            leny = cor[ilev+1].end.y - cor[ilev+1].begin.y;
+            ncells = lenx*leny;
+            if (icell < ncells) {
+                int j = icell /   lenx;
+                int i = icell - j*lenx;
+                j += cor[ilev+1].begin.y;
+                i += cor[ilev+1].begin.x;
+                for (int n = 0; n < 2; ++n) {
+                    res[ilev+1](i,j,0,n) = Real(0.25)*(rescor[ilev](2*i  ,2*j  ,0,n) +
+                                                       rescor[ilev](2*i+1,2*j  ,0,n) +
+                                                       rescor[ilev](2*i  ,2*j+1,0,n) +
+                                                       rescor[ilev](2*i+1,2*j+1,0,n));
+                }
+            }
+            HPMG_SYNCTHREADS;
+
+            facx *= Real(0.25);
+            facy *= Real(0.25);
+        }
+
+        // bottom
+        {
+            const int ilev = nlevs-1;
+            if (icell < ncells) {
+                cor[ilev].p[icell] = Real(0.);
+                cor[ilev].p[icell+ncells] = Real(0.);
+            }
+            HPMG_SYNCTHREADS;
+
+            for (int is = 0; is < NS; ++is) {
+                if (icell < ncells) {
+                    int j = icell /   lenx;
+                    int i = icell - j*lenx;
+                    j += cor[ilev].begin.y;
+                    i += cor[ilev].begin.x;
+                    if ((i+j+is)%2 == 0) {
+                        fgs(i, j,
+                            cor[ilev].begin.x, cor[ilev].begin.y,
+                            cor[ilev].end.x-1, cor[ilev].end.y-1,
+                            cor[ilev],
+                            res[ilev](i,j,0,0),
+                            res[ilev](i,j,0,1),
+                            acf[ilev](i,j,0), facx, facy);
+                    }
+                }
+                HPMG_SYNCTHREADS;
+            }
+        }
+
+        for (int ilev = nlevs-2; ilev >=0; --ilev) {
+            lenx = cor[ilev].end.x - cor[ilev].begin.x;
+            leny = cor[ilev].end.y - cor[ilev].begin.y;
+            ncells = lenx*leny;
+            facx *= Real(4.);
+            facy *= Real(4.);
+
+            if (icell < ncells) {
+                int j = icell /   lenx;
+                int i = icell - j*lenx;
+                j += cor[ilev].begin.y;
+                i += cor[ilev].begin.x;
+                int ic = amrex::coarsen(i,2);
+                int jc = amrex::coarsen(j,2);
+                cor[ilev](i,j,0,0) += cor[ilev+1](ic,jc,0,0);
+                cor[ilev](i,j,0,1) += cor[ilev+1](ic,jc,0,1);
+            }
+
+            for (int is = 0; is < 4; ++is) {
+                HPMG_SYNCTHREADS;
+                if (icell < ncells) {
+                    int j = icell /   lenx;
+                    int i = icell - j*lenx;
+                    j += cor[ilev].begin.y;
+                    i += cor[ilev].begin.x;
+                    if ((i+j+is)%2 == 0) {
+                        fgs(i, j,
+                            cor[ilev].begin.x, cor[ilev].begin.y,
+                            cor[ilev].end.x-1, cor[ilev].end.y-1,
+                            cor[ilev],
+                            res[ilev](i,j,0,0),
+                            res[ilev](i,j,0,1),
+                            acf[ilev](i,j,0), facx, facy);
+                    }
+                }
+            }
+        }
+    });
+}
+
+#endif // AMREX_USE_GPU
 
 } // namespace {}
 
@@ -251,19 +476,35 @@ MultiGrid::MultiGrid (Geometry const& geom)
 }
 
 void
-MultiGrid::solve (FArrayBox& a_sol, FArrayBox const& a_rhs, FArrayBox const& a_acf,
-                  Real const tol_rel, Real const tol_abs, int const nummaxiter,
-                  int const verbose)
+MultiGrid::solve1 (FArrayBox& a_sol, FArrayBox const& a_rhs, FArrayBox const& a_acf,
+                   Real const tol_rel, Real const tol_abs, int const nummaxiter,
+                   int const verbose)
 {
-    HIPACE_PROFILE("hpmg::MultiGrid::solve()");
+    HIPACE_PROFILE("hpmg::MultiGrid::solve1()");
+    m_system_type = 1;
+    solve_doit(a_sol, a_rhs, a_acf, tol_rel, tol_abs, nummaxiter, verbose);
+}
 
+void
+MultiGrid::solve2 (FArrayBox& a_sol, FArrayBox const& a_rhs,
+                   Real const a_acf_real, FArrayBox const& a_acf_imag,
+                   Real const tol_rel, Real const tol_abs,
+                   int const nummaxiter, int const verbose)
+{
+    HIPACE_PROFILE("hpmg::MultiGrid::solve2()");
+    m_system_type = 2;
+    m_acf_real = a_acf_real;
+    solve_doit(a_sol, a_rhs, a_acf_imag, tol_rel, tol_abs, nummaxiter, verbose);
+}
+
+void
+MultiGrid::solve_doit (FArrayBox& a_sol, FArrayBox const& a_rhs, FArrayBox const& a_acf,
+                       Real const tol_rel, Real const tol_abs, int const nummaxiter,
+                       int const verbose)
+{
     AMREX_ALWAYS_ASSERT(amrex::makeSlab(a_rhs.box(),2,0) == m_domain.front() &&
                         amrex::makeSlab(a_acf.box(),2,0) == m_domain.front() &&
                         a_sol.nComp() >= 2 && a_rhs.nComp() >= 2);
-
-#ifdef AMREX_USE_GPU
-    Gpu::Device::setStreamIndex(0); // Use non-null stream
-#endif
 
     m_sol = FArrayBox(amrex::makeSlab(a_sol.box(), 2, 0), 2, a_sol.dataPtr());
     m_rhs = FArrayBox(amrex::makeSlab(a_rhs.box(), 2, 0), 2, a_rhs.dataPtr());
@@ -271,7 +512,8 @@ MultiGrid::solve (FArrayBox& a_sol, FArrayBox const& a_rhs, FArrayBox const& a_a
     average_down_acoef(FArrayBox(amrex::makeSlab(a_acf.box(), 2, 0), 1, a_acf.dataPtr()));
 
     compute_residual(m_domain[0], m_res[0].array(), m_sol.array(),
-                     m_rhs.const_array(), m_acf[0].const_array(), m_dx, m_dy);
+                     m_rhs.const_array(), m_acf[0].const_array(), m_dx, m_dy,
+                     m_system_type, m_acf_real);
 
     Real resnorm0, rhsnorm0;
     {
@@ -320,7 +562,9 @@ MultiGrid::solve (FArrayBox& a_sol, FArrayBox const& a_rhs, FArrayBox const& a_a
             vcycle();
 
             compute_residual(m_domain[0], m_res[0].array(), m_sol.array(),
-                             m_rhs.const_array(), m_acf[0].const_array(), m_dx, m_dy);
+                             m_rhs.const_array(), m_acf[0].const_array(), m_dx, m_dy,
+                             m_system_type, m_acf_real);
+
             Real const* pres0 = m_res[0].dataPtr();
             norminf = Reduce::Max<Real>(m_domain[0].numPts()*2,
                                         [=] AMREX_GPU_DEVICE (Long i) -> Real
@@ -359,17 +603,17 @@ MultiGrid::solve (FArrayBox& a_sol, FArrayBox const& a_rhs, FArrayBox const& a_a
             amrex::Abort("hpmg failed");
         }
     }
-
-#ifdef AMREX_USE_GPU
-    Gpu::Device::setStreamIndex(-1); // reset stream
-#endif
 }
 
 void
 MultiGrid::vcycle ()
 {
 #if defined(AMREX_USE_CUDA)
-    if (!m_cuda_graph_vcycle_created) {
+    const int igraph = m_system_type-1;
+    bool& graph_created = m_cuda_graph_vcycle_created[igraph];
+    cudaGraph_t& graph = m_cuda_graph_vcycle[igraph];
+    cudaGraphExec_t& graph_exe = m_cuda_graph_exe_vcycle[igraph];
+    if (!graph_created) {
     cudaStreamBeginCapture(Gpu::gpuStream(), cudaStreamCaptureModeGlobal);
 #endif
 
@@ -383,12 +627,14 @@ MultiGrid::vcycle ()
         Real dy = m_dy * fac;
         for (int is = 0; is < 4; ++is) {
             gsrb(is, m_domain[ilev], m_cor[ilev].array(),
-                 m_res[ilev].const_array(), m_acf[ilev].const_array(), dx, dy);
+                 m_res[ilev].const_array(), m_acf[ilev].const_array(), dx, dy,
+                 m_system_type, m_acf_real);
         }
 
         // rescor = res - L(cor)
         compute_residual(m_domain[ilev], m_rescor[ilev].array(), m_cor[ilev].array(),
-                         m_res[ilev].const_array(), m_acf[ilev].const_array(), dx, dy);
+                         m_res[ilev].const_array(), m_acf[ilev].const_array(), dx, dy,
+                         m_system_type, m_acf_real);
 
         // res[ilev+1] = R(rescor[ilev])
         restriction(m_domain[ilev+1], m_res[ilev+1].array(), m_rescor[ilev].const_array());
@@ -405,16 +651,17 @@ MultiGrid::vcycle ()
         Real dy = m_dy * fac;
         for (int is = 0; is < 4; ++is) {
             gsrb(is, m_domain[ilev], m_cor[ilev].array(),
-                 m_res[ilev].const_array(), m_acf[ilev].const_array(), dx, dy);
+                 m_res[ilev].const_array(), m_acf[ilev].const_array(), dx, dy,
+                 m_system_type, m_acf_real);
         }
     }
 
 #if defined(AMREX_USE_CUDA)
-    cudaStreamEndCapture(Gpu::gpuStream(), &m_cuda_graph_vcycle);
-    cudaGraphInstantiate(&m_cuda_graph_exe_vcycle, m_cuda_graph_vcycle, NULL, NULL, 0);
-    m_cuda_graph_vcycle_created = true;
+    cudaStreamEndCapture(Gpu::gpuStream(), &graph);
+    cudaGraphInstantiate(&graph_exe, graph, NULL, NULL, 0);
+    graph_created = true;
     }
-    cudaGraphLaunch(m_cuda_graph_exe_vcycle, Gpu::gpuStream());
+    cudaGraphLaunch(graph_exe, Gpu::gpuStream());
 #endif
 
     auto const& sol = m_sol.array();
@@ -437,154 +684,52 @@ MultiGrid::bottomsolve ()
     Array4<amrex::Real> const* res = m_res_a;
     Array4<amrex::Real> const* cor = m_cor_a;
     Array4<amrex::Real> const* rescor = m_rescor_a;
+    Real acf_real = m_acf_real;
     int nlevs = m_num_single_block_levels;
-#if defined(AMREX_USE_DPCPP)
-    amrex::Abort("DPCPP todo");
-#else
-    static_assert(n_cell_single*n_cell_single <= 1024, "n_cell_single is too big");
-    amrex::launch_global<1024><<<1, 1024, 0, Gpu::gpuStream()>>>(
-    [=] AMREX_GPU_DEVICE () noexcept
-    {
-        Real facx = Real(1.)/(dx0*dx0);
-        Real facy = Real(1.)/(dy0*dy0);
-        int lenx = cor[0].end.x - cor[0].begin.x;
-        int leny = cor[0].end.y - cor[0].begin.y;
-        int ncells = lenx*leny;
-        const int icell = threadIdx.x;
 
-        for (int ilev = 0; ilev < nlevs-1; ++ilev) {
-            if (icell < ncells) {
-                cor[ilev].p[icell] = Real(0.);
-                cor[ilev].p[icell+ncells] = Real(0.);
-            }
-            __syncthreads();
-
-            for (int is = 0; is < 4; ++is) {
-                if (icell < ncells) {
-                    int j = icell /   lenx;
-                    int i = icell - j*lenx;
-                    j += cor[ilev].begin.y;
-                    i += cor[ilev].begin.x;
-                    if ((i+j+is)%2 == 0) {
-                        for (int n = 0; n < 2; ++n) {
-                            gs(i, j, n,
-                               cor[ilev].begin.x, cor[ilev].begin.y,
-                               cor[ilev].end.x-1, cor[ilev].end.y-1,
-                               cor[ilev], res[ilev](i,j,0,n), acf[ilev](i,j,0), facx, facy);
-                        }
-                    }
-                }
-                __syncthreads();
-            }
-
-            if (icell < ncells) {
-                int j = icell /   lenx;
-                int i = icell - j*lenx;
-                j += cor[ilev].begin.y;
-                i += cor[ilev].begin.x;
-                for (int n = 0; n < 2; ++n) {
-                    rescor[ilev](i,j,0,n) =
-                        residual(i, j, n,
-                                 cor[ilev].begin.x, cor[ilev].begin.y,
-                                 cor[ilev].end.x-1, cor[ilev].end.y-1,
-                                 cor[ilev], res[ilev](i,j,0,n), acf[ilev](i,j,0), facx, facy);
-                }
-            }
-            __syncthreads();
-
-            lenx = cor[ilev+1].end.x - cor[ilev+1].begin.x;
-            leny = cor[ilev+1].end.y - cor[ilev+1].begin.y;
-            ncells = lenx*leny;
-            if (icell < ncells) {
-                int j = icell /   lenx;
-                int i = icell - j*lenx;
-                j += cor[ilev+1].begin.y;
-                i += cor[ilev+1].begin.x;
-                for (int n = 0; n < 2; ++n) {
-                    res[ilev+1](i,j,0,n) = Real(0.25)*(rescor[ilev](2*i  ,2*j  ,0,n) +
-                                                       rescor[ilev](2*i+1,2*j  ,0,n) +
-                                                       rescor[ilev](2*i  ,2*j+1,0,n) +
-                                                       rescor[ilev](2*i+1,2*j+1,0,n));
-                }
-            }
-            __syncthreads();
-
-            facx *= Real(0.25);
-            facy *= Real(0.25);
-        }
-
-        // bottom
-        {
-            const int ilev = nlevs-1;
-            if (icell < ncells) {
-                cor[ilev].p[icell] = Real(0.);
-                cor[ilev].p[icell+ncells] = Real(0.);
-            }
-            __syncthreads();
-
-            for (int is = 0; is < nsweeps; ++is) {
-                if (icell < ncells) {
-                    int j = icell /   lenx;
-                    int i = icell - j*lenx;
-                    j += cor[ilev].begin.y;
-                    i += cor[ilev].begin.x;
-                    if ((i+j+is)%2 == 0) {
-                        for (int n = 0; n < 2; ++n) {
-                            gs(i, j, n,
-                               cor[ilev].begin.x, cor[ilev].begin.y,
-                               cor[ilev].end.x-1, cor[ilev].end.y-1,
-                               cor[ilev], res[ilev](i,j,0,n), acf[ilev](i,j,0), facx, facy);
-                        }
-                    }
-                }
-                __syncthreads();
-            }
-        }
-
-        for (int ilev = nlevs-2; ilev >=0; --ilev) {
-            lenx = cor[ilev].end.x - cor[ilev].begin.x;
-            leny = cor[ilev].end.y - cor[ilev].begin.y;
-            ncells = lenx*leny;
-            facx *= Real(4.);
-            facy *= Real(4.);
-
-            if (icell < ncells) {
-                int j = icell /   lenx;
-                int i = icell - j*lenx;
-                j += cor[ilev].begin.y;
-                i += cor[ilev].begin.x;
-                int ic = amrex::coarsen(i,2);
-                int jc = amrex::coarsen(j,2);
-                cor[ilev](i,j,0,0) += cor[ilev+1](ic,jc,0,0);
-                cor[ilev](i,j,0,1) += cor[ilev+1](ic,jc,0,1);
-            }
-
-            for (int is = 0; is < 4; ++is) {
-                __syncthreads();
-                if (icell < ncells) {
-                    int j = icell /   lenx;
-                    int i = icell - j*lenx;
-                    j += cor[ilev].begin.y;
-                    i += cor[ilev].begin.x;
-                    if ((i+j+is)%2 == 0) {
-                        for (int n = 0; n < 2; ++n) {
-                            gs(i, j, n,
-                               cor[ilev].begin.x, cor[ilev].begin.y,
-                               cor[ilev].end.x-1, cor[ilev].end.y-1,
-                               cor[ilev], res[ilev](i,j,0,n), acf[ilev](i,j,0), facx, facy);
-                        }
-                    }
-                }
-            }
-        }
-    });
-#endif
+    if (m_system_type == 1) {
+        bottomsolve_gpu<nsweeps>(dx0, dy0, acf, res, cor, rescor, nlevs,
+            [=] AMREX_GPU_DEVICE (int i, int j, int ilo, int jlo, int ihi, int jhi,
+                                  Array4<Real> const& phi, Real rhs0, Real rhs1,
+                                  Real acf, Real facx, Real facy)
+            {
+                gs1(i, j, 0, ilo, jlo, ihi, jhi, phi, rhs0, acf, facx, facy);
+                gs1(i, j, 1, ilo, jlo, ihi, jhi, phi, rhs1, acf, facx, facy);
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j, Real& res0, Real& res1,
+                                  int ilo, int jlo, int ihi, int jhi,
+                                  Array4<Real> const& phi, Real rhs0, Real rhs1,
+                                  Real acf, Real facx, Real facy)
+            {
+                res0 = residual1(i, j, 0, ilo, jlo, ihi, jhi, phi, rhs0, acf, facx, facy);
+                res1 = residual1(i, j, 1, ilo, jlo, ihi, jhi, phi, rhs1, acf, facx, facy);
+            });
+    } else {
+        bottomsolve_gpu<nsweeps>(dx0, dy0, acf, res, cor, rescor, nlevs,
+            [=] AMREX_GPU_DEVICE (int i, int j, int ilo, int jlo, int ihi, int jhi,
+                                  Array4<Real> const& phi, Real rhs0, Real rhs1,
+                                  Real acf, Real facx, Real facy)
+            {
+                gs2(i, j, ilo, jlo, ihi, jhi, phi, rhs0, rhs1, acf_real, acf, facx, facy);
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j, Real& res0, Real& res1,
+                                  int ilo, int jlo, int ihi, int jhi,
+                                  Array4<Real> const& phi, Real rhs_r, Real rhs_i,
+                                  Real acf, Real facx, Real facy)
+            {
+                res0 = residual2r(i, j, ilo, jlo, ihi, jhi, phi, rhs_r, acf_real, acf,
+                                  facx, facy);
+                res1 = residual2i(i, j, ilo, jlo, ihi, jhi, phi, rhs_i, acf_real, acf,
+                                  facx, facy);
+            });
+    }
 #else
     const int ilev = m_single_block_level_begin;
     m_cor[ilev].setVal(Real(0.));
     for (int is = 0; is < nsweeps; ++is) {
         gsrb(is, m_domain[ilev], m_cor[ilev].array(),
-             m_res[ilev].const_array(), m_acf[ilev].const_array(), dx0, dy0);
+             m_res[ilev].const_array(), m_acf[ilev].const_array(), dx0, dy0,
+             m_system_type, m_acf_real);
     }
 #endif
 }
@@ -618,22 +763,29 @@ MultiGrid::average_down_acoef (FArrayBox const& a_acf)
     }
 
 #if defined(AMREX_USE_GPU)
-#if defined (AMREX_USE_DPCPP)
-    amrex::Abort("DPCPP todo");
-#endif
-
     if (m_num_single_block_levels > 1) {
         Array4<Real> const* acf = m_acf_a;
         int nlevels = m_num_single_block_levels;
 
+#if defined(AMREX_USE_DPCPP)
+        amrex::launch(1, 1024, Gpu::gpuStream(),
+        [=] (sycl::nd_item<1> const& item) noexcept
+#else
         amrex::launch_global<1024><<<1, 1024, 0, Gpu::gpuStream()>>>(
         [=] AMREX_GPU_DEVICE () noexcept
+#endif
         {
             for (int ilev = 1; ilev < nlevels; ++ilev) {
                 const int lenx = acf[ilev].end.x - acf[ilev].begin.x;
                 const int leny = acf[ilev].end.y - acf[ilev].begin.y;
                 const int ncells = lenx*leny;
+#if defined(AMREX_USE_DPCPP)
+                for (int icell = item.get_local_range(0)*item.get_group_linear_id()
+                         + item.get_local_linear_id(),
+                         stride = item.get_local_range(0)*item.get_group_range(0);
+#else
                 for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
+#endif
                      icell < ncells; icell += stride) {
                     int j = icell /   lenx;
                     int i = icell - j*lenx;
@@ -644,7 +796,7 @@ MultiGrid::average_down_acoef (FArrayBox const& a_acf)
                                                    acf[ilev-1](2*i  ,2*j+1,0) +
                                                    acf[ilev-1](2*i+1,2*j+1,0));
                 }
-                __syncthreads();
+                HPMG_SYNCTHREADS;
             }
         });
     }
@@ -666,9 +818,11 @@ MultiGrid::~MultiGrid ()
         cudaGraphDestroy(m_cuda_graph_acf);
         cudaGraphExecDestroy(m_cuda_graph_exe_acf);
     }
-    if (m_cuda_graph_vcycle_created) {
-        cudaGraphDestroy(m_cuda_graph_vcycle);
-        cudaGraphExecDestroy(m_cuda_graph_exe_vcycle);
+    for (int i = 0; i < m_num_single_block_levels; ++i) {
+        if (m_cuda_graph_vcycle_created[i]) {
+            cudaGraphDestroy(m_cuda_graph_vcycle[i]);
+            cudaGraphExecDestroy(m_cuda_graph_exe_vcycle[i]);
+        }
     }
 #endif
 }


### PR DESCRIPTION
This extends the MultiGrid solver for Lap(sol) - a * sol = rhs to complex
numbers.  This can be used in simulating a laser pulse.  The solver has been
verified on Nvidia, AMD and Intel GPUs with a standalone test code.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
