### PR TITLE
Fix memory access in BeamBins

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1345,7 +1345,7 @@ Hipace::Notify (const int step, const int it,
             const auto p_psend_buffer = psend_buffer + offset_beam*psize;
 
             BeamBins::index_type const * const indices = bins[ibeam].permutationPtr();
-            BeamBins::index_type const * const offsets = bins[ibeam].offsetsPtr();
+            BeamBins::index_type const * const offsets = bins[ibeam].offsetsPtrCpu();
             BeamBins::index_type cell_start = 0;
 
             // The particles that are in the last slice (sent as ghost particles) are

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -26,7 +26,29 @@ struct BeamIdx
     };
 };
 
-using BeamBins = amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>::ParticleType>;
+struct BeamBins : amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>::ParticleType> {
+
+    template<class...Args>
+    void build (Args&&...args) {
+        amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>::ParticleType>::build(args...);
+
+        const auto offset_size = numBins() + 1;
+        const auto offsets_gpu = offsetsPtr();
+        m_offsets_cpu.resize(offset_size);
+#ifdef AMREX_USE_GPU
+        amrex::Gpu::dtoh_memcpy_async(m_offsets_cpu.dataPtr(), offsets_gpu,
+                                      offset_size * sizeof(index_type));
+        amrex::Gpu::streamSynchronize();
+#else
+        std::memcpy(m_offsets_cpu.dataPtr(), offsets_gpu,
+                    offset_size * sizeof(index_type));
+#endif
+    }
+
+    const index_type* offsetsPtrCpu () const noexcept { return m_offsets_cpu.dataPtr(); }
+
+    amrex::Vector<index_type> m_offsets_cpu;
+};
 
 /** \brief Container for particles of 1 beam species. */
 class BeamParticleContainer

--- a/src/particles/BeamParticleContainer.H
+++ b/src/particles/BeamParticleContainer.H
@@ -30,8 +30,11 @@ struct BeamBins : amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 
 
     template<class...Args>
     void build (Args&&...args) {
+        // call build function of the underlying DenseBins object
+        // with all of the arguments forwarded
         amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>::ParticleType>::build(args...);
 
+        // after every build call copy offsets array form GPU to CPU
         const auto offset_size = numBins() + 1;
         const auto offsets_gpu = offsetsPtr();
         m_offsets_cpu.resize(offset_size);
@@ -45,6 +48,7 @@ struct BeamBins : amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 
 #endif
     }
 
+    // get offsets array on the CPU
     const index_type* offsetsPtrCpu () const noexcept { return m_offsets_cpu.dataPtr(); }
 
     amrex::Vector<index_type> m_offsets_cpu;

--- a/src/particles/BeamParticleContainer.cpp
+++ b/src/particles/BeamParticleContainer.cpp
@@ -251,7 +251,7 @@ BeamParticleContainer::InSituComputeDiags (int islice, const BeamBins& bins, int
     const auto uzp = soa.GetRealData(BeamIdx::uz).data() + box_offset;
 
     BeamBins::index_type const * const indices = bins.permutationPtr();
-    BeamBins::index_type const * const offsets = bins.offsetsPtr();
+    BeamBins::index_type const * const offsets = bins.offsetsPtrCpu();
     BeamBins::index_type const cell_start = offsets[islice-islice0];
     BeamBins::index_type const cell_stop = offsets[islice-islice0+1];
     int const num_particles = cell_stop-cell_start;

--- a/src/particles/MultiBeam.cpp
+++ b/src/particles/MultiBeam.cpp
@@ -132,7 +132,7 @@ int
 MultiBeam::NGhostParticles (int ibeam, const amrex::Vector<BeamBins>& bins, amrex::Box bx)
 {
     BeamBins::index_type const * offsets = 0;
-    offsets = bins[ibeam].offsetsPtr();
+    offsets = bins[ibeam].offsetsPtrCpu();
     return offsets[bx.bigEnd(Direction::z)+1-bx.smallEnd(Direction::z)]
         - offsets[bx.bigEnd(Direction::z)-bx.smallEnd(Direction::z)];
 }

--- a/src/particles/SliceSort.H
+++ b/src/particles/SliceSort.H
@@ -13,8 +13,6 @@
 
 #include <AMReX_MultiFab.H>
 
-using BeamBins = amrex::DenseBins<BeamParticleContainer::ParticleType>;
-
 /** \brief Find particles that are in each slice, and return collections of indices per slice.
  *
  * Note that this does *not* rearrange particle arrays

--- a/src/particles/deposition/BeamDepositCurrentInner.H
+++ b/src/particles/deposition/BeamDepositCurrentInner.H
@@ -109,7 +109,7 @@ void doDepositionShapeN (const BeamParticleContainer& ptile,
         "jx, jy, jz and rho must be exactly one cell thick in the z direction.");
 
     BeamBins::index_type const * const indices = bins.permutationPtr();
-    BeamBins::index_type const * const offsets = bins.offsetsPtr();
+    BeamBins::index_type const * const offsets = bins.offsetsPtrCpu();
     BeamBins::index_type cell_start = 0, cell_stop = 0;
 
     // The particles that are in slice islice are

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -67,7 +67,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, const Fields& fields,
 
     // Declare a DenseBins to pass it to doDepositionShapeN, although it will not be used.
     BeamBins::index_type const * const indices = bins.permutationPtr();
-    BeamBins::index_type const * const offsets = bins.offsetsPtr();
+    BeamBins::index_type const * const offsets = bins.offsetsPtrCpu();
     BeamBins::index_type const
         cell_start = offsets[islice_local], cell_stop = offsets[islice_local+1];
     // The particles that are in slice islice_local are


### PR DESCRIPTION
This is the same issue as in #798, however here the performance is not affected much with the current memory page layout. This PR is necessary to avoid segfaults with the option
```
amrex.the_arena_is_managed = 0
```

Runtime in s:

resolution | old | new
-- | -- | --
16 | 0.5078 | 0.5039
32 | 0.8205 | 0.7247
64 | 1.5510 | 1.4600
128 | 1.9580 | 1.9480
256 | 6.9270 | 6.8080
512 | 19.5200 | 19.5100
1024 | 69.9800 | 69.9400


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
