### PR TITLE
Multigrid smoother

### DIFF
--- a/src/mg_solver/HpMultiGrid.cpp
+++ b/src/mg_solver/HpMultiGrid.cpp
@@ -175,8 +175,36 @@ void gs2 (int i, int j, int ilo, int jlo, int ihi, int jhi,
           Array4<Real> const& phi, Real rhs_r, Real rhs_i,
           Real ar, Real ai, Real facx, Real facy)
 {
-    gs1(i,j,0,ilo,jlo,ihi,jhi,phi, rhs_r-ai*phi(i,j,0,1), ar, facx, facy);
-    gs1(i,j,1,ilo,jlo,ihi,jhi,phi, rhs_i+ai*phi(i,j,0,0), ar, facx, facy);
+    Real lap[2];
+    Real c0 = Real(-2.)*(facx+facy);
+    if (i == ilo) {
+        lap[0] = facx * Real(4./3.)*phi(i+1,j,0,0);
+        lap[1] = facx * Real(4./3.)*phi(i+1,j,0,1);
+        c0 -= Real(2.)*facx;
+    } else if (i == ihi) {
+        lap[0] = facx * Real(4./3.)*phi(i-1,j,0,0);
+        lap[1] = facx * Real(4./3.)*phi(i-1,j,0,1);
+        c0 -= Real(2.)*facx;
+    } else {
+        lap[0] = facx * (phi(i-1,j,0,0) + phi(i+1,j,0,0));
+        lap[1] = facx * (phi(i-1,j,0,1) + phi(i+1,j,0,1));
+    }
+    if (j == jlo) {
+        lap[0] += facy * Real(4./3.)*phi(i,j+1,0,0);
+        lap[1] += facy * Real(4./3.)*phi(i,j+1,0,1);
+        c0 -= Real(2.)*facy;
+    } else if (j == jhi) {
+        lap[0] += facy * Real(4./3.)*phi(i,j-1,0,0);
+        lap[1] += facy * Real(4./3.)*phi(i,j-1,0,1);
+        c0 -= Real(2.)*facy;
+    } else {
+        lap[0] += facy * (phi(i,j-1,0,0) + phi(i,j+1,0,0));
+        lap[1] += facy * (phi(i,j-1,0,1) + phi(i,j+1,0,1));
+    }
+    Real c[2] = {c0-ar, -ai};
+    Real cmag = Real(1.)/(c[0]*c[0] + c[1]*c[1]);
+    phi(i,j,0,0) = ((rhs_r-lap[0])*c[0] + (rhs_i-lap[1])*c[1]) * cmag;
+    phi(i,j,0,1) = ((rhs_i-lap[1])*c[0] - (rhs_r-lap[0])*c[1]) * cmag;
 }
 
 void gsrb (int icolor, Box const& box, Array4<Real> const& phi,


### PR DESCRIPTION
For the type 2 equation, do GSRB smoothing on the complex variable.  This has much better convergence behavior when the imaginary part of the a coefficient is negative.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
