### PR TITLE
Enable multiple laser pulses

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -508,56 +508,60 @@ Laser parameters
 ----------------
 
 The laser profile is defined by :math:`a(x,y,z) = a_0 * \mathrm{exp}[-(x^2/w0_x^2 + y^2/w0_y^2 + z^2/L0^2)]`.
-The laser pulse length :math:`L0 = \tau / c_0` can be specified via the pulse duration ``laser.tau``. The model implemented is the one from [C. Benedetti et al. Plasma Phys. Control. Fusion 60.1: 014002 (2017)].
+The model implemented is the one from [C. Benedetti et al. Plasma Phys. Control. Fusion 60.1: 014002 (2017)].
+Unlike for ``beams`` and ``plasmas``, all the laser pulses are currently stored on the same array,
+which you can find in the output openPMD file as `laser_real` (for the real part of the envelope) and `laser_imag` for its imaginary part.
+Parameters starting with ``lasers.`` apply to all laser pulses, parameters starting with ``<laser name>`` apply to a single laser pulse.
 
-* ``laser.use_laser`` (`0` or `1`) optional (default `0`)
-    Whether to activate the laser envelope solver.
+* ``lasers.names`` (list of `string`)
+    The names of the laser pulses, separated by a space.
+    To run without a laser, choose the name ``no_laser``.
 
-* ``laser.a0`` (`float`) optional (default `0`)
-    Peak normalized vector potential of the laser pulse.
+* ``lasers.lambda0`` (`float`)
+    Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
 
-* ``laser.position_mean`` (3 `float`) optional (default `0 0 0`)
-    The mean position of the laser in `x, y, z`.
-
-* ``laser.w0`` (2 `float`) optional (default `0 0`)
-    The laser waist in `x, y`.
-
-* ``laser.L0`` (`float`) optional (default `0`)
-    The laser pulse length in `z`. Use either the pulse length or the pulse duration.
-
-* ``laser.tau`` (`float`) optional (default `0`)
-    The laser pulse duration. The pulse length will be set to `laser.tau`:math:`/c_0`.
-    Use either the pulse length or the pulse duration.
-
-* ``laser.lambda0`` (`float`)
-    The laser pulse wavelength.
-
-* ``laser.focal_distance`` (`float`)
-    Distance at which the laser pulse if focused (in the z direction, counted from laser initial position).
-
-* ``laser.use_phase`` (`bool`) optional (default `true`)
+* ``lasers.use_phase`` (`bool`) optional (default `true`)
     Whether the phase terms (:math:`\theta` in Eq. (6) of [C. Benedetti et al. Plasma Phys. Control. Fusion 60.1: 014002 (2017)]) are computed and used in the laser envelope advance. Keeping the phase should be more accurate, but can cause numerical issues in the presence of strong depletion/frequency shift.
 
-* ``laser.solver_type`` (`string`) optional (default `multigrid`)
+* ``lasers.solver_type`` (`string`) optional (default `multigrid`)
     Type of solver for the laser envelope solver, either ``fft`` or ``multigrid``.
     Currently, the approximation that the phase is evaluated on-axis only is made with both solvers.
     With the multigrid solver, we could drop this assumption.
     For now, the fft solver should be faster, more accurate and more stable, so only use the multigrid one with care.
 
-* ``laser.MG_tolerance_rel`` (`float`) optional (default `1e-4`)
+* ``lasers.MG_tolerance_rel`` (`float`) optional (default `1e-4`)
     Relative error tolerance of the multigrid solver used for the laser pulse.
 
-* ``laser.MG_tolerance_abs`` (`float`) optional (default `0.`)
+* ``lasers.MG_tolerance_abs`` (`float`) optional (default `0.`)
     Absolute error tolerance of the multigrid solver used for the laser pulse.
 
-* ``laser.MG_verbose`` (`int`) optional (default `0`)
+* ``lasers.MG_verbose`` (`int`) optional (default `0`)
     Level of verbosity of the multigrid solver used for the laser pulse.
 
-* ``laser.MG_average_rhs`` (`0` or `1`) optional (default `1`)
+* ``lasers.MG_average_rhs`` (`0` or `1`) optional (default `1`)
     Whether to use the most stable discretization for the envelope solver.
 
-* ``laser.3d_on_host`` (`0` or `1`) optional (default `0`)
+* ``lasers.3d_on_host`` (`0` or `1`) optional (default `0`)
     When running on GPU: whether the 3D array containing the laser envelope is stored in host memory (CPU, slower but large memory available) or in device memory (GPU, faster but less memory available).
+
+* ``<laser name>.a0`` (`float`) optional (default `0`)
+    Peak normalized vector potential of the laser pulse.
+
+* ``<laser name>.position_mean`` (3 `float`) optional (default `0 0 0`)
+    The mean position of the laser in `x, y, z`.
+
+* ``<laser name>.w0`` (2 `float`) optional (default `0 0`)
+    The laser waist in `x, y`.
+
+* ``<laser name>.L0`` (`float`) optional (default `0`)
+    The laser pulse length in `z`. Use either the pulse length or the pulse duration ``<laser name>.tau``.
+
+* ``<laser name>.tau`` (`float`) optional (default `0`)
+    The laser pulse duration. The pulse length will be set to `laser.tau`:math:`/c_0`.
+    Use either the pulse length or the pulse duration.
+
+* ``<laser name>.focal_distance`` (`float`)
+    Distance at which the laser pulse if focused (in the z direction, counted from laser initial position).
 
 Diagnostic parameters
 ---------------------

--- a/examples/beam_in_vacuum/inputs_SI
+++ b/examples/beam_in_vacuum/inputs_SI
@@ -39,4 +39,6 @@ beam2.ppc = 2 2 1
 
 plasmas.names = no_plasma
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/beam_in_vacuum/inputs_normalized
+++ b/examples/beam_in_vacuum/inputs_normalized
@@ -30,4 +30,6 @@ beam.ppc = 2 2 1
 
 plasmas.names = no_plasma
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/beam_in_vacuum/inputs_normalized_transverse
+++ b/examples/beam_in_vacuum/inputs_normalized_transverse
@@ -39,4 +39,7 @@ beam2.position_mean = 0. 0. 0
 beam2.position_std = 8. 0.3 1.41
 
 plasmas.names = no_plasma
