### PR TITLE
Fix errors in I/O

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -525,11 +525,11 @@ Hipace::Evolve ()
         m_predcorr_avg_B_error = 0.;
 
         m_physical_time += m_dt;
-    }
 
 #ifdef HIPACE_USE_OPENPMD
-    if (m_output_period > 0) m_openpmd_writer.reset();
+        m_openpmd_writer.reset(step);
 #endif
+    }
 }
 
 void

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -156,8 +156,10 @@ public:
         const amrex::Vector<BoxSorter>& a_box_sorter_vec, amrex::Vector<amrex::Geometry> const& geom3D,
         const OpenPMDWriterCallType call_type);
 
-    /** \brief Resets the openPMD series of all levels */
-    void reset ();
+    /** \brief Resets the openPMD series of all levels
+     * \param[in] output_step current iteration
+     */
+    void reset (const int output_step);
 
     /** Prefix/path for the output files */
     std::string m_file_prefix;

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -57,8 +57,8 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
     if (output_period < 0 ||
        (!(output_step == max_step) && output_step % output_period != 0)) return;
 
-    m_outputSeries.resize(nlev+1);
-    m_last_output_dumped.resize(nlev+1);
+    m_outputSeries.resize(nlev);
+    m_last_output_dumped.resize(nlev);
 
     if (nlev > 1) {
         for (int lev=0; lev<nlev; ++lev) {

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -57,21 +57,24 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
     if (output_period < 0 ||
        (!(output_step == max_step) && output_step % output_period != 0)) return;
 
+    m_outputSeries.resize(nlev+1);
+    m_last_output_dumped.resize(nlev+1);
+
     if (nlev > 1) {
         for (int lev=0; lev<nlev; ++lev) {
             std::string filename = m_file_prefix + "/lev_" + std::to_string(lev) +  "/openpmd_%06T."
                                    + m_openpmd_backend;
 
-            m_outputSeries.push_back(std::make_unique< openPMD::Series >(
-                filename, openPMD::Access::CREATE) );
-            m_last_output_dumped.push_back(-1);
+            m_outputSeries[lev] = std::make_unique< openPMD::Series >(
+                filename, openPMD::Access::CREATE);
+            m_last_output_dumped[lev] = -1;
         }
     } else {
         std::string filename = m_file_prefix + "/openpmd_%06T." + m_openpmd_backend;
 
-        m_outputSeries.push_back(std::make_unique< openPMD::Series >(
-            filename, openPMD::Access::CREATE) );
-        m_last_output_dumped.push_back(-1);
+        m_outputSeries[0] = std::make_unique< openPMD::Series >(
+            filename, openPMD::Access::CREATE);
+        m_last_output_dumped[0] = -1;
     }
 
 

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -60,24 +60,15 @@ OpenPMDWriter::InitDiagnostics (const int output_step, const int output_period, 
     m_outputSeries.resize(nlev);
     m_last_output_dumped.resize(nlev);
 
-    if (nlev > 1) {
-        for (int lev=0; lev<nlev; ++lev) {
-            std::string filename = m_file_prefix + "/lev_" + std::to_string(lev) +  "/openpmd_%06T."
-                                   + m_openpmd_backend;
+    for (int lev=0; lev<nlev; ++lev) {
+        std::string filename = m_file_prefix +
+            (nlev>1 ? "/lev_" + std::to_string(lev) : "") +
+            "/openpmd_%06T." + m_openpmd_backend;
 
-            m_outputSeries[lev] = std::make_unique< openPMD::Series >(
-                filename, openPMD::Access::CREATE);
-            m_last_output_dumped[lev] = -1;
-        }
-    } else {
-        std::string filename = m_file_prefix + "/openpmd_%06T." + m_openpmd_backend;
-
-        m_outputSeries[0] = std::make_unique< openPMD::Series >(
+        m_outputSeries[lev] = std::make_unique< openPMD::Series >(
             filename, openPMD::Access::CREATE);
-        m_last_output_dumped[0] = -1;
+        m_last_output_dumped[lev] = -1;
     }
-
-
 
     // TODO: meta-data: author, mesh path, extensions, software
 }

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -414,9 +414,10 @@ OpenPMDWriter::SaveRealProperty (BeamParticleContainer& pc,
     }
 }
 
-void OpenPMDWriter::reset ()
+void OpenPMDWriter::reset (const int output_step)
 {
     for (int lev = 0; lev<m_outputSeries.size(); ++lev) {
+        if (output_step != m_last_output_dumped[lev]) continue;
         m_outputSeries[lev].reset();
     }
 }


### PR DESCRIPTION
This PR resolves #815 

As @AlexanderSinn pointed out, an `openPMD::series` is appended to the `outputSeries` vector at each time step. This vector was intended to be a vector over levels.

In this PR, the outputSeries vector is initialized once per level and per time step, and the series is reset at the end of the time step. This removes the unwanted openPMD series, which then give errors since they were never used, but also the problem that the IO of prematurely exited simulation was unusable. Now, it is usable for the finished time steps. Note, that it will still give an error if half-written time steps are in the directory. Still, with this PR it is possible to copy iterations to other folders and analyze them before the full run is finished.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
