### PR TITLE
Add normalized_density_factor to in-situ data, fix doxygen for v1.9.5

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -400,6 +400,21 @@ which are valid only for certain beam types, are introduced further below under
     ``sum(w), [x], [x^2], [y], [y^2], [ux], [ux^2], [uy], [uy^2], [x*ux], [y*uy], [ga], [ga^2], np``
     where "[]" stands for averaging over all particles in the current slice,
     "w" stands for weight, "ux" is the momentum in the x direction, "ga" is the Lorentz factor.
+    Averages and totals over all slices are also provided for convenience under the
+    respective ``average`` and ``total`` subcategories.
+
+    Additionally, some metadata is also available:
+    ``time, step, n_slices, charge, mass, z_lo, z_hi, normalized_density_factor``.
+    ``time`` and ``step`` refers to the physical time of the simulation and step number of the
+    current timestep.
+    ``n_slices`` equal to the number of slices in the zeta direction.
+    ``charge`` and ``mass`` relate to a single beam particle and are for example equal to the
+    electron charge and mass.
+    ``z_lo`` and ``z_hi`` are the lower and upper bounds of the z-axis of the simulation domain
+    specified in the input file and can be used to generate a z/zeta-axis for plotting.
+    ``normalized_density_factor`` is equal to ``dx * dy * dz`` in normalized units and 1 in
+    SI units. It can be used to convert ``sum(w)``, which specifies the beam density in normalized
+    units and beam weight an SI units, to the beam weight in both unit systems.
 
     The data is written to a file at ``<insitu_file_prefix>/reduced_<beam name>.<MPI rank number>.txt``.
     The in-situ diagnostics file format consists of a header part in ASCII containing a JSON object.

--- a/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
@@ -15,11 +15,7 @@
 
 namespace AnyDST
 {
-    /** \brief Extend src into a symmetrized larger array dst
-     *
-     * \param[in,out] dst destination array, odd symmetry around 0 and the middle points in x and y
-     * \param[in] src source array
-     */
+    // see WrapCuDST for documentation
     void ExpandR2R (amrex::FArrayBox& dst, amrex::FArrayBox& src)
     {
         HIPACE_DETAIL_PROFILE("AnyDST::ExpandR2R()");
@@ -49,11 +45,7 @@ namespace AnyDST
             );
     }
 
-    /** \brief Extract symmetrical src array into smaller array dst
-     *
-     * \param[in,out] dst destination array
-     * \param[in] src destination array, symmetric in x and y
-     */
+    // see WrapCuDST for documentation
     void ShrinkC2R (amrex::FArrayBox& dst, amrex::BaseFab<amrex::GpuComplex<amrex::Real>>& src)
     {
         HIPACE_DETAIL_PROFILE("AnyDST::ShrinkC2R()");
@@ -73,15 +65,7 @@ namespace AnyDST
             );
     }
 
-    /** \brief Make Complex array out of Real array to prepare for fft.
-     * out[idx] = -in[2*idx-2] + in[2*idx] + i*in[2*idx-1] for each column with
-     * in[-1] = 0; in[-2] = -in[0]; in[n_data] = 0; in[n_data+1] = -in[n_data-1]
-     *
-     * \param[in] in input real array
-     * \param[out] out output complex array
-     * \param[in] n_data number of (contiguous) rows in position matrix
-     * \param[in] n_batch number of (strided) columns in position matrix
-     */
+    // see WrapCuDST for documentation
     void ToComplex (const amrex::Real* const AMREX_RESTRICT in,
                     amrex::GpuComplex<amrex::Real>* const AMREX_RESTRICT out,
                     const int n_data, const int n_batch)
@@ -116,14 +100,7 @@ namespace AnyDST
         }
     }
 