+
+lasers.names = no_laser
+
 diagnostic.diag_type = xz

--- a/examples/blowout_wake/inputs_SI
+++ b/examples/blowout_wake/inputs_SI
@@ -44,4 +44,6 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/blowout_wake/inputs_ionization_SI
+++ b/examples/blowout_wake/inputs_ionization_SI
@@ -53,4 +53,6 @@ ion.mass_Da = 1.008
 ion.initial_ion_level = 0
 ion.ionization_product = elec
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -40,4 +40,6 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/gaussian_weight/inputs_SI
+++ b/examples/gaussian_weight/inputs_SI
@@ -29,4 +29,6 @@ beam.ppc = 2 2 1
 
 plasmas.names = no_plasma
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/gaussian_weight/inputs_normalized
+++ b/examples/gaussian_weight/inputs_normalized
@@ -29,4 +29,6 @@ beam.u_std = 3. 4. 0.
 
 plasmas.names = no_plasma
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/get_started/inputs_normalized
+++ b/examples/get_started/inputs_normalized
@@ -36,6 +36,10 @@ plasma.element = electron               # type of plasma: electron, proton, or a
 plasma.density(x,y,z) = 1.              # density function in the respective unit systems
 plasma.ppc = 1 1                        # particles per cell in x,y
 
+### Laser
+################################
+lasers.names = no_laser                 # name(s) of the laser pulses. Here, no laser pulse used.
+
 ### Diagnostics
 ################################
 diagnostic.diag_type = xz               # 2D xz slice output. Options: xyz, xz, yz

--- a/examples/laser/inputs_SI
+++ b/examples/laser/inputs_SI
@@ -12,12 +12,13 @@ hipace.do_tiling = 0
 geometry.prob_lo     = -6.*kp_inv   -6.*kp_inv   -8.*kp_inv
 geometry.prob_hi     =  6.*kp_inv    6.*kp_inv    6.*kp_inv
 
-laser.use_laser = 1
+lasers.names = laser
+lasers.lambda0 = .8e-6
+
 laser.a0 = 1
 laser.position_mean = 0. 0. 0
-laser.w0 = 2.*kp_inv 2.*kp_inv
+laser.w0 = 2.*kp_inv
 laser.L0 = 2.*kp_inv
-laser.lambda0 = .8e-6
 laser.focal_distance = 0.001
 
 hipace.bxby_solver=explicit

--- a/examples/linear_wake/inputs_SI
+++ b/examples/linear_wake/inputs_SI
@@ -38,4 +38,6 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/linear_wake/inputs_ion_motion_SI
+++ b/examples/linear_wake/inputs_ion_motion_SI
@@ -57,4 +57,6 @@ ions.neutralize_background = false
 "ions.density(x,y,z)" = ne
 ions.ppc = 1 1
 
+lasers.names = no_laser
+
 diagnostic.diag_type = xyz

--- a/examples/linear_wake/inputs_normalized
+++ b/examples/linear_wake/inputs_normalized
@@ -36,3 +36,5 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 diagnostic.diag_type = xyz
+
+lasers.names = no_laser

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -16,7 +16,7 @@
 #include "particles/beam/BeamParticleContainer.H"
 #include "utils/AdaptiveTimeStep.H"
 #include "utils/GridCurrent.H"
-#include "laser/Laser.H"
+#include "laser/MultiLaser.H"
 #include "utils/Constants.H"
 #include "utils/Parser.H"
 #include "diagnostics/Diagnostic.H"
@@ -361,7 +361,7 @@ public:
     /** Adaptive time step instance */
     AdaptiveTimeStep m_adaptive_time_step;
     /** Laser instance (soon to be multi laser container) */
-    Laser m_laser;
+    MultiLaser m_multi_laser;
     /** GridCurrent instance */
     GridCurrent m_grid_current;
 #ifdef HIPACE_USE_OPENPMD

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -11,7 +11,7 @@
 
 #include "fft_poisson_solver/FFTPoissonSolver.H"
 #include "diagnostics/Diagnostic.H"
-#include "laser/Laser.H"
+#include "laser/MultiLaser.H"
 #include "utils/GPUUtil.H"
 
 #include <AMReX_MultiFab.H>
@@ -21,7 +21,7 @@
 #include <algorithm>
 
 class Hipace;
