### PR TITLE
Avoid spurious copies to/from GPU in laser MPI communication pattern

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1337,7 +1337,7 @@ Hipace::Wait (const int step, int it, bool only_ghost)
                  {
                      laser_arr(i,j,k,n) = buf(i,j,k,n);
                  });
-            amrex::Gpu::Device::synchronize();
+            amrex::Gpu::streamSynchronize();
             amrex::The_Pinned_Arena()->free(lrecv_buffer);
         }
     }
@@ -1529,7 +1529,7 @@ Hipace::Notify (const int step, const int it,
                  {
                      buf(i,j,k,n) = laser_arr(i,j,k,n);
                  });
-            amrex::Gpu::Device::synchronize();
+            amrex::Gpu::streamSynchronize();
         }
         MPI_Isend(m_lsend_buffer, nreals,
                   amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1315,20 +1315,31 @@ Hipace::Wait (const int step, int it, bool only_ghost)
             bx.bigEnd(2)-bx.smallEnd(2)+1 == nz_laser,
             "Laser requires all sub-domains to be the same size, i.e., nz%nrank=0");
         const std::size_t nreals = bx.numPts()*laser_fab.nComp();
-        auto lrecv_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc
-            (sizeof(amrex::Real)*nreals);
-        auto const buf = amrex::makeArray4(lrecv_buffer, bx, laser_fab.nComp());
         MPI_Status lstatus;
-        MPI_Recv(lrecv_buffer, nreals,
-                 amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
-                 (m_rank_z+1)%m_numprocs_z, lcomm_z_tag, m_comm_z, &lstatus);
-        amrex::ParallelFor
-            (bx, laser_fab.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-            {
-                laser_arr(i,j,k,n) = buf(i,j,k,n);
-            });
-        amrex::Gpu::Device::synchronize();
-        amrex::The_Pinned_Arena()->free(lrecv_buffer);
+
+        if (m_laser.is3dOnHost()) {
+            // Directly receive envelope in laser fab
+            MPI_Recv(laser_fab.dataPtr(), nreals,
+                     amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
+                     (m_rank_z+1)%m_numprocs_z, lcomm_z_tag, m_comm_z, &lstatus);
+        } else {
+            // Receive envelope in a host buffer, and copy to laser fab on device
+            auto lrecv_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc
+                (sizeof(amrex::Real)*nreals);
+            MPI_Recv(lrecv_buffer, nreals,
+                     amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
+                     (m_rank_z+1)%m_numprocs_z, lcomm_z_tag, m_comm_z, &lstatus);
+
+            auto const buf = amrex::makeArray4(lrecv_buffer, bx, laser_fab.nComp());
+            amrex::ParallelFor
+                (bx, laser_fab.nComp(),
+                 [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                 {
+                     laser_arr(i,j,k,n) = buf(i,j,k,n);
+                 });
+            amrex::Gpu::Device::synchronize();
+            amrex::The_Pinned_Arena()->free(lrecv_buffer);
+        }
     }
 #endif
 }
