### PR TITLE
Remove numprocs_x/y in all inputs, useless and confusing

### DIFF
--- a/examples/beam_in_vacuum/inputs_SI
+++ b/examples/beam_in_vacuum/inputs_SI
@@ -6,8 +6,6 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
 hipace.predcorr_B_mixing_factor = 0.95
 hipace.predcorr_max_iterations = 5
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/beam_in_vacuum/inputs_normalized
+++ b/examples/beam_in_vacuum/inputs_normalized
@@ -8,8 +8,6 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
 hipace.predcorr_B_mixing_factor = 0.95
 hipace.predcorr_max_iterations = 5
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/beam_in_vacuum/inputs_normalized_transverse
+++ b/examples/beam_in_vacuum/inputs_normalized_transverse
@@ -9,9 +9,7 @@ amr.max_level = 0
 
 max_step = 9
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-hipace.dt=1.
+hipace.dt = 1.
 
 hipace.depos_order_xy = 2
 

--- a/examples/blowout_wake/inputs_SI
+++ b/examples/blowout_wake/inputs_SI
@@ -15,9 +15,6 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-
 hipace.depos_order_xy = 2
 
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/blowout_wake/inputs_ionization_SI
+++ b/examples/blowout_wake/inputs_ionization_SI
@@ -16,9 +16,6 @@ amr.max_level = 0
 max_step = 2
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-
 hipace.depos_order_xy = 2
 
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -11,9 +11,6 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-
 hipace.depos_order_xy = 2
 
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/gaussian_weight/inputs_SI
+++ b/examples/gaussian_weight/inputs_SI
@@ -6,8 +6,6 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
 hipace.predcorr_B_mixing_factor = 0.95
 geometry.coord_sys   = 0                  # 0: Cartesian
 geometry.is_periodic = 0 0 0      # Is periodic?

--- a/examples/gaussian_weight/inputs_normalized
+++ b/examples/gaussian_weight/inputs_normalized
@@ -6,8 +6,7 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 hipace.normalized_units = 1
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
+
 hipace.predcorr_B_mixing_factor = 0.95
 geometry.coord_sys   = 0                  # 0: Cartesian
 geometry.is_periodic = 0 0 0      # Is periodic?

--- a/examples/laser/inputs_SI
+++ b/examples/laser/inputs_SI
@@ -28,9 +28,6 @@ amr.max_level = 0
 
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-
 hipace.depos_order_xy = 0
 
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/linear_wake/inputs_SI
+++ b/examples/linear_wake/inputs_SI
@@ -11,9 +11,6 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-
 hipace.depos_order_xy = 2
 
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/linear_wake/inputs_ion_motion_SI
+++ b/examples/linear_wake/inputs_ion_motion_SI
@@ -19,9 +19,6 @@ amr.max_level = 0
 max_step = 0
 hipace.output_period = 1
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-
 hipace.depos_order_xy = 2
 
 geometry.coord_sys   = 0                  # 0: Cartesian

--- a/examples/linear_wake/inputs_normalized
+++ b/examples/linear_wake/inputs_normalized
@@ -9,9 +9,6 @@ amr.max_level = 0
 
 max_step = 0
 
-hipace.numprocs_x = 1
-hipace.numprocs_y = 1
-
 hipace.depos_order_xy = 2
 
 geometry.coord_sys   = 0                  # 0: Cartesian


### PR DESCRIPTION
All input scripts contained `hipace.numprocs_x = 1`, which just takes up some space although `1` is the only possible value (and the default). This PR proposes to remove othem.