-class Laser;
+class MultiLaser;
 
 /** \brief describes which slice with respect to the currently calculated is used */
 struct WhichSlice {
@@ -158,12 +158,12 @@ public:
      * \param[in] calc_geom main geometry
      * \param[in] diag_comps_vect the field components to copy
      * \param[in] ncomp number of components to copy
-     * \param[in] laser Laser object
+     * \param[in] multi_laser MultiLaser object
      */
      void Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom,
                 amrex::FArrayBox& diag_fab, amrex::Box diag_box, const amrex::Geometry& calc_geom,
                 const amrex::Gpu::DeviceVector<int>& diag_comps_vect, const int ncomp,
-                Laser& laser);
+                MultiLaser& multi_laser);
 
     /** \brief Shift slices by 1 element: slices (1,2) are then stored in (2,3).
      *

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -406,7 +406,7 @@ void
 Fields::Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom,
               amrex::FArrayBox& diag_fab, amrex::Box diag_box, const amrex::Geometry& calc_geom,
               const amrex::Gpu::DeviceVector<int>& diag_comps_vect, const int ncomp,
-              Laser& laser)
+              MultiLaser& multi_laser)
 {
     HIPACE_PROFILE("Fields::Copy()");
     constexpr int depos_order_xy = 1;
@@ -461,7 +461,7 @@ Fields::Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom
     if (diag_box.isEmpty()) return;
     auto& slice_mf = m_slices[lev][WhichSlice::This];
     auto slice_func = interpolated_field_xy<depos_order_xy, guarded_field_xy>{{slice_mf}, calc_geom};
-    auto& laser_mf = laser.getSlices(WhichLaserSlice::n00j00);
+    auto& laser_mf = multi_laser.getSlices(WhichLaserSlice::n00j00);
     auto laser_func = interpolated_field_xy<depos_order_xy, guarded_field_xy>{{laser_mf}, calc_geom};
 
 #ifdef AMREX_USE_GPU
@@ -493,7 +493,7 @@ Fields::Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom
                 diag_array(i,j,k,n) += rel_z_data[k-k_min] * slice_array(x,y,m);
             });
 
-        if (!laser.m_use_laser) continue;
+        if (!multi_laser.m_use_laser) continue;
         auto laser_array = laser_func.array(mfi);
         amrex::ParallelFor(diag_box,
             [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept

--- a/src/laser/CMakeLists.txt
+++ b/src/laser/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(HiPACE
   PRIVATE
     MultiLaser.cpp
+    Laser.cpp
 )

--- a/src/laser/CMakeLists.txt
+++ b/src/laser/CMakeLists.txt
@@ -1,4 +1,4 @@
 target_sources(HiPACE
   PRIVATE
-    Laser.cpp
+    MultiLaser.cpp
 )

--- a/src/laser/Laser.H
+++ b/src/laser/Laser.H
@@ -1,0 +1,43 @@
+/* Copyright 2022
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: MaxThevenet, AlexanderSinn
+ * Severin Diederichs, atmyers, Angel Ferran Pousa
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef LASER_H_
+#define LASER_H_
+
+#include <AMReX_Vector.H>
+#include <AMReX_RealVect.H>
+
+class Laser
+{
+public:
+    Laser (std::string name);
+/*
+    amrex::Real getA0 () {return m_a0};
+    amrex::Real getK0 () {return m_k0};
+    amrex::Real getW0 () {return m_w0};
+    amrex::Real getL0 () {return m_l0};
+    amrex::Real getTau () {return m_tau};
+    amrex::Real getLambda () {return m_lambda0};
+    amrex::Real getFoc () {return m_focal_distance};
+    amrex::Real getX0 () {return m_position_mean[0]};
+    amrex::Real getY0 () {return m_position_mean[1]};
+    amrex::Real getZ0 () {return m_position_mean[2]};
+*/
+    std::string m_name {""};
+    amrex::Real m_a0 {0.}; /**< Laser peak normalized amplitude */
+    amrex::Real m_w0 {0.}; /**< Laser waist */
+    amrex::Real m_L0 {0.}; /**< Laser length (HW 1/e in amplitude) */
+    amrex::Real m_tau {0.}; /**< Laser duration (HW 1/e in amplitude) */
+    /** Focal distance of the laser pulse */
+    amrex::Real m_focal_distance {0.};
+    /** Average position of the Gaussian laser pulse */
+    amrex::RealVect m_position_mean {0., 0., 0.};
+};
+
+#endif // LASER_H_

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -1,0 +1,35 @@
+/* Copyright 2022
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: MaxThevenet, AlexanderSinn
+ * Severin Diederichs, atmyers, Angel Ferran Pousa
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "Laser.H"
+#include "utils/Parser.H"
+#include "Hipace.H"
+
+#include <AMReX_Vector.H>
+#include <AMReX_ParmParse.H>
+
+Laser::Laser (std::string name)
+{
+    m_name = name;
+    amrex::ParmParse pp(m_name);
+    queryWithParser(pp, "a0", m_a0);
+    queryWithParser(pp, "w0", m_w0);
+    bool length_is_specified = queryWithParser(pp, "L0", m_L0);;
+    bool duration_is_specified = queryWithParser(pp, "tau", m_tau);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE( length_is_specified + duration_is_specified == 1,
+        "Please specify exlusively either the pulse length L0 or the duration tau of the laser");
+    if (duration_is_specified) m_L0 = m_tau/get_phys_const().c;
+    queryWithParser(pp, "focal_distance", m_focal_distance);
+
+    amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
+    queryWithParser(pp, "position_mean", loc_array);
+    for (int idim=0; idim < AMREX_SPACEDIM; ++idim) m_position_mean[idim] = loc_array[idim];
+    AMREX_ALWAYS_ASSERT(m_position_mean[0] == 0.);
+    AMREX_ALWAYS_ASSERT(m_position_mean[1] == 0.);    
+}

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -31,5 +31,5 @@ Laser::Laser (std::string name)
     queryWithParser(pp, "position_mean", loc_array);
     for (int idim=0; idim < AMREX_SPACEDIM; ++idim) m_position_mean[idim] = loc_array[idim];
     AMREX_ALWAYS_ASSERT(m_position_mean[0] == 0.);
-    AMREX_ALWAYS_ASSERT(m_position_mean[1] == 0.);    
+    AMREX_ALWAYS_ASSERT(m_position_mean[1] == 0.);
 }

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -1,5 +1,5 @@
-#ifndef LASER_H_
-#define LASER_H_
+#ifndef MULTILASER_H_
+#define MULTILASER_H_
 
 #include "fields/Fields.H"
 #include "mg_solver/HpMultiGrid.H"
@@ -62,7 +62,7 @@ struct WhichLaserSlice {
 
 class Fields;
 
-class Laser
+class MultiLaser
 {
 
     using SpectralFieldLoc = amrex::BaseFab <amrex::GpuComplex<amrex::Real>>;
@@ -74,12 +74,12 @@ private:
 public:
 
     /** Constructor */
-    explicit Laser ()
+    explicit MultiLaser ()
     {
         ReadParameters();
     }
 