@@ -1506,13 +1517,20 @@ Hipace::Notify (const int step, const int it,
         const std::size_t nreals = lbx.numPts()*laser_fab.nComp();
         m_lsend_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc
             (sizeof(amrex::Real)*nreals);
-        auto const buf = amrex::makeArray4(m_lsend_buffer, lbx, laser_fab.nComp());
-        amrex::ParallelFor
-            (lbx, laser_fab.nComp(), [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-            {
-                buf(i,j,k,n) = laser_arr(i,j,k,n);
-            });
-        amrex::Gpu::Device::synchronize();
+        if (m_laser.is3dOnHost()) {
+            // Copy from laser envelope 3D array (on host) to MPI buffer (on host)
+            laser_fab.copyToMem<amrex::RunOn::Host>(lbx, 0, laser_fab.nComp(), m_lsend_buffer);
+        } else {
+            // Copy from laser envelope 3D array (on device) to MPI buffer (on host)
+            auto const buf = amrex::makeArray4(m_lsend_buffer, lbx, laser_fab.nComp());
+            amrex::ParallelFor
+                (lbx, laser_fab.nComp(),
+                 [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                 {
+                     buf(i,j,k,n) = laser_arr(i,j,k,n);
+                 });
+            amrex::Gpu::Device::synchronize();
+        }
         MPI_Isend(m_lsend_buffer, nreals,
                   amrex::ParallelDescriptor::Mpi_typemap<amrex::Real>::type(),
                   (m_rank_z-1+m_numprocs_z)%m_numprocs_z, lcomm_z_tag, m_comm_z, &m_lsend_request);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1518,6 +1518,7 @@ Hipace::Notify (const int step, const int it,
         m_lsend_buffer = (amrex::Real*)amrex::The_Pinned_Arena()->alloc
             (sizeof(amrex::Real)*nreals);
         if (m_laser.is3dOnHost()) {
+            amrex::Gpu::streamSynchronize();
             // Copy from laser envelope 3D array (on host) to MPI buffer (on host)
             laser_fab.copyToMem<amrex::RunOn::Host>(lbx, 0, laser_fab.nComp(), m_lsend_buffer);
         } else {

--- a/src/laser/Laser.H
+++ b/src/laser/Laser.H
@@ -104,6 +104,9 @@ public:
     /** Retun the 3D FArrayBox containing the laser envelope, non-const version */
     amrex::FArrayBox& getFAB () {return m_F;}
 
+    /** getter function, whether 3D envelope is store in host memory */
+    int is3dOnHost () const {return m_3d_on_host;}
+
     /** \brief Allocate laser multifab
      * \param[in] slice_ba box array of the slice
      * \param[in] slice_dm corresponding distribution mapping


### PR DESCRIPTION
In the previous implementation, the copy from laser envelope (on host) to MPI buffer (on host) was done with a `ParallelFor`, causing the data to transit unnecessarily via device memory. This PR proposes a fix. The performance gain is minor for this example with 12 steps, 1024 1024 500 cells on 4 ranks. Probably more significant when scaling to many ranks.

@AlexanderSinn is to credit for the compact implementation.

Before:
```
[thevenet1@jwlogin24 laser_CI]$ grep "total time" output*txt
output.old_ranks.1_host.0.txt:TinyProfiler total time across processes [min...avg...max]: 17.49 ... 17.49 ... 17.49
output.old_ranks.1_host.1.txt:TinyProfiler total time across processes [min...avg...max]: 35.19 ... 35.19 ... 35.19
output.old_ranks.4_host.0.txt:TinyProfiler total time across processes [min...avg...max]: 20.34 ... 21.88 ... 23.19
output.old_ranks.4_host.1.txt:TinyProfiler total time across processes [min...avg...max]: 26.69 ... 28.66 ... 30.36
[thevenet1@jwlogin24 laser_CI]$ grep "Free  GPU global memory" output*txt
output.old_ranks.1_host.0.txt:Free  GPU global memory (MB) spread across MPI: [23391 ... 23391]
output.old_ranks.1_host.1.txt:Free  GPU global memory (MB) spread across MPI: [39361 ... 39361]
output.old_ranks.4_host.0.txt:Free  GPU global memory (MB) spread across MPI: [35265 ... 35265]
output.old_ranks.4_host.1.txt:Free  GPU global memory (MB) spread across MPI: [39225 ... 39353]
```
After:
```
$ grep "total time" output*txt
output.old_ranks.1_host.0.txt:TinyProfiler total time across processes [min...avg...max]: 17.39 ... 17.39 ... 17.39
output.old_ranks.1_host.1.txt:TinyProfiler total time across processes [min...avg...max]: 35.2 ... 35.2 ... 35.2
output.old_ranks.4_host.0.txt:TinyProfiler total time across processes [min...avg...max]: 20.15 ... 21.7 ... 22.87
output.old_ranks.4_host.1.txt:TinyProfiler total time across processes [min...avg...max]: 25.53 ... 27.38 ... 28.86
$ grep "Free  GPU global memory" output*txt
output.old_ranks.1_host.0.txt:Free  GPU global memory (MB) spread across MPI: [23391 ... 23391]
output.old_ranks.1_host.1.txt:Free  GPU global memory (MB) spread across MPI: [39361 ... 39361]
output.old_ranks.4_host.0.txt:Free  GPU global memory (MB) spread across MPI: [35265 ... 35265]
output.old_ranks.4_host.1.txt:Free  GPU global memory (MB) spread across MPI: [39233 ... 39361]
```