### PR TITLE
Mesh Refinement with Explicit Solver

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -209,8 +209,9 @@ public:
      *
      * \param[lev] MR level
      * \param[in] which_slice defines if this or the salame slice is handled
+     * \param[in] islice longitudinal slice
      */
-    void ExplicitMGSolveBxBy (const int lev, const int which_slice);
+    void ExplicitMGSolveBxBy (const int lev, const int which_slice, const int islice);
 
     /** \brief Reset plasma and field slice quantities to initial value.
      *
@@ -403,12 +404,12 @@ private:
 
 #ifdef AMREX_USE_LINEAR_SOLVERS
     /** Linear operator for the explicit Bx and By solver */
-    std::unique_ptr<amrex::MLALaplacian> m_mlalaplacian;
+    amrex::Vector<std::unique_ptr<amrex::MLALaplacian>> m_mlalaplacian;
     /** Geometric multigrid solver class, for the explicit Bx and By solver */
-    std::unique_ptr<amrex::MLMG> m_mlmg;
+    amrex::Vector<std::unique_ptr<amrex::MLMG>> m_mlmg;
 #endif
     /** hpmg solver for the explicit Bx and by solver */
-    std::unique_ptr<hpmg::MultiGrid> m_hpmg;
+    amrex::Vector<std::unique_ptr<hpmg::MultiGrid>> m_hpmg;
 public:
     /** Used to sort the beam particles into boxes for pipelining */
     amrex::Vector<BoxSorter> m_box_sorters;

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -359,6 +359,8 @@ public:
     static bool m_use_amrex_mlmg;
     /** Whether the simulation uses a laser pulse */
     static bool m_use_laser;
+    /** Whether the simulation uses mesh refinement */
+    static bool m_do_MR
     /** Adaptive time step instance */
     AdaptiveTimeStep m_adaptive_time_step;
     /** Laser instance (soon to be multi laser container) */

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -360,7 +360,7 @@ public:
     /** Whether the simulation uses a laser pulse */
     static bool m_use_laser;
     /** Whether the simulation uses mesh refinement */
-    static bool m_do_MR
+    static bool m_do_MR;
     /** Adaptive time step instance */
     AdaptiveTimeStep m_adaptive_time_step;
     /** Laser instance (soon to be multi laser container) */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -591,15 +591,19 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox, int step,
                 m_multi_laser.Copy(islice_coarse, true);
             }
 
-            // shift slices of all levels
-            m_fields.ShiftSlices(lev, islice_coarse, Geom(0), patch_lo[2], patch_hi[2]);
-
+            if (lev!=0) {
+                // shift slices of level 1
+                m_fields.ShiftSlices(lev, islice_coarse, Geom(0), patch_lo[2], patch_hi[2]);
+            }
         } // end for (int isubslice = nsubslice-1; isubslice >= 0; --isubslice)
 
         // After this, the parallel context is the full 3D communicator again
         amrex::ParallelContext::pop();
 
     } // end for (int lev = 0; lev <= finestLevel(); ++lev)