-    ~Laser ()
+    ~MultiLaser ()
     {
         if (!m_use_laser) return;
         if (m_solver_type == "fft") {
@@ -223,4 +223,4 @@ private:
 #endif
 };
 
-#endif // LASER_H_
+#endif // MULTILASER_H_

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -1,6 +1,16 @@
+/* Copyright 2022
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: MaxThevenet, AlexanderSinn
+ * Severin Diederichs, atmyers, Angel Ferran Pousa
+ * License: BSD-3-Clause-LBNL
+ */
+
 #ifndef MULTILASER_H_
 #define MULTILASER_H_
 
+#include "Laser.H"
 #include "fields/Fields.H"
 #include "mg_solver/HpMultiGrid.H"
 
@@ -171,16 +181,24 @@ public:
 
 private:
 
-    std::string m_name = "laser"; /**< name of the laser */
-    amrex::Real m_a0 {0.}; /**< Laser peak normalized amplitude */
-    amrex::RealVect m_w0 {0., 0., 0.}; /**< Laser waist in x and y (the third value is omitted) */
-    amrex::Real m_L0 {0.}; /**< Laser length (HW 1/e in amplitude) */
-    amrex::Real m_tau {0.}; /**< Laser duration (HW 1/e in amplitude) */
-    amrex::Real m_lambda0 {0.}; /**< Laser central wavelength */
-    /** Average position of the Gaussian laser pulse */
-    amrex::RealVect m_position_mean {0., 0., 0.};
+/*
+    amrex::Gpu::DeviceVector<amrex::Real> getA0s ();
+    amrex::Gpu::DeviceVector<amrex::Real> getK0s ();
+    amrex::Gpu::DeviceVector<amrex::Real> getW0s ();
+    amrex::Gpu::DeviceVector<amrex::Real> getX0s ();
+    amrex::Gpu::DeviceVector<amrex::Real> getY0s ();
+    amrex::Gpu::DeviceVector<amrex::Real> getZ0s ();
+    amrex::Gpu::DeviceVector<amrex::Real> getL0s ();
+    amrex::Gpu::DeviceVector<amrex::Real> getZfocs ();
+*/
+    /** Laser central wavelength.
+     * he central wavelength influences the solver. As long as all the lasers are on the same grid
+     * (part of MultiLaser), this must be a property of MultiLaser. */
+    amrex::Real m_lambda0 {0.};
+    amrex::Vector<std::string> m_names; /**< name of the laser */
+    int m_nlasers; /**< Number of laser pulses */
+    amrex::Vector<Laser> m_all_lasers; /**< Each is a laser pulse */
     int m_3d_on_host {0};/** Whether the 3D laser envelope is stored in host or device memory */
-    amrex::Real m_focal_distance {0.};
     /** Number of guard cells for slices MultiFab */
     amrex::IntVect m_slices_nguards = {-1, -1, -1};
     std::string m_solver_type = "multigrid";

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -730,6 +730,8 @@ MultiLaser::InitLaserSlice (const amrex::Geometry& geom, const int islice)
                 const amrex::Real x = (i+0.5_rt)*dx_arr[0]+plo[0];
                 const amrex::Real y = (j+0.5_rt)*dx_arr[1]+plo[1];
 
+                np1j00_arr(i,j,k,dcomp  ) = 0._rt;
+                np1j00_arr(i,j,k,dcomp+1) = 0._rt;
                 for (const auto& laser : m_all_lasers) {
                     const amrex::Real a0 = laser.m_a0;
                     const amrex::Real w0 = laser.m_w0;

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -39,6 +39,9 @@ MultiLaser::ReadParameters ()
 #endif
 
     m_nlasers = m_names.size();
+    for (int i = 0; i < m_nlasers; ++i) {
+        m_all_lasers.emplace_back(Laser(m_names[i]));
+    }
 
     getWithParser(pp, "lambda0", m_lambda0);
     queryWithParser(pp, "3d_on_host", m_3d_on_host);

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1,4 +1,4 @@
-#include "Laser.H"
+#include "MultiLaser.H"
 #include "utils/Constants.H"
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
@@ -17,7 +17,7 @@
 #endif
 
 void
-Laser::ReadParameters ()
+MultiLaser::ReadParameters ()
 {
     amrex::ParmParse pp(m_name);
     queryWithParser(pp, "use_laser", m_use_laser);
@@ -63,12 +63,12 @@ Laser::ReadParameters ()
 
 
 void
-Laser::InitData (const amrex::BoxArray& slice_ba,
+MultiLaser::InitData (const amrex::BoxArray& slice_ba,
                  const amrex::DistributionMapping& slice_dm)
 {
     if (!m_use_laser) return;
 
-    HIPACE_PROFILE("Laser::InitData()");
+    HIPACE_PROFILE("MultiLaser::InitData()");
 
     // Alloc 2D slices
     // Need at least 1 guard cell transversally for transverse derivative
@@ -128,12 +128,12 @@ Laser::InitData (const amrex::BoxArray& slice_ba,
 }
 
 void
-Laser::Init3DEnvelope (int step, amrex::Box bx, const amrex::Geometry& gm)
+MultiLaser::Init3DEnvelope (int step, amrex::Box bx, const amrex::Geometry& gm)
 {
 
     if (!m_use_laser) return;
 
-    HIPACE_PROFILE("Laser::Init3DEnvelope()");
+    HIPACE_PROFILE("MultiLaser::Init3DEnvelope()");
     // Allocate the 3D field on this box
     // Note: box has no guard cells
     m_F.resize(bx, m_nfields_3d, m_3d_on_host ? amrex::The_Pinned_Arena() : amrex::The_Arena());
@@ -163,13 +163,13 @@ Laser::Init3DEnvelope (int step, amrex::Box bx, const amrex::Geometry& gm)
 }
 
 void
-Laser::Copy (int isl, bool to3d)
+MultiLaser::Copy (int isl, bool to3d)
 {
     if (!m_use_laser) return;
 
     using namespace amrex::literals;
 
-    HIPACE_PROFILE("Laser::Copy()");
+    HIPACE_PROFILE("MultiLaser::Copy()");
 
     amrex::MultiFab& nm1j00 = m_slices[WhichLaserSlice::nm1j00];
     amrex::MultiFab& nm1jp1 = m_slices[WhichLaserSlice::nm1jp1];
@@ -222,7 +222,7 @@ Laser::Copy (int isl, bool to3d)
 }
 
 void
-Laser::AdvanceSlice (const Fields& fields, const amrex::Geometry& geom, amrex::Real dt, int step)
+MultiLaser::AdvanceSlice (const Fields& fields, const amrex::Geometry& geom, amrex::Real dt, int step)
 {
 
     if (!m_use_laser) return;
@@ -237,10 +237,10 @@ Laser::AdvanceSlice (const Fields& fields, const amrex::Geometry& geom, amrex::R
 }
 
 void
-Laser::AdvanceSliceMG (const Fields& fields, const amrex::Geometry& geom, amrex::Real dt, int step)
+MultiLaser::AdvanceSliceMG (const Fields& fields, const amrex::Geometry& geom, amrex::Real dt, int step)
 {
 
-    HIPACE_PROFILE("Laser::AdvanceSliceMG()");
+    HIPACE_PROFILE("MultiLaser::AdvanceSliceMG()");
 
     using namespace amrex::literals;
     using Complex = amrex::GpuComplex<amrex::Real>;
@@ -453,10 +453,10 @@ Laser::AdvanceSliceMG (const Fields& fields, const amrex::Geometry& geom, amrex:
 }
 
 void
-Laser::AdvanceSliceFFT (const Fields& fields, const amrex::Geometry& geom, const amrex::Real dt, int step)
+MultiLaser::AdvanceSliceFFT (const Fields& fields, const amrex::Geometry& geom, const amrex::Real dt, int step)
 {
 
-    HIPACE_PROFILE("Laser::AdvanceSliceFFT()");
+    HIPACE_PROFILE("MultiLaser::AdvanceSliceFFT()");
 
     using namespace amrex::literals;
     using Complex = amrex::GpuComplex<amrex::Real>;
@@ -694,11 +694,11 @@ Laser::AdvanceSliceFFT (const Fields& fields, const amrex::Geometry& geom, const
 }
 
 void
-Laser::InitLaserSlice (const amrex::Geometry& geom, const int islice)
+MultiLaser::InitLaserSlice (const amrex::Geometry& geom, const int islice)
 {
     if (!m_use_laser) return;
 
-    HIPACE_PROFILE("Laser::InitLaserSlice()");
+    HIPACE_PROFILE("MultiLaser::InitLaserSlice()");
 
     using namespace amrex::literals;
     using Complex = amrex::GpuComplex<amrex::Real>;

--- a/src/particles/deposition/ExplicitDeposition.H
+++ b/src/particles/deposition/ExplicitDeposition.H
@@ -14,12 +14,12 @@
 /** Depose Sx and Sy of particles in species plasma into the current 2D slice in fields
  * \param[in] plasma species of which the current is deposited
  * \param[in,out] fields the general field class, modified by this function
- * \param[in] laser that affects the plasma during the deposition
+ * \param[in] multi_laser Lasers that affects the plasma during the deposition
  * \param[in] gm Geometry of the simulation, to get the cell size etc.
  * \param[in] lev MR level
  */
 void
-ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields, const Laser& laser,
+ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields, const MultiLaser& multi_laser,
                     amrex::Geometry const& gm, const int lev);
 
 #endif //  EXPLICITDEPOSITION_H_

--- a/src/particles/deposition/ExplicitDeposition.cpp
+++ b/src/particles/deposition/ExplicitDeposition.cpp
@@ -16,7 +16,7 @@
 #include "AMReX_GpuLaunch.H"
 
 void
-ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields, const Laser& laser,
+ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields, const MultiLaser& multi_laser,
                     amrex::Geometry const& gm, const int lev) {
     HIPACE_PROFILE("ExplicitDeposition()");
     using namespace amrex::literals;
@@ -48,8 +48,8 @@ ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields, const Laser
             plasma.m_can_ionize ? soa.GetIntData(PlasmaIdx::ion_lev).data() : nullptr;
 
         // Construct empty Array4 with one z slice so that Array3 constructor works for no laser
-        const Array3<const amrex::Real> a_laser_arr = laser.m_use_laser ?
-            laser.getSlices(WhichLaserSlice::n00j00).const_array(pti) :
+        const Array3<const amrex::Real> a_laser_arr = multi_laser.m_use_laser ?
+            multi_laser.getSlices(WhichLaserSlice::n00j00).const_array(pti) :
             amrex::Array4<const amrex::Real>(nullptr, {0,0,0}, {0,0,1}, 0);
 
         const amrex::Real x_pos_offset = GetPosOffset(0, gm, isl_fab.box());
@@ -71,7 +71,7 @@ ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields, const Laser
             amrex::TypeList<amrex::CompileTimeOptions<0, 1, 2, 3>,      // depos_order
                             amrex::CompileTimeOptions<false, true>,     // can_ionize
                             amrex::CompileTimeOptions<false, true>>{},  // use_laser
-            {Hipace::m_depos_order_xy, plasma.m_can_ionize, laser.m_use_laser},
+            {Hipace::m_depos_order_xy, plasma.m_can_ionize, multi_laser.m_use_laser},
             pti.numParticles(),
             [=] AMREX_GPU_DEVICE (int ip, auto a_depos_order, auto can_ionize, auto use_laser) {
                 constexpr int depos_order = a_depos_order.value;

--- a/src/particles/deposition/PlasmaDepositCurrent.H
+++ b/src/particles/deposition/PlasmaDepositCurrent.H
@@ -12,13 +12,13 @@
 #include "particles/sorting/TileSort.H"
 #include "fields/Fields.H"
 #include "utils/Constants.H"
-#include "laser/Laser.H"
+#include "laser/MultiLaser.H"
 #include "Hipace.H"
 
 /** Depose current of particles in species plasma into the current 2D slice in fields
  * \param[in] plasma species of which the current is deposited
  * \param[in,out] fields the general field class, modified by this function
- * \param[in] laser that affects the plasma during the deposition
+ * \param[in] multi_laser MultiLaser that affects the plasma during the deposition
  * \param[in] which_slice defines if this or the next slice is handled
  * \param[in] temp_slice if true, the temporary data (x_temp, ...) is used
  * \param[in] deposit_jx_jy if true, deposit to jx and jy
@@ -31,7 +31,7 @@
  * \param[in] bin_size tile size (square)
  */
 void
-DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const Laser& laser,
+DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLaser& multi_laser,
                 const int which_slice, const bool temp_slice,
                 const bool deposit_jx_jy, const bool deposit_jz, const bool deposit_rho,
                 bool deposit_chi, amrex::Geometry const& gm, int const lev,

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -214,6 +214,9 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const Laser& l
                     q_mu0_mass_ratio *= ion_lev[ip];
                 }
 
+                const amrex::Real xmid = (xp - x_pos_offset) * dx_inv;
+                const amrex::Real ymid = (yp - y_pos_offset) * dy_inv;
+
                 amrex::Real Aabssqp = 0._rt;
                 [[maybe_unused]] auto laser_arr = a_laser_arr;
                 if constexpr (use_laser.value) {
@@ -248,12 +251,10 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const Laser& l
                         }
                         // --- Compute shape factors
                         // x direction
-                        const amrex::Real xmid = (xp - x_pos_offset) * dx_inv;
                         auto [shape_x, cell_x] =
                             compute_single_shape_factor<outer_depos_loop_x, depos_order_xy>(xmid, tx);
 
                         // y direction
-                        const amrex::Real ymid = (yp - y_pos_offset) * dy_inv;
                         auto [shape_y, cell_y] =
                             compute_single_shape_factor<false, depos_order_xy>(ymid, iy);
 

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -20,7 +20,7 @@
 
 
 void
-DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const Laser& laser,
+DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLaser& multi_laser,
                 const int which_slice, const bool temp_slice,
                 const bool deposit_jx_jy, const bool deposit_jz, const bool deposit_rho,
                 const bool deposit_chi, amrex::Geometry const& gm, int const lev,
@@ -62,7 +62,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const Laser& l
         amrex::Vector<amrex::FArrayBox>& tmp_dens = fields.getTmpDensities();
 
         // extract the laser Fields
-        const amrex::MultiFab& a_mf = laser.getSlices(WhichLaserSlice::n00j00);
+        const amrex::MultiFab& a_mf = multi_laser.getSlices(WhichLaserSlice::n00j00);
 
         // Offset for converting positions to indexes
         const amrex::Real x_pos_offset = GetPosOffset(0, gm, isl_fab.box());
@@ -86,7 +86,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const Laser& l
 
         // Extract laser array from MultiFab
         const Array3<const amrex::Real> a_laser_arr =
-            laser.m_use_laser ? a_mf[pti].const_array() : amrex::Array4<const amrex::Real>();
+            multi_laser.m_use_laser ? a_mf[pti].const_array() : amrex::Array4<const amrex::Real>();
 
         // Extract box properties
         const amrex::Real invvol = Hipace::m_normalized_units ? 1._rt : 1._rt/(dx[0]*dx[1]*dx[2]);
@@ -174,7 +174,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const Laser& l
                     Hipace::m_outer_depos_loop,
                     plasma.m_can_ionize,
                     do_tiling,
-                    laser.m_use_laser
+                    multi_laser.m_use_laser
                 },
                 num_particles,
                 [=] AMREX_GPU_DEVICE (int idx, auto depos_order, auto outer_depos_loop,

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -11,7 +11,7 @@
 #include "PlasmaParticleContainer.H"
 #include "particles/sorting/TileSort.H"
 #include "fields/Fields.H"
-#include "laser/Laser.H"
+#include "laser/MultiLaser.H"
 #include "particles/collisions/CoulombCollision.H"
 
 class MultiPlasma
@@ -42,7 +42,7 @@ public:
     /** Loop over plasma species and depose their currents into the current 2D slice in fields
      *
      * \param[in,out] fields the general field class, modified by this function
-     * \param[in] laser that affects the plasma during the deposition
+     * \param[in] multi_laser Lasers that affects the plasma during the deposition
      * \param[in] which_slice defines if this or the next slice is handled
      * \param[in] temp_slice if true, the temporary data (x_temp, ...) is used
      * \param[in] deposit_jx_jy if true, deposit to jx and jy
@@ -53,18 +53,18 @@ public:
      * \param[in] lev MR level
      */
     void DepositCurrent (
-        Fields & fields, const Laser & laser, int which_slice, bool temp_slice, bool deposit_jx_jy,
+        Fields & fields, const MultiLaser & multi_laser, int which_slice, bool temp_slice, bool deposit_jx_jy,
         bool deposit_jz, bool deposit_rho, bool deposit_chi, amrex::Geometry const& gm,
         int const lev);
 
     /** Loop over plasma species and depose Sx and Sy into the current 2D slice in fields
      *
      * \param[in,out] fields the general field class, modified by this function
-     * \param[in] laser that affects the plasma during the deposition
+     * \param[in] multi_laser Lasers that affects the plasma during the deposition
      * \param[in] gm Geometry of the simulation, to get the cell size etc.
      * \param[in] lev MR level
      */
-    void ExplicitDeposition (Fields& fields, const Laser& laser,
+    void ExplicitDeposition (Fields& fields, const MultiLaser& multi_laser,
                              amrex::Geometry const& gm, int const lev);
 
     /** \brief Return max density, to compute the adaptive time step.
@@ -77,7 +77,7 @@ public:
     /** \brief Loop over plasma species and Gather fields, update forces and push particles
      *
      * \param[in,out] fields the general field class, modified by this function
-     * \param[in] laser that affects the plasma during the deposition
+     * \param[in] multi_laser Lasers that affects the plasma during the deposition
      * \param[in] gm Geometry of the simulation, to get the cell size etc.
      * \param[in] temp_slice if true, the temporary data (x_temp, ...) will be used
      * \param[in] do_push boolean to define if plasma particles are pushed
@@ -86,7 +86,7 @@ public:
      * \param[in] lev MR level
      */
     void AdvanceParticles (
-        const Fields & fields, const Laser & laser, amrex::Geometry const& gm, bool temp_slice,
+        const Fields & fields, const MultiLaser & multi_laser, amrex::Geometry const& gm, bool temp_slice,
         bool do_push, bool do_update, bool do_shift, int lev);
 
     /** \brief Resets the particle position x, y, to x_prev, y_prev
@@ -99,13 +99,13 @@ public:
     /** \brief Loop over plasma species and deposit their neutralizing background, if needed
      *
      * \param[in,out] fields the general field class, modified by this function
-     * \param[in] laser that affects the plasma during the deposition
+     * \param[in] multi_laser that affects the plasma during the deposition
      * \param[in] which_slice slice in which the densities are deposited
      * \param[in] gm Geometry of the simulation, to get the cell size etc.
      * \param[in] nlev number of MR levels
      */
     void DepositNeutralizingBackground (
-        Fields & fields, const Laser & laser, int which_slice, amrex::Geometry const& gm,
+        Fields & fields, const MultiLaser & multi_laser, int which_slice, amrex::Geometry const& gm,
         int const nlev);
 
     /** Calculates Ionization Probability and makes new Plasma Particles

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -82,34 +82,34 @@ MultiPlasma::maxDensity () const
 
 void
 MultiPlasma::DepositCurrent (
-    Fields & fields, const Laser & laser, int which_slice, bool temp_slice, bool deposit_jx_jy,
-    bool deposit_jz, bool deposit_rho, bool deposit_chi, amrex::Geometry const& gm,
-    int const lev)
+    Fields & fields, const MultiLaser & multi_laser, int which_slice, bool temp_slice,
+    bool deposit_jx_jy, bool deposit_jz, bool deposit_rho, bool deposit_chi,
+    amrex::Geometry const& gm, int const lev)
 {
     for (int i=0; i<m_nplasmas; i++) {
-        ::DepositCurrent(m_all_plasmas[i], fields, laser, which_slice, temp_slice,
+        ::DepositCurrent(m_all_plasmas[i], fields, multi_laser, which_slice, temp_slice,
                          deposit_jx_jy, deposit_jz, deposit_rho, deposit_chi,
                          gm, lev, m_all_bins[i], m_sort_bin_size);
     }
 }
 
 void
-MultiPlasma::ExplicitDeposition (Fields& fields, const Laser& laser,
+MultiPlasma::ExplicitDeposition (Fields& fields, const MultiLaser& multi_laser,
                                  amrex::Geometry const& gm, int const lev)
 {
     for (int i=0; i<m_nplasmas; i++) {
-        ::ExplicitDeposition(m_all_plasmas[i], fields, laser, gm, lev);
+        ::ExplicitDeposition(m_all_plasmas[i], fields, multi_laser, gm, lev);
     }
 }
 
 void
 MultiPlasma::AdvanceParticles (
-    const Fields & fields, const Laser & laser, amrex::Geometry const& gm, bool temp_slice,
+    const Fields & fields, const MultiLaser & multi_laser, amrex::Geometry const& gm, bool temp_slice,
     bool do_push, bool do_update, bool do_shift, int lev)
 {
     for (int i=0; i<m_nplasmas; i++) {
         AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice,
-                               do_push, do_update, do_shift, lev, m_all_bins[i], laser);
+                               do_push, do_update, do_shift, lev, m_all_bins[i], multi_laser);
     }
 }
 
@@ -124,14 +124,14 @@ MultiPlasma::ResetParticles (int lev, bool initial)
 
 void
 MultiPlasma::DepositNeutralizingBackground (
-    Fields & fields, const Laser & laser, int which_slice, amrex::Geometry const& gm, int const nlev)
+    Fields & fields, const MultiLaser & multi_laser, int which_slice, amrex::Geometry const& gm, int const nlev)
 {
     for (int lev = 0; lev < nlev; ++lev) {
         for (int i=0; i<m_nplasmas; i++) {
             if (m_all_plasmas[i].m_neutralize_background){
                 // current of ions is zero, so they are not deposited.
-                ::DepositCurrent(m_all_plasmas[i], fields, laser, which_slice, false, false, false,
-                                 true, false, gm, lev, m_all_bins[i], m_sort_bin_size);
+                ::DepositCurrent(m_all_plasmas[i], fields, multi_laser, which_slice, false, false,
+                                 false, true, false, gm, lev, m_all_bins[i], m_sort_bin_size);
             }
         }
     }

--- a/src/particles/pusher/PlasmaParticleAdvance.H
+++ b/src/particles/pusher/PlasmaParticleAdvance.H
@@ -12,7 +12,7 @@
 #include "particles/sorting/TileSort.H"
 #include "fields/Fields.H"
 #include "Hipace.H"
-#include "laser/Laser.H"
+#include "laser/MultiLaser.H"
 
 /** \brief Gather field values for particles, update the force terms, and push the particles
  * \param[in,out] plasma plasma species to push
@@ -24,13 +24,13 @@
  * \param[in] do_shift boolean to define if the force terms are shifted
  * \param[in] lev MR level
  * \param[in] bins objects containing indices of plasma particles in each tile
- * \param[in] laser laser pulse, which affects the plasma via the ponderomotive force
+ * \param[in] multi_laser Laser pulses, which affects the plasma via the ponderomotive force
  */
 void
 AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Geometry const& gm, const bool temp_slice, const bool do_push,
                         const bool do_update, const bool do_shift, int const lev,
-                        PlasmaBins& bins, const Laser& laser);
+                        PlasmaBins& bins, const MultiLaser& multi_laser);
 
 /** \brief Resets the particle position x, y, to x_prev, y_prev
  * \param[in,out] plasma plasma species to reset

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -26,7 +26,7 @@ void
 AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Geometry const& gm, const bool temp_slice, const bool do_push,
                         const bool do_update, const bool do_shift, int const lev,
-                        PlasmaBins& bins, const Laser& laser)
+                        PlasmaBins& bins, const MultiLaser& multi_laser)
 {
     std::string str = "UpdateForcePushParticles_Plasma(    )";
     if (temp_slice) str.at(32) = 't';
@@ -59,8 +59,8 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
         const int bz_comp = Comps[WhichSlice::This]["Bz"];
 
         // extract the laser Fields
-        const bool use_laser = laser.m_use_laser;
-        const amrex::MultiFab& a_mf = laser.getSlices(WhichLaserSlice::n00j00);
+        const bool use_laser = multi_laser.m_use_laser;
+        const amrex::MultiFab& a_mf = multi_laser.getSlices(WhichLaserSlice::n00j00);
 
         // Extract field array from MultiFab
         Array3<const amrex::Real> const& a_arr = use_laser ?

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -30,14 +30,14 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
         // STEP 1: Calculate what Ez would be with the initial SALAME beam weight
 
         // advance plasma to the temp slice, only shift once
-        hipace->m_multi_plasma.AdvanceParticles(hipace->m_fields, hipace->m_laser, hipace->Geom(lev),
+        hipace->m_multi_plasma.AdvanceParticles(hipace->m_fields, hipace->m_multi_laser, hipace->Geom(lev),
                                                 true, true, true, iter==0, lev);
 
         hipace->m_fields.duplicate(lev, WhichSlice::Salame, {"jx", "jy"},
                                         WhichSlice::Next, {"jx_beam", "jy_beam"});
 
         // deposit plasma jx and jy on the next temp slice, to the SALANE slice
-        hipace->m_multi_plasma.DepositCurrent(hipace->m_fields, hipace->m_laser,
+        hipace->m_multi_plasma.DepositCurrent(hipace->m_fields, hipace->m_multi_laser,
                 WhichSlice::Salame, true, true, false, false, false, hipace->Geom(lev), lev);
 
         // use an initial guess of zero for Bx and By in MG solver to reduce relative error
@@ -64,7 +64,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
         if (do_advance) {
             SalameOnlyAdvancePlasma(hipace, lev);
 
-            hipace->m_multi_plasma.DepositCurrent(hipace->m_fields, hipace->m_laser,
+            hipace->m_multi_plasma.DepositCurrent(hipace->m_fields, hipace->m_multi_laser,
                     WhichSlice::Salame, true, true, false, false, false, hipace->Geom(lev), lev);
         } else {
             SalameGetJxJyFromBxBy(hipace, lev);
@@ -110,7 +110,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
 
         hipace->InitializeSxSyWithBeam(lev);
 
-        hipace->m_multi_plasma.ExplicitDeposition(hipace->m_fields, hipace->m_laser,
+        hipace->m_multi_plasma.ExplicitDeposition(hipace->m_fields, hipace->m_multi_laser,
                                                   hipace->Geom(lev), lev);
 
         hipace->ExplicitMGSolveBxBy(lev, WhichSlice::This);

--- a/tests/laser_blowout_wake_explicit.1Rank.sh
+++ b/tests/laser_blowout_wake_explicit.1Rank.sh
@@ -29,9 +29,9 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beams.names = no_beam \
         geometry.prob_lo     = -20.   -20.   -8  \
         geometry.prob_hi     =  20.    20.    6  \
-        laser.use_laser = 1 \
+        lasers.names = laser \
+        lasers.lambda0 = .8e-6 \
         laser.a0 = 4.5 \
-        laser.lambda0 = .8e-6 \
         laser.position_mean = 0. 0. 0 \
         laser.w0 = 4 4 \
         laser.L0 = 2 \

--- a/tests/laser_blowout_wake_explicit.1Rank.sh
+++ b/tests/laser_blowout_wake_explicit.1Rank.sh
@@ -33,7 +33,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         lasers.lambda0 = .8e-6 \
         laser.a0 = 4.5 \
         laser.position_mean = 0. 0. 0 \
-        laser.w0 = 4 4 \
+        laser.w0 = 4 \
         laser.L0 = 2 \
         amr.n_cell = 128 128 100 \
 

--- a/tests/laser_blowout_wake_explicit.SI.1Rank.sh
+++ b/tests/laser_blowout_wake_explicit.SI.1Rank.sh
@@ -32,7 +32,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_SI \
         lasers.lambda0 = .8e-6 \
         laser.a0 = 4.5 \
         laser.position_mean = 0. 0. 0 \
-        laser.w0 = 4.*kp_inv 4.*kp_inv \
+        laser.w0 = 4.*kp_inv \
         laser.L0 = 2.*kp_inv \
         amr.n_cell = 128 128 100 \
 

--- a/tests/laser_blowout_wake_explicit.SI.1Rank.sh
+++ b/tests/laser_blowout_wake_explicit.SI.1Rank.sh
@@ -28,9 +28,9 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_SI \
         beams.names = no_beam \
         geometry.prob_lo     = -20.*kp_inv   -20.*kp_inv   -8.*kp_inv  \
         geometry.prob_hi     =  20.*kp_inv    20.*kp_inv    6.*kp_inv  \
-        laser.use_laser = 1 \
+        lasers.names = laser \
+        lasers.lambda0 = .8e-6 \
         laser.a0 = 4.5 \
-        laser.lambda0 = .8e-6 \
         laser.position_mean = 0. 0. 0 \
         laser.w0 = 4.*kp_inv 4.*kp_inv \
         laser.L0 = 2.*kp_inv \

--- a/tests/laser_evolution.SI.2Rank.sh
+++ b/tests/laser_evolution.SI.2Rank.sh
@@ -27,7 +27,7 @@ TEST_NAME="${FILE_NAME%.*}"
 
 # Run the simulation with multigrid Poisson solver
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_SI \
-        laser.solver_type = multigrid \
+        lasers.solver_type = multigrid \
         hipace.file_prefix = $TEST_NAME
 # Compare the result with theory
 $HIPACE_EXAMPLE_DIR/analysis_laser_vacuum.py --output-dir=$TEST_NAME
@@ -36,7 +36,7 @@ rm -rf $TEST_NAME
 
 # Run the simulation with FFT Poisson solver
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_SI \
-        laser.solver_type = fft \
+        lasers.solver_type = fft \
         hipace.file_prefix = $TEST_NAME
 # Compare the result with theory
 $HIPACE_EXAMPLE_DIR/analysis_laser_vacuum.py --output-dir=$TEST_NAME


### PR DESCRIPTION
This PR enables multiple laser pulses. Files `Laser.H/cpp` are renamed `MultiLaser.H/cpp`, handling multiple laser pulses. The `MultiLaser` class holds a vector of `Laser`s, similar to beams or plasmas, with 1 notable difference: the actual data is stored into 1 single array for all lasers, and this array is in `MultiLaser`. `Laser` is almost an empty class. In the future, this will be generalised and each `Laser` instance will have a separate array. Important point: `lambda0` is a property of `MultiLaser` rather than `Laser`, so we can solve for all lasers at the same time.

Change along the way:
- w0 is not a scalar (previously 2 scalars for x and y but we asserted they were equal). Very easy to change.
- The input parameters are now similar to beams and plasmas, see below. We got rid of the `use_laser` that @SeverinDiederichs disliked so much :).

The PR is unnecessary long, the content of `MultiLaser`  is just the one from `Laser`, except for the constructor and `ReadParameters`. Unfortunately, `git mv` did not help and git is being confused here.

```
lasers.names = laser laser2 # deactivated with no_laser
lasers.lambda0 = .8e-6

laser.a0 = 1
laser.position_mean = 0. 0. 0
laser.w0 = 2.*kp_inv
laser.L0 = 2.*kp_inv
laser.focal_distance = 0.001

laser2.a0 = 2
laser2.position_mean = 0. 0. -4*kp_inv
laser2.w0 = 4.*kp_inv
laser2.L0 = 1.*kp_inv
laser2.focal_distance = 0.0005
```

On Juwels GPUs: top is `laser_real`, bottom is `Ez`, for a laser propagating upwards in a plasma. All looks fine.
![Screenshot 2022-11-24 at 16 00 12](https://user-images.githubusercontent.com/26292713/203814675-6f409585-fbab-4da7-8398-804da993033b.png)
