### PR TITLE
fix Hipace Profiler Wrapper

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -307,8 +307,6 @@ public:
     static bool m_do_beam_jx_jy_deposition;
     /** Whether the jz-c*rho contribution of the beam is computed and used. If not, jz-c*rho=0 is assumed */
     static bool m_do_beam_jz_minus_rho;
-    /** Whether to call amrex::Gpu::synchronize() around all profiler region */
-    static int m_do_device_synchronize;
     /** Whether to use tiling for particle operations */
     static bool m_do_tiling;
     /** How much the box is coarsened for beam injection, to avoid exceeding max int in cell count.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -51,7 +51,6 @@ int Hipace::m_predcorr_max_iterations = 30;
 amrex::Real Hipace::m_predcorr_B_mixing_factor = 0.05;
 bool Hipace::m_do_beam_jx_jy_deposition = true;
 bool Hipace::m_do_beam_jz_minus_rho = false;
-int Hipace::m_do_device_synchronize = 0;
 int Hipace::m_beam_injection_cr = 1;
 amrex::Real Hipace::m_external_ExmBy_slope = 0.;
 amrex::Real Hipace::m_external_Ez_slope = 0.;
@@ -131,7 +130,7 @@ Hipace::Hipace () :
     queryWithParser(pph, "beam_injection_cr", m_beam_injection_cr);
     queryWithParser(pph, "do_beam_jx_jy_deposition", m_do_beam_jx_jy_deposition);
     queryWithParser(pph, "do_beam_jz_minus_rho", m_do_beam_jz_minus_rho);
-    queryWithParser(pph, "do_device_synchronize", m_do_device_synchronize);
+    queryWithParser(pph, "do_device_synchronize", DO_DEVICE_SYNCHRONIZE);
     queryWithParser(pph, "external_ExmBy_slope", m_external_ExmBy_slope);
     queryWithParser(pph, "external_Ez_slope", m_external_Ez_slope);
     queryWithParser(pph, "external_Ez_uniform", m_external_Ez_uniform);

--- a/src/utils/HipaceProfilerWrapper.H
+++ b/src/utils/HipaceProfilerWrapper.H
@@ -21,13 +21,13 @@
 #include <AMReX_GpuDevice.H>
 
 /** Whether to call amrex::Gpu::synchronize() around all profiler region */
-inline int m_do_device_synchronize = 0;
+inline int DO_DEVICE_SYNCHRONIZE = 0;
 
 template<int detail_level>
 AMREX_FORCE_INLINE
 void doDeviceSynchronize ()
 {
-    if ( m_do_device_synchronize >= detail_level )
+    if ( DO_DEVICE_SYNCHRONIZE >= detail_level )
         amrex::Gpu::synchronize();
 }
 

--- a/src/utils/HipaceProfilerWrapper.H
+++ b/src/utils/HipaceProfilerWrapper.H
@@ -20,11 +20,14 @@
 #include <AMReX_BLProfiler.H>
 #include <AMReX_GpuDevice.H>
 
+/** Whether to call amrex::Gpu::synchronize() around all profiler region */
+inline int m_do_device_synchronize = 0;
+
 template<int detail_level>
 AMREX_FORCE_INLINE
 void doDeviceSynchronize ()
 {
-    if ( Hipace::m_do_device_synchronize >= detail_level )
+    if ( m_do_device_synchronize >= detail_level )
         amrex::Gpu::synchronize();
 }
 
@@ -37,18 +40,18 @@ struct synchronizeOnDestruct {
     }
 };
 
-#define HIPACE_PROFILE(fname) doDeviceSynchronize<1>(); BL_PROFILE(fname); synchronizeOnDestruct<1> SYNC_SCOPE{}
+#define HIPACE_PROFILE(fname) doDeviceSynchronize<1>(); BL_PROFILE(fname); synchronizeOnDestruct<1> BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__){}
 #define HIPACE_PROFILE_VAR(fname, vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}
 #define HIPACE_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<1> SYNC_V_##vname{}
 #define HIPACE_PROFILE_VAR_START(vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR_START(vname)
 #define HIPACE_PROFILE_VAR_STOP(vname) doDeviceSynchronize<1>(); BL_PROFILE_VAR_STOP(vname)
-#define HIPACE_PROFILE_REGION(rname) doDeviceSynchronize<1>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<1> SYNC_R_##rname{}
+#define HIPACE_PROFILE_REGION(rname) doDeviceSynchronize<1>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<1> BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){}
 
-#define HIPACE_DETAIL_PROFILE(fname) doDeviceSynchronize<2>(); BL_PROFILE(fname); synchronizeOnDestruct<2> SYNC_SCOPE{}
+#define HIPACE_DETAIL_PROFILE(fname) doDeviceSynchronize<2>(); BL_PROFILE(fname); synchronizeOnDestruct<2> BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__){}
 #define HIPACE_DETAIL_PROFILE_VAR(fname, vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
 #define HIPACE_DETAIL_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
 #define HIPACE_DETAIL_PROFILE_VAR_START(vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR_START(vname)
 #define HIPACE_DETAIL_PROFILE_VAR_STOP(vname) doDeviceSynchronize<2>(); BL_PROFILE_VAR_STOP(vname)
-#define HIPACE_DETAIL_PROFILE_REGION(rname) doDeviceSynchronize<2>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<2> SYNC_R_##rname{}
+#define HIPACE_DETAIL_PROFILE_REGION(rname) doDeviceSynchronize<2>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<2> BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){}
 
 #endif // HIPACE_PROFILERWRAPPER_H_


### PR DESCRIPTION
Some fixes to be more robust like the version in ablastr. There is however still the issue that some cpp files include Hipace.H only through HipaceProfilerWrapper.H

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
