### PR TITLE
Fix invalid CUDA device function error in HPMG

### DIFF
--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -63,18 +63,68 @@ public:
      *
      * \param[in,out] sol the initial guess and final solution
      * \param[in] rhs right hand side
-     * \param[in] acoef_real the real part of the coefficient
-     * \param[in] acoef_imag the imaginary part of the coefficient
+     * \param[in] acoef_real the constant real part of the coefficient
+     * \param[in] acoef_imag the constant imaginary part of the coefficient
      * \param[in] tol_rel relative tolerance
      * \param[in] tol_abs absolute tolerance
      * \param[in] nummaxiter maximum number of iterations
      * \param[in] verbose verbosity level
      */
-    template <typename TR, typename TI>
     void solve2 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
-                 TR const& acoef_real, TI const& acoef_imag,
+                 amrex::Real const acoef_real, amrex::Real const acoef_imag,
                  amrex::Real const tol_rel, amrex::Real const tol_abs,
                  int const nummaxiter, int const verbose);
+
+    /** \brief Solve the Type II equation given the initial guess, right hand side,
+     * and the coefficient.
+     *
+     * \param[in,out] sol the initial guess and final solution
+     * \param[in] rhs right hand side
+     * \param[in] acoef_real the constant real part of the coefficient
+     * \param[in] acoef_imag the array imaginary part of the coefficient
+     * \param[in] tol_rel relative tolerance
+     * \param[in] tol_abs absolute tolerance
+     * \param[in] nummaxiter maximum number of iterations
+     * \param[in] verbose verbosity level
+     */
+    void solve2 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
+                amrex::Real const acoef_real, amrex::FArrayBox const& acoef_imag,
+                amrex::Real const tol_rel, amrex::Real const tol_abs,
+                int const nummaxiter, int const verbose);
+
+    /** \brief Solve the Type II equation given the initial guess, right hand side,
+     * and the coefficient.
+     *
+     * \param[in,out] sol the initial guess and final solution
+     * \param[in] rhs right hand side
+     * \param[in] acoef_real the array real part of the coefficient
+     * \param[in] acoef_imag the constant imaginary part of the coefficient
+     * \param[in] tol_rel relative tolerance
+     * \param[in] tol_abs absolute tolerance
+     * \param[in] nummaxiter maximum number of iterations
+     * \param[in] verbose verbosity level
+     */
+    void solve2 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
+                amrex::FArrayBox const& acoef_real, amrex::Real const acoef_imag,
+                amrex::Real const tol_rel, amrex::Real const tol_abs,
+                int const nummaxiter, int const verbose);
+
+    /** \brief Solve the Type II equation given the initial guess, right hand side,
+     * and the coefficient.
+     *
+     * \param[in,out] sol the initial guess and final solution
+     * \param[in] rhs right hand side
+     * \param[in] acoef_real the array real part of the coefficient
+     * \param[in] acoef_imag the array imaginary part of the coefficient
+     * \param[in] tol_rel relative tolerance
+     * \param[in] tol_abs absolute tolerance
+     * \param[in] nummaxiter maximum number of iterations
+     * \param[in] verbose verbosity level
+     */
+    void solve2 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
+                amrex::FArrayBox const& acoef_real, amrex::FArrayBox const& acoef_imag,
+                amrex::Real const tol_rel, amrex::Real const tol_abs,
+                int const nummaxiter, int const verbose);
 
     /** \brief Average down the coefficient.  Ideally, this function is not
      * supposed to be a public function.  It's made public due to a CUDA
@@ -200,75 +250,6 @@ void ParallelFor (amrex::Box const& box, int ncomp, F&& f) noexcept
 }
 
 #endif
-
-template <typename TR, typename TI>
-void MultiGrid::solve2 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
-                        TR const& acoef_real, TI const& acoef_imag,
-                        amrex::Real const tol_rel, amrex::Real const tol_abs,
-                        int const nummaxiter, int const verbose)
-{
-    HIPACE_PROFILE("hpmg::MultiGrid::solve2()");
-    m_system_type = 2;
-
-    auto const& array_m_acf = m_acf[0].array();
-    if constexpr (std::is_arithmetic<TR>::value && std::is_arithmetic<TI>::value)
-    {
-        hpmg::ParallelFor(m_acf[0].box(),
-            [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
-            {
-                array_m_acf(i,j,0,0) = acoef_real;
-                array_m_acf(i,j,0,1) = acoef_imag;
-            });
-    }
-    else if constexpr (std::is_arithmetic<TR>::value)
-    {
-        AMREX_ALWAYS_ASSERT(amrex::makeSlab(acoef_imag.box(),2,0).contains(m_domain.front()));
-        amrex::FArrayBox ifab(amrex::makeSlab(acoef_imag.box(), 2, 0),
-                              1, acoef_imag.dataPtr());
-        auto const& ai = ifab.const_array();
-        hpmg::ParallelFor(m_acf[0].box(),
-            [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
-            {
-                array_m_acf(i,j,0,0) = acoef_real;
-                array_m_acf(i,j,0,1) = ai(i,j,0);
-            });
-    }
-    else if constexpr (std::is_arithmetic<TI>::value)
-    {
-        AMREX_ALWAYS_ASSERT(amrex::makeSlab(acoef_real.box(),2,0).contains(m_domain.front()));
-        amrex::FArrayBox rfab(amrex::makeSlab(acoef_real.box(), 2, 0),
-                              1, acoef_real.dataPtr());
-        auto const& ar = rfab.const_array();
-        hpmg::ParallelFor(m_acf[0].box(),
-            [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
-            {
-                array_m_acf(i,j,0,0) = ar(i,j,0);
-                array_m_acf(i,j,0,1) = acoef_imag;
-            });
-    }
-    else
-    {
-        AMREX_ALWAYS_ASSERT(amrex::makeSlab(acoef_real.box(),2,0).contains(m_domain.front()) &&
-                            amrex::makeSlab(acoef_imag.box(),2,0).contains(m_domain.front()));
-        amrex::FArrayBox rfab(amrex::makeSlab(acoef_real.box(), 2, 0),
-                              1, acoef_real.dataPtr());
-        amrex::FArrayBox ifab(amrex::makeSlab(acoef_imag.box(), 2, 0),
-                              1, acoef_imag.dataPtr());
-        auto const& ar = rfab.const_array();
-        auto const& ai = ifab.const_array();
-        hpmg::ParallelFor(m_acf[0].box(),
-            [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
-            {
-                array_m_acf(i,j,0,0) = ar(i,j,0);
-                array_m_acf(i,j,0,1) = ai(i,j,0);
-            });
-
-    }
-
-    average_down_acoef();
-
-    solve_doit(sol, rhs, tol_rel, tol_abs, nummaxiter, verbose);
-}
 
 }
 


### PR DESCRIPTION
Replace template and if constexpr with good old overloading for NVCC 11.4

From Severin:

We found that the laser envelope crashes on Maxwell for the following input script:

```
my_constants.kp_inv = 10.e-6
my_constants.kp = 1. / kp_inv
my_constants.wp = clight * kp
my_constants.ne = wp^2 * m_e * epsilon0 / q_e^2

max_step = 50
hipace.dt = 10.*kp_inv/clight

hipace.verbose = 0

amr.n_cell = 512 512 1000

hipace.do_tiling = 0

geometry.prob_lo     = -25.6*kp_inv   -25.6*kp_inv   -13.*kp_inv
geometry.prob_hi     =  25.6*kp_inv    25.6*kp_inv    0.*kp_inv

laser.a0 = 2.5
laser.use_laser = 1
laser.position_mean = 0. 0. -4*kp_inv
laser.w0 = 3.2*kp_inv 3.2*kp_inv
laser.L0 = 2.26*kp_inv * .57 # .57 is a rough conversion factor between cos**2 and exp profiles
laser.lambda0 = 2*pi/34*kp_inv
laser.solver_type = multigrid

hipace.bxby_solver=explicit

amr.blocking_factor = 2
amr.max_level = 0

hipace.output_period = 1

hipace.numprocs_x = 1
hipace.numprocs_y = 1

# hipace.depos_order_xy = 2

geometry.coord_sys   = 0                  # 0: Cartesian
geometry.is_periodic = true  true  false  # Is periodic?

beams.names = no_beam

plasmas.names = plasma
my_constants.zramp = 20*kp_inv
plasma.density(x,y,z) = ne * if(z>zramp,1,z/zramp) * if(z>0,1,0)
plasma.ppc = 2 2
plasma.u_mean = 0.0 0.0 0.
plasma.element = electron
plasma.radius = 23.*kp_inv

diagnostic.diag_type = xz
```

with the following error:
```
amrex::Abort::0::GPU last error detected in file /home/diederse/software/hipace/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsG.H line 868: invalid device function !!!
SIGABRT
See Backtrace.0 file for details
```

This PR fixes the issue


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