-    /** \brief Complex to Real fft for every column of the input matrix.
-     * The output Matrix has its indexes reversed compared to some other libraries
-     *
-     * \param[in] plan cuda fft plan for transformation
-     * \param[in] in input complex array
-     * \param[out] out output real array
-     * \param[in] execinfo execution info containing gpu stream and work buffer
-     */
+    // see WrapCuDST for documentation
     void C2Rfft (AnyFFT::VendorFFTPlan& plan, amrex::GpuComplex<amrex::Real>* AMREX_RESTRICT in,
                  amrex::Real* const AMREX_RESTRICT out, rocfft_execution_info execinfo)
     {
@@ -137,15 +114,7 @@ namespace AnyDST
         RocFFTUtils::assert_rocfft_status("rocfft_execute", result);
     }
 
-    /** \brief Make Sine-space Real array out of array from fft.
-     * out[idx] = 0.5 *(in[n_data-idx] - in[idx+1] + (in[n_data-idx] + in[idx+1])/
-     * (2*sin((idx+1)*pi/(n_data+1)))) for each column
-     *
-     * \param[in] in input real array
-     * \param[out] out output real array
-     * \param[in] n_data number of (contiguous) rows in position matrix
-     * \param[in] n_batch number of (strided) columns in position matrix
-     */
+    // see WrapCuDST for documentation
     void ToSine (const amrex::Real* const AMREX_RESTRICT in, amrex::Real* const AMREX_RESTRICT out,
                  const int n_data, const int n_batch)
     {
@@ -174,14 +143,7 @@ namespace AnyDST
             });
     }
 
-    /** \brief Transpose input matrix
-     * out[idy][idx] = in[idx][idy]
-     *
-     * \param[in] in input real array
-     * \param[out] out output real array
-     * \param[in] n_data number of (contiguous) rows in input matrix
-     * \param[in] n_batch number of (strided) columns in input matrix
-     */
+    // see WrapCuDST for documentation
     void Transpose (const amrex::Real* const AMREX_RESTRICT in,
                     amrex::Real* const AMREX_RESTRICT out,
                     const int n_data, const int n_batch)

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -354,6 +354,8 @@ BeamParticleContainer::InSituWriteToFile (int step, amrex::Real time, const amre
 
     const amrex::Real sum_w0 = m_insitu_sum_rdata[0];
     const std::size_t nslices = static_cast<std::size_t>(m_nslices);
+    const amrex::Real normalized_density_factor = Hipace::m_normalized_units ?
+        geom.CellSizeArray().product() : 1; // dx * dy * dz in normalized units, 1 otherwise
 
     // specify the structure of the data later available in python
     // avoid pointers to temporary objects as second argument, stack variables are ok
@@ -365,6 +367,7 @@ BeamParticleContainer::InSituWriteToFile (int step, amrex::Real time, const amre
         {"mass"    , &m_mass},
         {"z_lo"    , &geom.ProbLo()[2]},
         {"z_hi"    , &geom.ProbHi()[2]},
+        {"normalized_density_factor", &normalized_density_factor},
         {"[x]"     , &m_insitu_rdata[1*nslices], nslices},
         {"[x^2]"   , &m_insitu_rdata[2*nslices], nslices},
         {"[y]"     , &m_insitu_rdata[3*nslices], nslices},

--- a/tools/read_insitu_diagnostics.py
+++ b/tools/read_insitu_diagnostics.py
@@ -73,10 +73,10 @@ def position_std_y(all_data):
     return np.sqrt(np.maximum(all_data["[y^2]"] - all_data["[y]"]**2,0))
 
 def per_slice_charge(all_data):
-    return all_data["charge"] * all_data["sum(w)"]
+    return all_data["charge"] * all_data["sum(w)"] * all_data["normalized_density_factor"]
 
 def total_charge(all_data):
-    return all_data["charge"] * all_data["total"]["sum(w)"]
+    return all_data["charge"] * all_data["total"]["sum(w)"] * all_data["normalized_density_factor"]
 
 def z_axis(all_data):
     return (np.linspace(all_data["z_lo"][0], all_data["z_hi"][0], all_data["n_slices"][0]+1)[1:] \


### PR DESCRIPTION
This is needed to compute thigs like total charge in normalized units from the in-situ output.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
