### PR TITLE
[mini] remove unused x0 and y0 from laser

### DIFF
--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -727,8 +727,6 @@ MultiLaser::InitLaserSlice (const amrex::Geometry& geom, const int islice)
             const auto& laser = m_all_lasers[ilaser];
             const amrex::Real a0 = laser.m_a0;
             const amrex::Real w0 = laser.m_w0;
-            const amrex::Real x0 = laser.m_position_mean[0];
-            const amrex::Real y0 = laser.m_position_mean[1];
             const amrex::Real z0 = laser.m_position_mean[2];
             const amrex::Real L0 = laser.m_L0;
             const amrex::Real zfoc = laser.m_focal_distance;


### PR DESCRIPTION
This small PR removes two unused parameters to get rid of compiler warnings.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
