### PR TITLE
User defined Ez chirp in SALAME algorithm

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -161,6 +161,15 @@ General parameters
     Whether the SALAME algorithm should calculate the SALAME-beam-only Ez field
     by advancing plasma (if `1`) particles or by approximating it using the chi field (if `0`).
 
+* ``hipace.salame_Ez_target(zeta,zeta_initial,Ez_initial)`` (`string`) optional (default `Ez_initial`)
+    Parser function to specify the target Ez field at the witness beam for SALAME.
+    ``zeta``: position of the Ez field to set.
+    ``zeta_initial``: position where the SALAME algorithm first started.
+    ``Ez_initial``: field value at `zeta_initial`.
+    For `zeta` equal to `zeta_initial`, the function should return `Ez_initial`.
+    The default value of this function corresponds to a flat Ez field at the position of the SALAME beam.
+    Note: `zeta` is always less than or equal to `zeta_initial` and `Ez_initial` is typically below zero for electron beams.
+
 Field solver parameters
 -----------------------
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -392,6 +392,12 @@ public:
     int m_salame_last_slice = -1;
     /** if the SALAME beam was overloaded in the last slice */
     bool m_salame_overloaded = false;
+    /** the slice index of the previous slice with SALAME */
+    amrex::Real m_salame_zeta_initial = 0;
+    /** Parser for m_salame_target_func */
+    amrex::Parser m_salame_parser;
+    /** Function to get the target Ez field for SALAME */
+    amrex::ParserExecutor<3> m_salame_target_func;
 
     /** \brief Check that the ghost beam particles are in the proper box, and invalidate
      * those not in the right slice.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -156,6 +156,11 @@ Hipace::Hipace () :
     queryWithParser(pph, "external_Ez_uniform", m_external_Ez_uniform);
     queryWithParser(pph, "salame_n_iter", m_salame_n_iter);
     queryWithParser(pph, "salame_do_advance", m_salame_do_advance);
+    std::string salame_target_str = "Ez_initial";
+    queryWithParser(pph, "salame_Ez_target(zeta,zeta_initial,Ez_initial)", salame_target_str);
+    m_salame_target_func = makeFunctionWithParser<3>(salame_target_str, m_salame_parser,
+                                                     {"zeta", "zeta_initial", "Ez_initial"});
+
     std::string solver = "predictor-corrector";
     queryWithParser(pph, "bxby_solver", solver);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -123,7 +123,7 @@ public:
     amrex::ParserExecutor<3> m_density_func; /**< Density function for the plasma */
     amrex::Real m_min_density {0.}; /**< minimal density at which particles are injected */
     bool m_use_density_table; /**< if a density value table was specified */
-    /** plasma density value table, key: position=c*time, value=density funciton string */
+    /** plasma density value table, key: position=c*time, value=density function string */
     std::map<amrex::Real, std::string> m_density_table;
     int m_level {0}; /**< mesh refinement level on which the plasma lives */
     /** maximum weighting factor gamma/(Psi +1) before particle is regarded as violating

--- a/src/salame/Salame.H
+++ b/src/salame/Salame.H
@@ -54,10 +54,11 @@ SalameOnlyAdvancePlasma (Hipace* hipace, const int lev);
  * The average is weighted using the SALAME beam current.
  * \param[in] hipace pointer to Hipace instance
  * \param[in] lev MR level
+ * \param[in] islice slice index of the whole domain
  * \return new beam weighting factor and new total SALAME beam current on this slice
  */
 std::pair<amrex::Real, amrex::Real>
-SalameGetW (Hipace* hipace, const int lev);
+SalameGetW (Hipace* hipace, const int lev, const int islice);
 
 /** Multiply SALAME beam weight on this slice with W
  * \param[in] W weight multiplier

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -256,7 +256,7 @@ SalameOnlyAdvancePlasma (Hipace* hipace, const int lev)
                         amrex::Real Bxp = 0._rt;
                         amrex::Real Byp = 0._rt;
 
-                        // Gather Bx and By along with 4 dummy fields to use this funciton
+                        // Gather Bx and By along with 4 dummy fields to use this function
                         doBxByGatherShapeN<depos_order.value>(xp, yp, Bxp, Byp, slice_arr,
                             bx_comp, by_comp, dx_inv, dy_inv, x_pos_offset, y_pos_offset);
 
@@ -322,7 +322,7 @@ SalameGetW (Hipace* hipace, const int lev, const int islice)
     // - 1 because this is for the Ez field of the next slice
     const amrex::Real zeta = (islice-1) * hipace->Geom(lev).CellSize(2) +
                              GetPosOffset(2, hipace->Geom(lev), hipace->Geom(lev).Domain());
-    // update target with user funciton
+    // update target with user function
     sum_Ez_target = hipace->m_salame_target_func(
                         zeta,  hipace->m_salame_zeta_initial, sum_Ez_target);
 

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -360,7 +360,11 @@ makeFunctionWithParser (std::string const& func_str,
                         amrex::Parser& parser,
                         amrex::Vector<std::string> const& varnames)
 {
-    parser.define(func_str);
+    std::string clean_str = func_str;
+    for (char& c : clean_str) {
+        if (c=='\n' || c=='\r' || c=='\t') c = ' ';
+    }
+    parser.define(clean_str);
     Parser::initParser(parser, varnames);
     return parser.compile<N>();
 }


### PR DESCRIPTION
Use
```
hipace.salame_Ez_target(zeta,zeta_initial,Ez_initial) = "Ez_initial"
```
For a flat Ez field at the SALAME beam (this is the default) or something more custom if needed
```
hipace.salame_Ez_target(zeta,zeta_initial,Ez_initial) = "
x=(zeta-zeta_initial+0.1)*100;
Ez_initial*(1-0.05*
if(x<-7, 0,
    if(x<-3, 3*sqrt(1-x^2/49),
        if(x<-1, (6*sqrt(10)/7 + (1.5-0.5*abs(x)) - (6*sqrt(10)/14)*sqrt(4-(abs(x)-1)^2) ),
            if(x<-0.75, 9-8*abs(x),
                if(x<-0.5, 3*abs(x)+0.75,
                    if(x<=0.5, 2.25,
                        if(x<=0.75, 3*abs(x)+0.75,
                            if(x<=1, 9-8*abs(x),
                                if(x<=3, (6*sqrt(10)/7 + (1.5-0.5*abs(x)) - (6*sqrt(10)/14)*sqrt(4-(abs(x)-1)^2) ),
                                    if(x<=7, 3*sqrt(1-x^2/49),
                                        0
                                    )
                                )
                            )
                        )
                    )
                )
            )
        )
    )
)/3)"
```

![image](https://user-images.githubusercontent.com/64009254/212660152-1351b622-70c0-416c-8779-659989d41419.png)















- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
