### PR TITLE
Fix unwanted GPU memory access by CPU

### DIFF
--- a/src/particles/BoxSort.H
+++ b/src/particles/BoxSort.H
@@ -21,16 +21,16 @@ public:
                              const amrex::BoxArray a_ba, const amrex::Geometry& a_geom);
 
     //! \brief returns the pointer to the permutation array
-    index_type* boxCountsPtr () noexcept { return m_box_counts.dataPtr(); }
+    index_type* boxCountsPtr () noexcept { return m_box_counts_cpu.dataPtr(); }
 
     //! \brief returns the pointer to the offsets array
-    index_type* boxOffsetsPtr () noexcept { return m_box_offsets.dataPtr(); }
+    index_type* boxOffsetsPtr () noexcept { return m_box_offsets_cpu.dataPtr(); }
 
     //! \brief returns the pointer to the permutation array
-    const index_type* boxCountsPtr () const noexcept { return m_box_counts.dataPtr(); }
+    const index_type* boxCountsPtr () const noexcept { return m_box_counts_cpu.dataPtr(); }
 
     //! \brief returns the pointer to the offsets array
-    const index_type* boxOffsetsPtr () const noexcept { return m_box_offsets.dataPtr(); }
+    const index_type* boxOffsetsPtr () const noexcept { return m_box_offsets_cpu.dataPtr(); }
 
     /** Get the index of the most downstream box that has beam particles */
     int leftmostBoxWithParticles () const;
@@ -40,8 +40,12 @@ private:
     amrex::ParticleLocator<amrex::DenseBins<amrex::Box> > m_particle_locator;
     /** Number of particles in each box */
     amrex::Gpu::DeviceVector<index_type> m_box_counts;
+    /** Number of particles in each box, stored on the cpu */
+    amrex::Vector<index_type> m_box_counts_cpu;
     /** Index of the first particle in each box */
     amrex::Gpu::DeviceVector<index_type> m_box_offsets;
+    /** Index of the first particle in each box, stored on the cpu*/
+    amrex::Vector<index_type> m_box_offsets_cpu;
 };
 
 #endif // HIPACE_BoxSort_H_

--- a/src/particles/BoxSort.cpp
+++ b/src/particles/BoxSort.cpp
@@ -62,7 +62,7 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
                                                                              dst_indices.dataPtr());
 
     a_beam.swap(tmp);
-
+#ifdef AMREX_USE_GPU
     amrex::Gpu::dtoh_memcpy_async(m_box_counts_cpu.dataPtr(), m_box_counts.dataPtr(),
                                   m_box_counts.size() * sizeof(index_type));
 
@@ -70,6 +70,13 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
                                   m_box_offsets.size() * sizeof(index_type));
 
     amrex::Gpu::streamSynchronize();
+#else
+    std::memcpy(m_box_counts_cpu.dataPtr(), m_box_counts.dataPtr(),
+                m_box_counts.size() * sizeof(index_type));
+
+    std::memcpy(m_box_offsets_cpu.dataPtr(), m_box_offsets.dataPtr(),
+                m_box_offsets.size() * sizeof(index_type));
+#endif
 }
 
 int

--- a/src/particles/BoxSort.cpp
+++ b/src/particles/BoxSort.cpp
@@ -21,10 +21,10 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
     constexpr unsigned int max_unsigned_int = std::numeric_limits<unsigned int>::max();
 
     int num_boxes = a_ba.size();
-    m_box_counts.resize(0);
-    m_box_offsets.resize(0);
     m_box_counts.resize(num_boxes+1, 0);
+    m_box_counts_cpu.resize(num_boxes+1);
     m_box_offsets.resize(num_boxes+1);
+    m_box_offsets_cpu.resize(num_boxes+1);
 
     amrex::Gpu::DeviceVector<unsigned int> dst_indices(np);
 
@@ -62,13 +62,21 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
                                                                              dst_indices.dataPtr());
 
     a_beam.swap(tmp);
+
+    amrex::Gpu::dtoh_memcpy_async(m_box_counts_cpu.dataPtr(), m_box_counts.dataPtr(),
+                                  m_box_counts.size() * sizeof(index_type));
+
+    amrex::Gpu::dtoh_memcpy_async(m_box_offsets_cpu.dataPtr(), m_box_offsets.dataPtr(),
+                                  m_box_offsets.size() * sizeof(index_type));
+
+    amrex::Gpu::streamSynchronize();
 }
 
 int
 BoxSorter::leftmostBoxWithParticles () const
 {
     int boxid = 0;
-    while (m_box_counts[boxid]==0 && boxid<amrex::ParallelDescriptor::NProcs()-1){
+    while (m_box_counts_cpu[boxid]==0 && boxid<amrex::ParallelDescriptor::NProcs()-1){
         boxid++;
     }
     return boxid;


### PR DESCRIPTION
Dereferencing a GPU pointer on the CPU caused significant slowdown in ` MultiBeam::DepositCurrentSlice` (specifically ` a_box_sorter_vec[i].boxOffsetsPtr()[ibox]`). This took about as much time as an entire poisson solve. Now the data is copied to the CPU first with `dtoh_memcpy_async` resulting in a significant speedup (this data specifically is never directly needed on the GPU). This performance issue has been previously unnoticed because the effected code region is only profiled through `Hipace::SolveOneSlice()`.

Runtime in s:

resolution | old | new
-- | -- | --
16 | 0,5214 | 0,3547
32 | 0,8413 | 0,6476
64 | 1,5670 | 1,0980
128 | 2,0120 | 1,7540
256 | 6,8540 | 4,9990
512 | 19,5700 | 13,4200
1024 | 70,1200 | 64,8000


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
