### PR TITLE
[mini] print number of iterations only for PC solver

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -518,9 +518,9 @@ Hipace::Evolve ()
         m_multi_beam.InSituWriteToFile(step, m_physical_time, geom[lev]);
 
         // printing and resetting predictor corrector loop diagnostics
-        if (m_verbose>=2) amrex::AllPrint()<<"Rank "<<rank<<": avg. number of iterations "
-                                   << m_predcorr_avg_iterations << " avg. transverse B field error "
-                                   << m_predcorr_avg_B_error << "\n";
+        if (m_verbose>=2 && !m_explicit) amrex::AllPrint() << "Rank " << rank <<
+                                ": avg. number of iterations " << m_predcorr_avg_iterations <<
+                                " avg. transverse B field error " << m_predcorr_avg_B_error << "\n";
         m_predcorr_avg_iterations = 0.;
         m_predcorr_avg_B_error = 0.;
 


### PR DESCRIPTION
Previously, the number of iterations and B field error was printed even for the explicit solver, which was irrelevant. This PR removes the unnecessary printout

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
