### PR TITLE
Fix memory access in Fields::Copy

### DIFF
--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -430,7 +430,7 @@ private:
     /** Stores temporary values for z interpolation in Fields::Copy */
     amrex::Gpu::DeviceVector<amrex::Real> m_rel_z_vec;
     /** Stores temporary values for z interpolation in Fields::Copy on the CPU */
-    amrex::Vector<amrex::Real> m_rel_z_vec_cpu;
+    amrex::Gpu::PinnedVector<amrex::Real> m_rel_z_vec_cpu;
     /** Number of guard cells where ExmBy and EypBx are calculated */
     amrex::IntVect m_exmby_eypbx_nguard;
     /** Number of guard cells where sources for poisson equation are included */

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -429,6 +429,8 @@ private:
     amrex::Vector<std::string> m_all_charge_currents_names;
     /** Stores temporary values for z interpolation in Fields::Copy */
     amrex::Gpu::DeviceVector<amrex::Real> m_rel_z_vec;
+    /** Stores temporary values for z interpolation in Fields::Copy on the CPU */
+    amrex::Vector<amrex::Real> m_rel_z_vec_cpu;
     /** Number of guard cells where ExmBy and EypBx are calculated */
     amrex::IntVect m_exmby_eypbx_nguard;
     /** Number of guard cells where sources for poisson equation are included */

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -466,6 +466,8 @@ Fields::Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom
     auto slice_func = interpolated_field_xy<depos_order_xy, guarded_field_xy>{{slice_mf}, calc_geom};
 
 #ifdef AMREX_USE_GPU
+    // This async copy happens on the same stream as the ParallelFor below, which uses the copied array.
+    // Therefore, it is safe to do it async.
     amrex::Gpu::htod_memcpy_async(m_rel_z_vec.dataPtr(), m_rel_z_vec_cpu.dataPtr(),
                                   m_rel_z_vec_cpu.size() * sizeof(amrex::Real));
 #else

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -433,15 +433,16 @@ Fields::Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom
 
     // Put contributions from i_slice to different diag_fab slices in GPU vector
     m_rel_z_vec.resize(k_max+1-k_min);
+    m_rel_z_vec_cpu.resize(k_max+1-k_min);
     for (int k=k_min; k<=k_max; ++k) {
         const amrex::Real pos = k * diag_geom.CellSize(2) + poff_diag_z;
         const amrex::Real mid_i_slice = (pos - poff_calc_z)/calc_geom.CellSize(2);
         amrex::Real sz_cell[depos_order_z + 1];
         const int k_cell = compute_shape_factor<depos_order_z>(sz_cell, mid_i_slice);
-        m_rel_z_vec[k-k_min] = 0;
+        m_rel_z_vec_cpu[k-k_min] = 0;
         for (int i=0; i<=depos_order_z; ++i) {
             if (k_cell+i == i_slice) {
-                m_rel_z_vec[k-k_min] = sz_cell[i];
+                m_rel_z_vec_cpu[k-k_min] = sz_cell[i];
             }
         }
     }
@@ -450,11 +451,11 @@ Fields::Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom
     int k_start = k_min;
     int k_stop = k_max;
     for (int k=k_min; k<=k_max; ++k) {
-        if (m_rel_z_vec[k-k_min] == 0) ++k_start;
+        if (m_rel_z_vec_cpu[k-k_min] == 0) ++k_start;
         else break;
     }
     for (int k=k_max; k>=k_min; --k) {
-        if (m_rel_z_vec[k-k_min] == 0) --k_stop;
+        if (m_rel_z_vec_cpu[k-k_min] == 0) --k_stop;
         else break;
     }
     diag_box.setSmall(2, amrex::max(diag_box.smallEnd(2), k_start));
@@ -463,6 +464,14 @@ Fields::Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom
 
     auto& slice_mf = m_slices[lev][WhichSlice::This];
     auto slice_func = interpolated_field_xy<depos_order_xy, guarded_field_xy>{{slice_mf}, calc_geom};
+
+#ifdef AMREX_USE_GPU
+    amrex::Gpu::htod_memcpy_async(m_rel_z_vec.dataPtr(), m_rel_z_vec_cpu.dataPtr(),
+                                  m_rel_z_vec_cpu.size() * sizeof(amrex::Real));
+#else
+    std::memcpy(m_rel_z_vec.dataPtr(), m_rel_z_vec_cpu.dataPtr(),
+                m_rel_z_vec_cpu.size() * sizeof(amrex::Real));
+#endif
 
     // Finally actual kernel: Interpolation in x, y, z of zero-extended fields
     for (amrex::MFIter mfi(slice_mf); mfi.isValid(); ++mfi) {


### PR DESCRIPTION
Needed to avoid segfault with
```
amrex.the_arena_is_managed = 0
```

This PR needs #797 for the async copy to work

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
