### PR TITLE
[mini] Enable laser transverse offset

### DIFF
--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -30,6 +30,4 @@ Laser::Laser (std::string name)
     amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
     queryWithParser(pp, "position_mean", loc_array);
     for (int idim=0; idim < AMREX_SPACEDIM; ++idim) m_position_mean[idim] = loc_array[idim];
-    AMREX_ALWAYS_ASSERT(m_position_mean[0] == 0.);
-    AMREX_ALWAYS_ASSERT(m_position_mean[1] == 0.);
 }

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -737,8 +737,8 @@ MultiLaser::InitLaserSlice (const amrex::Geometry& geom, const int islice)
                 [=] AMREX_GPU_DEVICE(int i, int j, int k)
                 {
                     amrex::Real z = plo[2] + (islice+0.5_rt)*dx_arr[2] - zfoc;
-                    const amrex::Real x = (i+0.5_rt)*dx_arr[0]+plo[0];
-                    const amrex::Real y = (j+0.5_rt)*dx_arr[1]+plo[1];
+                    const amrex::Real x = (i+0.5_rt)*dx_arr[0]+plo[0]-x0;
+                    const amrex::Real y = (j+0.5_rt)*dx_arr[1]+plo[1]-y0;
 
                     // For first laser, setval to 0.
                     if (ilaser == 0) {


### PR DESCRIPTION
The option to have transverse offsets for laser pulses was incomplete, causing compilation issues, as seen in #829. This PR proposes to implement it.