### PR TITLE
[TEST] Profiler using CUDA Events

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,11 +15,13 @@
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
+    StreamProfilerNode::Initialize();
     {
         HIPACE_PROFILE("main()");
         Hipace hipace;
         hipace.InitData();
         hipace.Evolve();
     }
+    StreamProfilerNode::Finalize();
     amrex::Finalize();
 }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -12,4 +12,5 @@ target_sources(HiPACE
     IOUtil.cpp
     GridCurrent.cpp
     Parser.cpp
+    HipaceProfilerWrapper.cpp
 )

--- a/src/utils/HipaceProfilerWrapper.H
+++ b/src/utils/HipaceProfilerWrapper.H
@@ -38,7 +38,7 @@ struct StreamProfilerNode {
     std::map<std::string, StreamProfilerNode> m_children{};
 
     unsigned long long m_ncalls = 0;
-    static constexpr int m_nevents = 4;
+    static constexpr int m_nevents = 8;
 
     Event_t m_start[m_nevents];
     Event_t m_stop[m_nevents];
@@ -71,7 +71,9 @@ struct StreamProfilerNode {
 
         if (m_ncalls > m_nevents) {
             float time = 0.;
-            AMREX_CUDA_SAFE_CALL(cudaEventSynchronize(m_stop[ievent]));
+            if (cudaEventQuery(m_stop[ievent]) != cudaSuccess) {
+                AMREX_CUDA_SAFE_CALL(cudaEventSynchronize(m_stop[ievent]));
+            }
             AMREX_CUDA_SAFE_CALL(cudaEventElapsedTime(&time, m_start[ievent], m_stop[ievent]));
             m_time_inc += time/1000.;
             m_time_inc_sq += time/1000.*time/1000.;
@@ -117,8 +119,8 @@ struct StreamProfiler {
 
 
 #define HIPACE_PROFILE(fname) StreamProfiler BL_PROFILE_PASTE(PROF_SCOPE_, __COUNTER__){fname}
-#define HIPACE_DETAIL_PROFILE(fname) HIPACE_PROFILE(fname)
-
+//#define HIPACE_DETAIL_PROFILE(fname) HIPACE_PROFILE(fname)
+#define HIPACE_DETAIL_PROFILE(fname)
 
 /*
 template<int detail_level>

--- a/src/utils/HipaceProfilerWrapper.H
+++ b/src/utils/HipaceProfilerWrapper.H
@@ -15,12 +15,112 @@
 #ifndef HIPACE_PROFILERWRAPPER_H_
 #define HIPACE_PROFILERWRAPPER_H_
 
-#include <AMReX_BLProfiler.H>
 #include <AMReX_GpuDevice.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_Algorithm.H>
+#include <map>
+#include <string>
+#include <vector>
+#include <array>
+
 
 /** Whether to call amrex::Gpu::streamSynchronize() around all profiler region */
 inline int DO_DEVICE_SYNCHRONIZE = 0;
 
+
+
+
+struct StreamProfilerNode {
+
+    using Event_t = cudaEvent_t;
+
+    StreamProfilerNode* m_parent;
+    std::map<std::string, StreamProfilerNode> m_children{};
+
+    unsigned long long m_ncalls = 0;
+    static constexpr int m_nevents = 4;
+
+    Event_t m_start[m_nevents];
+    Event_t m_stop[m_nevents];
+
+    double m_time_inc = 0;
+    double m_time_exc = 0;
+    double m_time_inc_sq = 0;
+
+    static StreamProfilerNode* m_root;
+    static StreamProfilerNode* m_stack_location;
+
+
+    StreamProfilerNode () : m_parent{m_stack_location} {
+        for (int i=0; i<m_nevents; ++i) {
+            AMREX_CUDA_SAFE_CALL(cudaEventCreate(&m_start[i]));
+            AMREX_CUDA_SAFE_CALL(cudaEventCreate(&m_stop[i]));
+        }
+    }
+
+    ~StreamProfilerNode () {
+        for (int i=0; i<m_nevents; ++i) {
+            AMREX_CUDA_SAFE_CALL(cudaEventDestroy(m_start[i]));
+            AMREX_CUDA_SAFE_CALL(cudaEventDestroy(m_stop[i]));
+        }
+    }
+
+    void start () {
+        ++m_ncalls;
+        const int ievent = (m_ncalls-1) % m_nevents;
+
+        if (m_ncalls > m_nevents) {
+            float time = 0.;
+            AMREX_CUDA_SAFE_CALL(cudaEventSynchronize(m_stop[ievent]));
+            AMREX_CUDA_SAFE_CALL(cudaEventElapsedTime(&time, m_start[ievent], m_stop[ievent]));
+            m_time_inc += time/1000.;
+            m_time_inc_sq += time/1000.*time/1000.;
+        }
+
+        AMREX_CUDA_SAFE_CALL(cudaEventRecord(m_start[ievent], amrex::Gpu::gpuStream()));
+
+        m_stack_location = this;
+    }
+
+    void stop () {
+        const int ievent = (m_ncalls-1) % m_nevents;
+        AMREX_CUDA_SAFE_CALL(cudaEventRecord(m_stop[ievent], amrex::Gpu::gpuStream()));
+        m_stack_location = m_parent;
+    }
+
+    static void Initialize ();
+    static void Finalize ();
+
+private:
+
+    void GetExcData ();
+    void FinishEvents ();
+    void PrintTime (std::vector<std::array<std::string,6>>&, const std::string&,
+                                                             const std::string&, double);
+};
+
+
+struct StreamProfiler {
+    StreamProfilerNode* m_node;
+
+    StreamProfiler (const std::string& fname) {
+        m_node = &(StreamProfilerNode::m_stack_location->m_children[fname]);
+        //std::cout << fname << " " << m_node->m_ncalls << std::endl;
+        m_node->start();
+    }
+
+    ~StreamProfiler () {
+        m_node->stop();
+    }
+};
+
+
+
+#define HIPACE_PROFILE(fname) StreamProfiler BL_PROFILE_PASTE(PROF_SCOPE_, __COUNTER__){fname}
+#define HIPACE_DETAIL_PROFILE(fname) HIPACE_PROFILE(fname)
+
+
+/*
 template<int detail_level>
 AMREX_FORCE_INLINE
 void doStreamSynchronize ()
@@ -51,5 +151,6 @@ struct synchronizeOnDestruct {
 #define HIPACE_DETAIL_PROFILE_VAR_START(vname) doStreamSynchronize<2>(); BL_PROFILE_VAR_START(vname)
 #define HIPACE_DETAIL_PROFILE_VAR_STOP(vname) doStreamSynchronize<2>(); BL_PROFILE_VAR_STOP(vname)
 #define HIPACE_DETAIL_PROFILE_REGION(rname) doStreamSynchronize<2>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<2> BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){}
+*/
 
 #endif // HIPACE_PROFILERWRAPPER_H_

--- a/src/utils/HipaceProfilerWrapper.cpp
+++ b/src/utils/HipaceProfilerWrapper.cpp
@@ -1,0 +1,151 @@
+/* Copyright 2022
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: AlexanderSinn, MaxThevenet
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "HipaceProfilerWrapper.H"
+#include <AMReX.H>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <algorithm>
+
+
+
+StreamProfilerNode* StreamProfilerNode::m_root = nullptr;
+StreamProfilerNode* StreamProfilerNode::m_stack_location = nullptr;
+
+void StreamProfilerNode::Initialize () {
+    StreamProfilerNode::m_root = new StreamProfilerNode();
+    StreamProfilerNode::m_stack_location = StreamProfilerNode::m_root;
+    m_root->start();
+}
+
+void StreamProfilerNode::Finalize () {
+    m_root->stop();
+    StreamProfilerNode::m_root->FinishEvents();
+    StreamProfilerNode::m_root->GetExcData();
+
+    std::vector<std::array<std::string,6>> str_arr{};
+    m_root->PrintTime(str_arr, "", "", m_root->m_time_inc);
+
+    str_arr[0] = {"Name", "NCalls", "Inc. Time", "Inc. std %", "Excl. Time", "Excl. %"};
+
+    std::array<int, 6> num_chars{0,0,0,0,0,0};
+    for (int i=0; i<str_arr.size(); ++i) {
+        for (int j=0; j<num_chars.size(); ++j) {
+            num_chars[j] = std::max<int>(num_chars[j], str_arr[i][j].size());
+        }
+    }
+
+    for (int j=1; j<num_chars.size(); ++j) {
+        num_chars[j] += 2;
+    }
+
+    amrex::OutStream() << "\n\n";
+
+    for (int i=0; i<str_arr.size(); ++i) {
+        if (i==0 ||i==1) {
+            for (int j=0; j<num_chars.size(); ++j) {
+                for (int c=0; c<num_chars[j]; ++c) {
+                    amrex::OutStream() << '-';
+                }
+            }
+            amrex::OutStream() << '\n';
+        }
+
+        for (int j=0; j<num_chars.size(); ++j) {
+            if (j==0) {
+                amrex::OutStream() << std::setw(num_chars[j]) << std::left << str_arr[i][j];
+            } else {
+                amrex::OutStream() << std::setw(num_chars[j]) << std::right << str_arr[i][j];
+            }
+        }
+        amrex::OutStream() << '\n';
+    }
+
+
+    delete StreamProfilerNode::m_root;
+}
+
+void StreamProfilerNode::GetExcData () {
+    m_time_exc = m_time_inc;
+    for (auto& [fname, node] : m_children) {
+        m_time_exc -= node.m_time_inc;
+        node.GetExcData();
+    }
+}
+
+void StreamProfilerNode::FinishEvents () {
+    for (auto ncalls = m_ncalls; ncalls<(m_ncalls+m_nevents); ++ncalls) {
+        const int ievent = ncalls % m_nevents;
+        if (ncalls >= m_nevents) {
+            float time = 0.;
+            AMREX_CUDA_SAFE_CALL(cudaEventSynchronize(m_stop[ievent]));
+            AMREX_CUDA_SAFE_CALL(cudaEventElapsedTime(&time, m_start[ievent], m_stop[ievent]));
+            m_time_inc += time/1000.;
+            m_time_inc_sq += time/1000.*time/1000.;
+        }
+    }
+
+    for (auto& [fname, node] : m_children) {
+        node.FinishEvents();
+    }
+}
+
+void StreamProfilerNode::PrintTime (std::vector<std::array<std::string,6>>& str_arr,
+                                    const std::string& prefix, const std::string& name,
+                                    double time_total) {
+
+    std::stringstream ss1{};
+    ss1 << std::setprecision(4) << m_time_inc;
+    std::stringstream ss2{};
+    ss2 << "+-" << std::fixed << std::setprecision(2) << (100.*std::sqrt(
+        std::max(m_ncalls*m_time_inc_sq - m_time_inc*m_time_inc, 0.)/m_time_inc)) << "%";
+    std::stringstream ss3{};
+    ss3 << std::setprecision(4) << m_time_exc;
+    std::stringstream ss4{};
+    ss4 << std::fixed << std::setprecision(2) << (100.*m_time_exc/time_total) << "%";
+
+    str_arr.push_back({
+        prefix + name,
+        std::to_string(m_ncalls),
+        ss1.str(),
+        ss2.str(),
+        ss3.str(),
+        ss4.str()
+    });
+
+    std::vector<decltype(m_children)::value_type*> node_vect{m_children.size()};
+
+    unsigned long long i = 0;
+    for (auto& val : m_children) {
+        node_vect[i++] = &val;
+    }
+
+    std::sort(node_vect.begin(), node_vect.end(), [](auto* a, auto* b){
+        return a->second.m_time_inc > b->second.m_time_inc;
+    });
+
+    for (i=0; i<node_vect.size(); ++i) {
+        std::string new_prefix = prefix + "|-";
+        if (prefix.size() >= 2) {
+            if (prefix[prefix.size()-1] == '-' && prefix[prefix.size()-2] == '|') {
+                new_prefix[prefix.size()-2] = '|';
+                new_prefix[prefix.size()-1] = ' ';
+            } else if (prefix[prefix.size()-2] == '\\') {
+                new_prefix[prefix.size()-2] = ' ';
+                new_prefix[prefix.size()-1] = ' ';
+            }
+        }
+        if (i+1==node_vect.size()) {
+            new_prefix[new_prefix.size()-2] = '\\';
+            new_prefix[new_prefix.size()-1] = '-';
+        }
+
+        node_vect[i]->second.PrintTime(str_arr, new_prefix, node_vect[i]->first, time_total);
+    }
+}


### PR DESCRIPTION
Only works with CUDA.

Unfortunately, it seems that performance is not significantly improved compared to using stream synchronize with a CPU timer and still worse than not using a profiler.


Test with 256\*256\*2048 Cells (small kernels):

Events | Tiny+streamSynchronize | Tiny no sync
-- | -- | --
4.668s | 4.841s | 4.259s

Output from event profiler:

```
---------------------------------------------------------------------------------------------------------------
Name                                                         NCalls  Inc. Time  Inc. std %  Excl. Time  Excl. %
---------------------------------------------------------------------------------------------------------------
\-main()                                                          1      4.668     +-0.00%    0.001108    0.02%
  |-Hipace::Evolve()                                              1       4.58     +-0.00%     0.06826    1.46%
  | |-Hipace::SolveOneSlice()                                  2048      4.173    +-16.10%       0.151    3.23%
  | | |-Hipace::ExplicitMGSolveBxBy()                          2048      2.322    +-15.29%     0.01257    0.27%
  | | | \-hpmg::MultiGrid::solve1()                            2048       2.31    +-15.33%        2.31   49.48%
  | | |-Fields::SolveExmByAndEypBx()                           2048     0.4429     +-2.08%     0.05455    1.17%
  | | | |-FFTPoissonSolverDirichlet::SolvePoissonEquation()    2048     0.3682     +-0.58%     0.04043    0.87%
  | | | | \-AnyDST::Execute()                                  4096     0.3277     +-3.30%      0.3277    7.02%
  | | | |-Fields::LinCombination()                             2048    0.01475     +-1.04%     0.01475    0.32%
  | | | \-Fields::SetBoundaryCondition()                       2048   0.005476     +-1.48%    0.005476    0.12%
  | | |-Fields::SolvePoissonEz()                               2048     0.3837     +-0.26%     0.02214    0.47%
  | | | |-FFTPoissonSolverDirichlet::SolvePoissonEquation()    2048     0.3412     +-0.23%     0.03192    0.68%
  | | | | \-AnyDST::Execute()                                  4096     0.3093     +-0.37%      0.3093    6.63%
  | | | |-Fields::LinCombination()                             2048    0.01481     +-0.90%     0.01481    0.32%
  | | | \-Fields::SetBoundaryCondition()                       2048   0.005529     +-1.36%    0.005529    0.12%
  | | |-Fields::SolvePoissonBz()                               2048     0.3829     +-0.22%     0.02201    0.47%
  | | | |-FFTPoissonSolverDirichlet::SolvePoissonEquation()    2048     0.3416     +-0.22%     0.03228    0.69%
  | | | | \-AnyDST::Execute()                                  4096     0.3093     +-0.37%      0.3093    6.63%
  | | | |-Fields::LinCombination()                             2048    0.01377     +-0.89%     0.01377    0.29%
  | | | \-Fields::SetBoundaryCondition()                       2048   0.005548     +-1.35%    0.005548    0.12%
  | | |-DepositCurrent_PlasmaParticleContainer()               2048      0.101     +-0.81%       0.101    2.16%
  | | |-DepositCurrentSlice_BeamParticleContainer()            4096    0.08652    +-84.76%     0.08652    1.85%
  | | |-UpdateForcePushParticles_Plasma( pus)                  2048    0.07281     +-0.60%     0.07281    1.56%
  | | |-ExplicitDeposition()                                   2048    0.05614     +-0.80%     0.05614    1.20%
  | | |-AdvanceBeamParticlesSlice()                            2048      0.044    +-13.23%       0.044    0.94%
  | | |-Fields::AddRhoIons()                                   2048     0.0436     +-0.98%      0.0436    0.93%
  | | |-Fields::ShiftSlices()                                  2048    0.02827     +-0.70%     0.02827    0.61%
  | | |-Hipace::InitializeSxSyWithBeam()                       2048    0.02106     +-0.77%     0.02106    0.45%
  | | |-Fields::Copy()                                         2048    0.02027     +-0.81%     0.02027    0.43%
  | | |-PlasmaParticleContainer::IonizationModule()            2048   0.005541     +-1.35%    0.005541    0.12%
  | | |-MultiPlasma::doCoulombCollision                        2048   0.005516     +-1.36%    0.005516    0.12%
  | | \-GridCurrent::DepositCurrentSlice()                     2048   0.005475     +-1.38%    0.005475    0.12%
  | |-Hipace::WriteDiagnostics()                                  2     0.2962    +-54.42%      0.1959    4.20%
  | | \-WriteBeamParticleData()                                   1     0.1003     +-0.00%      0.1003    2.15%
  | |-findParticlesInEachSlice()                                  1    0.04101     +-0.00%     0.04101    0.88%
  | |-OpenPMDWriter::InitDiagnostics()                            1  0.0009677     +-0.00%   0.0009677    0.02%
  | |-Hipace::ResetAllQuantities()                                1  0.0001403     +-0.00%   8.499e-05    0.00%
  | | \-ResetPlasmaParticles()                                    1   5.53e-05     +-0.00%    5.53e-05    0.00%
  | |-DepositCurrent_PlasmaParticleContainer()                    1  5.837e-05     +-0.00%   5.837e-05    0.00%
  | |-AdaptiveTimeStep::Calculate()                               1  3.072e-06     +-0.00%   3.072e-06    0.00%
  | |-Hipace::Notify()                                            1  3.072e-06     +-0.00%   3.072e-06    0.00%
  | |-Hipace::Wait()                                              1  3.072e-06     +-0.00%   3.072e-06    0.00%
  | \-Hipace::CheckGhostSlice()                                   1  2.048e-06     +-0.00%   2.048e-06    0.00%
  \-Hipace::InitData()                                            1    0.08693     +-0.00%   0.0005018    0.01%
    |-Fields::AllocData()                                         1    0.07476     +-0.00%   0.0008858    0.02%
    | \-FFTPoissonSolverDirichlet::define()                       1    0.07387     +-0.00%   6.144e-05    0.00%
    |   \-AnyDST::CreatePlan()                                    1    0.07381     +-0.00%     0.07381    1.58%
    |-BeamParticleContainer::InitParticles                        1   0.009581     +-0.00%    0.009581    0.21%
    |-MultiPlasma::InitData()                                     1   0.002089     +-0.00%   6.349e-05    0.00%
    | \-PlasmaParticleContainer::InitParticles                    1   0.002025     +-0.00%    0.002025    0.04%
    \-AdaptiveTimeStep::Calculate()                               1  3.072e-06     +-0.00%   3.072e-06    0.00%
```
https://developer.nvidia.com/blog/how-implement-performance-metrics-cuda-cc/


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