+
+    // shift level 0
+    m_fields.ShiftSlices(0, islice_coarse, Geom(0), patch_lo[2], patch_hi[2]);
 }
 
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -585,13 +585,13 @@ Hipace::SolveOneSlice (int islice_coarse, const int ibox, int step,
 
             if (m_multi_plasma.IonizationOn() && m_do_tiling) m_multi_plasma.TileSort(bx, geom[lev]);
 
-            if (lev==0) {
+            if (lev == 0) {
                 // Advance laser slice by 1 step and store result to 3D array
                 m_multi_laser.AdvanceSlice(m_fields, Geom(0), m_dt, step);
                 m_multi_laser.Copy(islice_coarse, true);
             }
 
-            if (lev!=0) {
+            if (lev != 0) {
                 // shift slices of level 1
                 m_fields.ShiftSlices(lev, islice_coarse, Geom(0), patch_lo[2], patch_hi[2]);
             }
@@ -871,6 +871,11 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice, const int isl
             m_mlalaplacian.resize(maxLevel()+1);
             m_mlmg.resize(maxLevel()+1);
         }
+
+        // construct slice geometry
+        amrex::Geometry slice_geom = m_slice_geom[lev];
+        slice_geom.setPeriodicity({0,0,0});
+
         if (!m_mlalaplacian[lev]){
             // If first call, initialize the MG solver
             amrex::LPInfo lpinfo{};
@@ -917,7 +922,8 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice, const int isl
             m_hpmg.resize(maxLevel()+1);
         }
         if (!m_hpmg[lev]) {
-            m_hpmg[lev] = std::make_unique<hpmg::MultiGrid>(slice_geom,
+            m_hpmg[lev] = std::make_unique<hpmg::MultiGrid>(m_slice_geom[lev].CellSize(0),
+                                                            m_slice_geom[lev].CellSize(1),
                                                             slicemf_BxBySySx.boxArray()[0]);
         }
         const int max_iters = 200;

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -171,13 +171,13 @@ public:
      * to compute each slice. The current slice is always stored in index 1.
      * Hence, after one slice is computed, slices must be shifted by 1 element.
      *
-     * \param[in] nlev number of MR level
+     * \param[in] lev the MR level
      * \param[in] islice current slice to be shifted
      * \param[in] geom geometry
      * \param[in] patch_lo lower longitudinal end of refined level
      * \param[in] patch_hi upper longitudinal end of refined level
      */
-    void ShiftSlices (int nlev, int islice, const amrex::Geometry geom, const amrex::Real patch_lo,
+    void ShiftSlices (int lev, int islice, const amrex::Geometry geom, const amrex::Real patch_lo,
                       const amrex::Real patch_hi);
 
     /** add rho of the ions to rho (this slice) */
@@ -191,9 +191,11 @@ public:
      * \param[in] lev current level
      * \param[in] component which can be Psi, Ez, By, Bx ...
      * \param[in] islice longitudinal slice
+     * \param[in,out] staging_area Target MultiFab where the boundary condition is applied
      */
     void SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                               std::string component, const int islice);
+                               std::string component, const int islice,
+                               amrex::MultiFab&& staging_area);
 
     /** \brief Interpolate values from coarse grid to the fine grid
      *

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -63,7 +63,7 @@ Fields::AllocData (
 
         m_explicit = Hipace::GetInstance().m_explicit;
         m_any_neutral_background = Hipace::GetInstance().m_multi_plasma.AnySpeciesNeutralizeBackground();
-        const bool mesh_refinement = Hipace::GetInstance().maxLevel() != 0;
+        const bool mesh_refinement = Hipace::m_do_MR;
         const bool any_salame = Hipace::GetInstance().m_multi_beam.AnySpeciesSalame();
 
         if (m_explicit) {
@@ -522,7 +522,7 @@ Fields::ShiftSlices (int lev, int islice, amrex::Geometry geom, amrex::Real patc
     }
 
     const bool explicit_solve = Hipace::GetInstance().m_explicit;
-    const bool mesh_refinement = Hipace::GetInstance().maxLevel() != 0;
+    const bool mesh_refinement = Hipace::m_do_MR;
 
     // only shift the slices that are allocated
     if (explicit_solve) {

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -443,7 +443,7 @@ MultiLaser::AdvanceSliceMG (const Fields& fields, const amrex::Geometry& geom, a
 
     slice_geom.setPeriodicity({0,0,0});
     if (!m_mg) {
-        m_mg = std::make_unique<hpmg::MultiGrid>(slice_geom);
+        m_mg = std::make_unique<hpmg::MultiGrid>(slice_geom, np1j00.boxArray()[0]);
     }
 
     const int max_iters = 200;

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -423,27 +423,9 @@ MultiLaser::AdvanceSliceMG (const Fields& fields, const amrex::Geometry& geom, a
             });
     }
 
-    // construct slice geometry
-    // Set the lo and hi of domain and probdomain in the z direction
-    amrex::RealBox tmp_probdom({AMREX_D_DECL(geom.ProbLo(Direction::x),
-                                             geom.ProbLo(Direction::y),
-                                             geom.ProbLo(Direction::z))},
-                               {AMREX_D_DECL(geom.ProbHi(Direction::x),
-                                             geom.ProbHi(Direction::y),
-                                             geom.ProbHi(Direction::z))});
-    amrex::Box tmp_dom = geom.Domain();
-    const amrex::Real hi = geom.ProbHi(Direction::z);
-    const amrex::Real lo = hi - geom.CellSize(2);
-    tmp_probdom.setLo(Direction::z, lo);
-    tmp_probdom.setHi(Direction::z, hi);
-    tmp_dom.setSmall(Direction::z, 0);
-    tmp_dom.setBig(Direction::z, 0);
-    amrex::Geometry slice_geom = amrex::Geometry(
-        tmp_dom, tmp_probdom, geom.Coord(), geom.isPeriodic());
-
-    slice_geom.setPeriodicity({0,0,0});
     if (!m_mg) {
-        m_mg = std::make_unique<hpmg::MultiGrid>(slice_geom, np1j00.boxArray()[0]);
+        m_mg = std::make_unique<hpmg::MultiGrid>(geom.CellSize(0), geom.CellSize(1),
+                                                 np1j00.boxArray()[0]);
     }
 
     const int max_iters = 200;

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -37,7 +37,7 @@ public:
     /** \brief Ctor
      *
      * \param[in] dx Cell spacing in x direction
-     * \param[in] dy Cell spacing in x direction
+     * \param[in] dy Cell spacing in y direction
      * \param[in] a_domain Box describing a 2D slice
      */
     explicit MultiGrid (amrex::Real dx, amrex::Real dy, amrex::Box a_domain);

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -150,7 +150,6 @@ public:
         amrex::Box out_box = amrex::makeSlab(
             in_box + (domain.smallEnd() + domain.bigEnd() - in_box.smallEnd() - in_box.bigEnd())/2,
         2, 0);
-        amrex::Print() << "in box " << in_box << " out box " << out_box << " domain " << domain << '\n';
         AMREX_ALWAYS_ASSERT(out_box.contains(domain));
         return out_box;
     }

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -36,10 +36,11 @@ public:
 
     /** \brief Ctor
      *
-     * \param[in] geom Geometry for dx and dy
-     * \param[in] domain Box describing a 2D slice
+     * \param[in] dx Cell spacing in x direction
+     * \param[in] dy Cell spacing in x direction
+     * \param[in] a_domain Box describing a 2D slice
      */
-    explicit MultiGrid (amrex::Geometry const& geom, amrex::Box a_domain);
+    explicit MultiGrid (amrex::Real dx, amrex::Real dy, amrex::Box a_domain);
 
     /** \brief Dtor */
     ~MultiGrid ();

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -36,9 +36,10 @@ public:
 
     /** \brief Ctor
      *
-     * \param[in] geom Geometry describing a 2D slice
+     * \param[in] geom Geometry for dx and dy
+     * \param[in] domain Box describing a 2D slice
      */
-    explicit MultiGrid (amrex::Geometry const& geom);
+    explicit MultiGrid (amrex::Geometry const& geom, amrex::Box a_domain);
 
     /** \brief Dtor */
     ~MultiGrid ();
@@ -142,6 +143,17 @@ public:
     void solve_doit (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
                      amrex::Real const tol_rel, amrex::Real const tol_abs,
                      int const nummaxiter, int const verbose);
+    /** \brief Centers the input box in x and y around the domain so that only the ghost
+     * cells "overhang". Make it a slab in the z direction and set the index to 0.
+     */
+    amrex::Box center_box (amrex::Box in_box, amrex::Box domain) {
+        amrex::Box out_box = amrex::makeSlab(
+            in_box + (domain.smallEnd() + domain.bigEnd() - in_box.smallEnd() - in_box.bigEnd())/2,
+        2, 0);
+        amrex::Print() << "in box " << in_box << " out box " << out_box << " domain " << domain << '\n';
+        AMREX_ALWAYS_ASSERT(out_box.contains(domain));
+        return out_box;
+    }
 
 private:
 

--- a/src/mg_solver/HpMultiGrid.cpp
+++ b/src/mg_solver/HpMultiGrid.cpp
@@ -378,8 +378,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
 
 } // namespace {}
 
