### PR TITLE
Fix CPU depositing unnecessary currents

### DIFF
--- a/src/particles/deposition/PlasmaDepositCurrentInner.H
+++ b/src/particles/deposition/PlasmaDepositCurrentInner.H
@@ -147,13 +147,13 @@ void doDepositionShapeN (const bool use_laser,
 
         Array3<amrex::Real> const isl_arr =
             do_tiling ? tmp_densities[ithread].array() : isl_fab.array();
-        const int jx  = do_tiling ? 0 : jx_cmp;
-        const int jy  = do_tiling ? 1 : jy_cmp;
-        const int jz  = do_tiling ? 2 : jz_cmp;
-        const int rho = do_tiling ? 3 : rho_cmp;
-        const int jxx = do_tiling ? 4 : jxx_cmp;
-        const int jxy = do_tiling ? 5 : jxy_cmp;
-        const int jyy = do_tiling ? 6 : jyy_cmp;
+        const int jx  = (do_tiling && jx_cmp  != -1) ? 0 : jx_cmp;
+        const int jy  = (do_tiling && jy_cmp  != -1) ? 1 : jy_cmp;
+        const int jz  = (do_tiling && jz_cmp  != -1) ? 2 : jz_cmp;
+        const int rho = (do_tiling && rho_cmp != -1) ? 3 : rho_cmp;
+        const int jxx = (do_tiling && jxx_cmp != -1) ? 4 : jxx_cmp;
+        const int jxy = (do_tiling && jxy_cmp != -1) ? 5 : jxy_cmp;
+        const int jyy = (do_tiling && jyy_cmp != -1) ? 6 : jyy_cmp;
 
         int ntiley = 0;
         if (do_tiling) {


### PR DESCRIPTION
A small logic error caused the CPU to deposit every current into the local tile and only copy the needed ones into the global field. Now only the needed currents are deposited into the local tile. GPU behavior is unchanged.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
