### PR TITLE
Remove all calls to FillBoundary

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -223,13 +223,6 @@ public:
     void ResetLaser ();
 
     /**
-       \brief Calls FillBoundary on charges and currents on WhichSlice::This
-     *
-     * \param[in] lev MR level
-     */
-    void FillBoundaryChargeCurrents (int lev);
-
-    /**
        \brief Returns true on the head rank, otherwise false.
      */
     static bool HeadRank ()

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -436,37 +436,6 @@ public:
         }
     }
 
-    /** \brief call amrex FillBoundary for multiple fields
-     *
-     * \param[in] period periodicity of the fields
-     * \param[in] lev level of fields
-     * \param[in] islice slice of fields
-     * \param[in] comps names of fields like "Ez", "Bx", "By", "Bz"
-     */
-    template<class...Args>
-    void FillBoundary (const amrex::Periodicity& period, const int lev, const int islice,
-                       Args...comps) {
-        std::array<int, sizeof...(comps)> c_idx = {Comps[islice][comps]...};
-        amrex::MultiFab& mfab = getSlices(lev, islice);
-
-        // optimize adjacent fields to one FillBoundary call
-        std::sort(c_idx.begin(), c_idx.end());
-        int scomp = 0;
-        int ncomp = 0;
-        for (unsigned int i=0; i < c_idx.size(); ++i) {
-            if (ncomp==0) {
-                scomp = c_idx[i];
-                ncomp = 1;
-            }
-            if (i+1 >= c_idx.size() || c_idx[i+1] > scomp+ncomp) {
-                mfab.FillBoundary(scomp, ncomp, period);
-                ncomp = 0;
-            } else if (c_idx[i+1] == scomp+ncomp) {
-                ++ncomp;
-            }
-        }
-    }
-
     /** Number of guard cells for slices MultiFab */
     static amrex::IntVect m_slices_nguards;
     /** Number of guard cells for poisson solver MultiFab */

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -803,13 +803,6 @@ Fields::SolvePoissonExmByAndEypBx (amrex::Vector<amrex::Geometry> const& geom,
     SetBoundaryCondition(geom, lev, "Psi", islice, getStagingArea(lev));
     m_poisson_solver[lev]->SolvePoissonEquation(lhs);
 
-    if (!m_extended_solve) {
-        /* ---------- Transverse FillBoundary Psi ---------- */
-        amrex::ParallelContext::push(m_comm_xy);
-        lhs.FillBoundary(geom[lev].periodicity());
-        amrex::ParallelContext::pop();
-    }
-
     InterpolateFromLev0toLev1(geom, lev, "Psi", islice, m_slices_nguards, m_poisson_nguards);
 
     // Compute ExmBy = -d/dx psi and EypBx = -d/dy psi


### PR DESCRIPTION
Since HiPACE++ is not transversely parallelized, these are not necessarily. For the case of Dirichlet boundaries it does not make much sense to fille the guard cells with a periodic continuation rather than zero. Otherwise, the extended_solve option can be used to fill the guard cells using a slightly larger field solver.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
