### PR TITLE
update CUDA CI to 11.8

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -19,8 +19,8 @@ jobs:
 #   https://github.com/ComputationalRadiationPhysics/picongpu/blob/0.5.0/share/picongpu/dockerfiles/ubuntu-1604/Dockerfile
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_nvcc:
-    name: NVCC 11.0.2 SP
-    runs-on: ubuntu-18.04
+    name: NVCC 11.8 SP
+    runs-on: ubuntu-20.04
     if: github.event.pull_request.draft == false
     env:
       CXXFLAGS: "-Werror"

--- a/.github/workflows/setup/nvcc11.sh
+++ b/.github/workflows/setup/nvcc11.sh
@@ -20,6 +20,7 @@ sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
     cmake               \
+    g++                 \
     gnupg               \
     libhiredis-dev      \
     libopenmpi-dev      \
@@ -35,15 +36,15 @@ echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x8
 
 sudo apt-get update
 sudo apt-get install -y          \
-    cuda-command-line-tools-11-0 \
-    cuda-compiler-11-0           \
-    cuda-cupti-dev-11-0          \
-    cuda-minimal-build-11-0      \
-    cuda-nvml-dev-11-0           \
-    cuda-nvtx-11-0               \
-    libcufft-dev-11-0            \
-    libcurand-dev-11-0
-sudo ln -s cuda-11.0 /usr/local/cuda
+    cuda-command-line-tools-11-8 \
+    cuda-compiler-11-8           \
+    cuda-cupti-dev-11-8          \
+    cuda-minimal-build-11-8      \
+    cuda-nvml-dev-11-8           \
+    cuda-nvtx-11-8               \
+    libcufft-dev-11-8            \
+    libcurand-dev-11-8
+sudo ln -s cuda-11.8 /usr/local/cuda
 
 # cmake-easyinstall
 #


### PR DESCRIPTION
This PR is a clean version of #770

Recently, we noticed that some errors (see #825 and #833) are caught only in cuda versions >= 11.5, since nvcc seems to have added more asserts. Therefore, this PR proposes to switch to the latest cuda version 11.8.
From CI output: 
```
-- The CUDA compiler identification is NVIDIA 11.8.89
```

Using the latest cuda version would have captured #833, as demonstrated in #770

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
