### PR TITLE
Fix functions using electron charge and mass

### DIFF
--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -305,8 +305,8 @@ OpenPMDWriter::SetupPos (openPMD::ParticleSpecies& currSpecies, BeamParticleCont
     // calculate the multiplier to convert from Hipace to SI units
     double hipace_to_SI_pos = 1.;
     double hipace_to_SI_weight = 1.;
-    double hipace_to_SI_momentum = phys_const_SI.m_e;
-    double hipace_to_unitSI_momentum = phys_const_SI.m_e;
+    double hipace_to_SI_momentum = beam.m_mass;
+    double hipace_to_unitSI_momentum = beam.m_mass;
     double hipace_to_SI_charge = 1.;
     double hipace_to_SI_mass = 1.;
 
@@ -319,16 +319,15 @@ OpenPMDWriter::SetupPos (openPMD::ParticleSpecies& currSpecies, BeamParticleCont
         const double kp_inv = (double)phys_const_SI.c / omega_p;
         hipace_to_SI_pos = kp_inv;
         hipace_to_SI_weight = n_0 * dx[0] * dx[1] * dx[2] * kp_inv * kp_inv * kp_inv;
-        hipace_to_SI_momentum = phys_const_SI.m_e * phys_const_SI.c;
-        hipace_to_unitSI_momentum = 1.;
+        hipace_to_SI_momentum = beam.m_mass * phys_const_SI.m_e * phys_const_SI.c;
         hipace_to_SI_charge = phys_const_SI.q_e;
         hipace_to_SI_mass = phys_const_SI.m_e;
     }
 
     // temporary workaround until openPMD-viewer does not autonormalize momentum
     if(m_openpmd_viewer_workaround) {
-        if(Hipace::m_normalized_units){
-            hipace_to_unitSI_momentum = phys_const_SI.c;
+        if(Hipace::m_normalized_units) {
+            hipace_to_unitSI_momentum = beam.m_mass * phys_const_SI.c;
         }
     }
 

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -72,7 +72,6 @@ amrex::Real
 BeamParticleContainer::InitData (const amrex::Geometry& geom)
 {
     using namespace amrex::literals;
-    PhysConst phys_const = get_phys_const();
     amrex::Real ptime {0.};
     if (m_injection_type == "fixed_ppc") {
 
@@ -136,7 +135,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 
         if (peak_density_is_specified)
         {
-            m_total_charge = m_density*phys_const.q_e;
+            m_total_charge = m_density*m_charge;
             for (int idim=0; idim<AMREX_SPACEDIM; ++idim)
             {
                 m_total_charge *= m_position_std[idim] * sqrt(2. * MathConst::pi);

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -530,6 +530,7 @@ InitBeamFromFile (const std::string input_file,
     // Determine whether to use momentum or normalized momentum as well as weight, charge or mass
     // set conversion factor appropriately
     const PhysConst phys_const_SI = make_constants_SI();
+    const PhysConst phys_const = get_phys_const();
 
     std::string name_w = "", name_ww = "";
     std::string weighting_type = "";
@@ -540,7 +541,7 @@ InitBeamFromFile (const std::string input_file,
     input_type si_to_norm_weight = 1.;
 
     if(u_is_momentum) {
-        si_to_norm_momentum = m_mass * phys_const_SI.c;
+        si_to_norm_momentum = m_mass * (phys_const_SI.m_e / phys_const.m_e) * phys_const_SI.c;
         momentum_type = "Momentum";
     }
 
@@ -552,13 +553,13 @@ InitBeamFromFile (const std::string input_file,
     else if(name_qq != "") {
         name_w = name_q;
         name_ww = name_qq;
-        si_to_norm_weight = m_charge;
+        si_to_norm_weight = m_charge * (phys_const_SI.q_e / phys_const.q_e);
         weighting_type = "Charge";
     }
     else if(name_mm != "") {
         name_w = name_m;
         name_ww = name_mm;
-        si_to_norm_weight = m_mass;
+        si_to_norm_weight = m_mass * (phys_const_SI.m_e / phys_const.m_e);
         weighting_type = "Mass";
     }
     else {
@@ -674,7 +675,6 @@ InitBeamFromFile (const std::string input_file,
 
     // input data using AddOneBeamParticle function, make necessary variables and arrays
     const int num_to_add = electrons[name_r][name_rx].getExtent()[0];
-    const PhysConst phys_const = get_phys_const();
 
     if (Hipace::HeadRank()) {
 

--- a/src/particles/BeamParticleContainerInit.cpp
+++ b/src/particles/BeamParticleContainerInit.cpp
@@ -30,14 +30,14 @@ namespace
      * \param[in] x position in x
      * \param[in] y position in y
      * \param[in] z position in z
-     * \param[in] ux momentum in x
-     * \param[in] uy momentum in y
-     * \param[in] uz momentum in z
+     * \param[in] ux gamma * beta_x
+     * \param[in] uy gamma * beta_y
+     * \param[in] uz gamma * beta_z
      * \param[in] weight weight of the single particle
      * \param[in] pid particle ID to be assigned to the particle
      * \param[in] procID processor ID to be assigned to the particle
      * \param[in] ip index of the particle
-     * \param[in] speed_of_light speed of light in SI units
+     * \param[in] speed_of_light speed of light in the current units
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void AddOneBeamParticle (
@@ -292,6 +292,7 @@ InitBeamFixedWeight (int num_to_add,
         ParticleType::NextID(pid + num_to_add);
 
         const amrex::Real duz_per_uz0_dzeta = m_duz_per_uz0_dzeta;
+        const amrex::Real single_charge = m_charge;
         amrex::ParallelForRNG(
             num_to_add,
             [=] AMREX_GPU_DEVICE (int i, const amrex::RandomEngine& engine) noexcept
@@ -311,7 +312,7 @@ InitBeamFixedWeight (int num_to_add,
                 const amrex::Real cental_x_pos = pos_mean_x(z_central);
                 const amrex::Real cental_y_pos = pos_mean_y(z_central);
 
-                amrex::Real weight = total_charge / num_to_add / phys_const.q_e;
+                amrex::Real weight = total_charge / (num_to_add * single_charge);
                 if (!do_symmetrize)
                 {
                     AddOneBeamParticle(pstruct, arrdata, cental_x_pos+x, cental_y_pos+y,
@@ -464,6 +465,7 @@ InitBeamFromFile (const std::string input_file,
                     }
                 }
                 else if(units == std::array<double,7> {1., 0., -1., 0., 0., 0., 0.}) {
+                    // proper velocity = gamma * v
                     name_u = physical_quantity.first;
                     u_is_momentum = false;
                     for( auto const& axes_direction : physical_quantity.second ) {
@@ -479,6 +481,7 @@ InitBeamFromFile (const std::string input_file,
                     }
                 }
                 else if(units == std::array<double,7> {1., 1., -1., 0., 0., 0., 0.}) {
+                    // momentum = gamma * m * v
                     name_u = physical_quantity.first;
                     u_is_momentum = true;
                     for( auto const& axes_direction : physical_quantity.second ) {
@@ -530,14 +533,14 @@ InitBeamFromFile (const std::string input_file,
 
     std::string name_w = "", name_ww = "";
     std::string weighting_type = "";
-    std::string momentum_type = "Normalized momentum";
+    std::string momentum_type = "Proper velocity";
 
     input_type si_to_norm_pos = 1.;
-    input_type si_to_norm_momentum = 1.;
+    input_type si_to_norm_momentum = phys_const_SI.c;
     input_type si_to_norm_weight = 1.;
 
     if(u_is_momentum) {
-        si_to_norm_momentum = phys_const_SI.m_e * phys_const_SI.c;
+        si_to_norm_momentum = m_mass * phys_const_SI.c;
         momentum_type = "Momentum";
     }
 
@@ -549,13 +552,13 @@ InitBeamFromFile (const std::string input_file,
     else if(name_qq != "") {
         name_w = name_q;
         name_ww = name_qq;
-        si_to_norm_weight = phys_const_SI.q_e;
+        si_to_norm_weight = m_charge;
         weighting_type = "Charge";
     }
     else if(name_mm != "") {
         name_w = name_m;
         name_ww = name_mm;
-        si_to_norm_weight = phys_const_SI.m_e;
+        si_to_norm_weight = m_mass;
         weighting_type = "Mass";
     }
     else {
@@ -692,7 +695,7 @@ InitBeamFromFile (const std::string input_file,
                                (amrex::Real)(r_x_data.get()[i] * unit_rx),
                                (amrex::Real)(r_y_data.get()[i] * unit_ry),
                                (amrex::Real)(r_z_data.get()[i] * unit_rz),
-                               (amrex::Real)(u_x_data.get()[i] * unit_ux),
+                               (amrex::Real)(u_x_data.get()[i] * unit_ux), // = gamma * beta
                                (amrex::Real)(u_y_data.get()[i] * unit_uy),
                                (amrex::Real)(u_z_data.get()[i] * unit_uz),
                                (amrex::Real)(w_w_data.get()[i] * unit_ww),

--- a/src/particles/PlasmaParticleContainer.cpp
+++ b/src/particles/PlasmaParticleContainer.cpp
@@ -142,8 +142,9 @@ PlasmaParticleContainer::ReadParameters ()
     if (temperature_is_specified) {
         const PhysConst phys_const_SI = make_constants_SI();
         for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
-            m_u_std[idim] = sqrt( (m_temperature_in_ev * phys_const_SI.q_e)
-                                /(phys_const_SI.m_e * phys_const_SI.c * phys_const_SI.c ) );
+            m_u_std[idim] = std::sqrt( (m_temperature_in_ev * phys_const_SI.q_e)
+                                       /(m_mass * (phys_const_SI.m_e / phys_const.m_e) *
+                                       phys_const_SI.c * phys_const_SI.c ) );
         }
     }
 


### PR DESCRIPTION
Generalize functions from electron specific charge and mass to the correct values of that species.
Should fix bugs related to the IO file of a proton beam.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
