### PR TITLE
ensure that argument of sqrt in adaptive time step is positive

### DIFF
--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -161,9 +161,9 @@ AdaptiveTimeStep::Calculate (amrex::Real& dt, MultiBeam& beams, amrex::Real plas
                 "The sum of all weights is 0! Probably no beam particles are initialized");
             const amrex::Real mean_uz = m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUz]
                                            /m_timestep_data[ibeam][WhichDouble::SumWeights];
-            const amrex::Real sigma_uz = sqrt(m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared]
+            const amrex::Real sigma_uz = std::sqrt(std::abs(m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared]
                                               /m_timestep_data[ibeam][WhichDouble::SumWeights]
-                                              - mean_uz*mean_uz);
+                                              - mean_uz*mean_uz));
             const amrex::Real sigma_uz_dev = mean_uz - 4.*sigma_uz;
             const amrex::Real max_supported_uz = 1e30;
             const amrex::Real chosen_min_uz = std::min(std::max(sigma_uz_dev,


### PR DESCRIPTION


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
