### PR TITLE
reset laser slices before DepositNeutralizingBackground

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -215,9 +215,8 @@ public:
     /** \brief Reset plasma and field slice quantities to initial value.
      *
      * Typically done at the beginning of each iteration.
-     * \param[in] step current time step
      */
-    void ResetAllQuantities (const int step);
+    void ResetAllQuantities ();
 
     /** \brief reset all laser slices to 0 */
     void ResetLaser ();

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -215,8 +215,9 @@ public:
     /** \brief Reset plasma and field slice quantities to initial value.
      *
      * Typically done at the beginning of each iteration.
+     * \param[in] step current time step
      */
-    void ResetAllQuantities ();
+    void ResetAllQuantities (const int step);
 
     /** \brief reset all laser slices to 0 */
     void ResetLaser ();

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -432,7 +432,7 @@ Hipace::Evolve ()
         }
 #endif
 
-        ResetAllQuantities();
+        ResetAllQuantities(step);
 
         /* Store charge density of (immobile) ions into WhichSlice::RhoIons */
         if (m_do_tiling) m_multi_plasma.TileSort(boxArray(lev)[0], geom[lev]);
@@ -450,7 +450,6 @@ Hipace::Evolve ()
                 AMREX_ALWAYS_ASSERT(m_multi_plasma.GetNPlasmas() <= 1);
                 // Before that, the 3D fields of the envelope are not initialized (not even allocated).
                 m_multi_laser.Init3DEnvelope(step, bx, Geom(0));
-                if (it == n_boxes-1) ResetLaser();
             }
 
             Wait(step, it);
@@ -727,9 +726,13 @@ Hipace::PredictorCorrectorSolveOneSubSlice (const int lev, const int step, const
 }
 
 void
-Hipace::ResetAllQuantities ()
+Hipace::ResetAllQuantities (const int step)
 {
     HIPACE_PROFILE("Hipace::ResetAllQuantities()");
+
+    if (step != m_numprocs_z - 1 - m_rank_z && m_multi_laser.m_use_laser) {
+        ResetLaser();
+    }
 
     for (int lev = 0; lev <= finestLevel(); ++lev) {
         m_multi_plasma.ResetParticles(lev, true);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -432,7 +432,7 @@ Hipace::Evolve ()
         }
 #endif
 
-        ResetAllQuantities(step);
+        ResetAllQuantities();
 
         /* Store charge density of (immobile) ions into WhichSlice::RhoIons */
         if (m_do_tiling) m_multi_plasma.TileSort(boxArray(lev)[0], geom[lev]);
@@ -726,13 +726,11 @@ Hipace::PredictorCorrectorSolveOneSubSlice (const int lev, const int step, const
 }
 
 void
-Hipace::ResetAllQuantities (const int step)
+Hipace::ResetAllQuantities ()
 {
     HIPACE_PROFILE("Hipace::ResetAllQuantities()");
 
-    if (step != m_numprocs_z - 1 - m_rank_z && m_multi_laser.m_use_laser) {
-        ResetLaser();
-    }
+    if (m_use_laser) ResetLaser();
 
     for (int lev = 0; lev <= finestLevel(); ++lev) {
         m_multi_plasma.ResetParticles(lev, true);


### PR DESCRIPTION
Previously, the laser was reset in the beginning of the loop over boxes. However, this was after `DepositNeutralizingBackground`. When a laser was dephasing such that there was a laser in the last slice, the laser slice was not reset and the neutralizing background was under the laser influence. Then, the laser was reset and the plasma deposited on the first slice did not match the NeutralizingBackground so there was a charge separation including fields etc.

This PR resets the laser slices when all other quantities are reset. The step is passed to `ResetAllQuantities` since the laser is only allocated after `ResetAllQuantities` is called in the first time step.

Development:
step 0:
![Screenshot from 2022-11-27 10-17-58](https://user-images.githubusercontent.com/65728274/204127708-fe33935f-382d-4ce4-bdca-3dde23aec683.png)
step 1:
![Screenshot from 2022-11-27 10-18-29](https://user-images.githubusercontent.com/65728274/204127732-b89ce53c-9a90-44c6-8918-ed39000c4814.png)


This PR:
step 0
![Screenshot from 2022-11-27 10-15-08](https://user-images.githubusercontent.com/65728274/204127606-716c284a-aa34-48cc-9893-e5f8de66c0b6.png)
step 1:
![Screenshot from 2022-11-27 10-16-22](https://user-images.githubusercontent.com/65728274/204127640-abf6e929-9702-42fe-905d-f64a6d7dc02e.png)


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