-MultiGrid::MultiGrid (Geometry const& geom, Box a_domain)
-    : m_dx(geom.CellSize(0)), m_dy(geom.CellSize(1))
+MultiGrid::MultiGrid (Real dx, Real dy, Box a_domain)
+    : m_dx(dx), m_dy(dy)
 {
     AMREX_ALWAYS_ASSERT(a_domain.length(2) == 1 && a_domain.cellCentered());
 

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -56,7 +56,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
 
         SalameInitializeSxSyWithBeam(hipace, lev);
 
-        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::Salame);
+        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::Salame, islice);
 
         hipace->m_fields.setVal(0., lev, WhichSlice::Salame, "Ez", "jx", "jy");
 
@@ -113,7 +113,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
         hipace->m_multi_plasma.ExplicitDeposition(hipace->m_fields, hipace->m_multi_laser,
                                                   hipace->Geom(lev), lev);
 
-        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::This);
+        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::This, islice);
     }
 }
 


### PR DESCRIPTION
A few things had to be adjusted for MR to work with the explicit solver:
- One MG solver per level.
- Set the boundary condition for Bx and By on level 1. This is similar compared to PC but the MG solvers (hpmg and amrex) expect the boundary at the cell face instead of center, so a few values had to be adjusted.
- Properly shift slices for level 1.
- Shift the domain box in hpmg so that lo is at 0,0,0. Contrary to level 0, level 1 doesn’t already have this property.
- Assert that MR is not used with SALAME.

This fixes the last open issue in #667

![image](https://user-images.githubusercontent.com/64009254/205714403-61520fb3-bd6c-40e1-8896-81ee00a28db2.png)

![image](https://user-images.githubusercontent.com/64009254/205714550-4644b8cb-b4a8-4073-a7ce-812a3281f26d.png)


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
