### PR TITLE
option to focus the beam at arbitrary position

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -486,6 +486,10 @@ Option: ``fixed_weight``
     Whether the beam particles are pushed along the z-axis. The momentum is still fully updated.
     Note: using ``do_z_push = 0`` results in unphysical behavior.
 
+* ``<beam name>.f_foc`` (`float`) optional (default `0.`)
+    Distance at which the beam will be focused, calculated from the position at which the beam is initialized.
+    The beam is assumed to propagate ballistically in-between.
+
 Option: ``fixed_ppc``
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -486,7 +486,7 @@ Option: ``fixed_weight``
     Whether the beam particles are pushed along the z-axis. The momentum is still fully updated.
     Note: using ``do_z_push = 0`` results in unphysical behavior.
 
-* ``<beam name>.f_foc`` (`float`) optional (default `0.`)
+* ``<beam name>.z_foc`` (`float`) optional (default `0.`)
     Distance at which the beam will be focused, calculated from the position at which the beam is initialized.
     The beam is assumed to propagate ballistically in-between.
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -97,6 +97,7 @@ public:
                               const amrex::Real pos_mean_z,
                               const amrex::RealVect pos_std,
                               const amrex::Real total_charge,
+                              const amrex::Real z_foc,
                               const bool do_symmetrize,
                               const bool can, const amrex::Real zmin, const amrex::Real zmax);
 
@@ -170,6 +171,8 @@ private:
     amrex::Parser m_pos_mean_y_parser;
     /** Width of the Gaussian beam. Only used for a fixed-weight beam */
     amrex::RealVect m_position_std {0., 0., 0.};
+    /** Distance at which the beam is focused, starting from its initial position */
+    amrex::Real m_z_foc {0.};
     amrex::Real m_duz_per_uz0_dzeta {0.}; /**< relative energy spread per dzeta */
     /** injection type, fixed_width or fixed_ppc */
     std::string m_injection_type;

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -123,6 +123,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 
         std::array<std::string, 3> pos_mean_arr{"","",""};
         getWithParser(pp, "position_mean", pos_mean_arr);
+        queryWithParser(pp, "z_foc", m_z_foc);
         auto pos_mean_x = makeFunctionWithParser<1>(pos_mean_arr[0], m_pos_mean_x_parser, {"z"});
         auto pos_mean_y = makeFunctionWithParser<1>(pos_mean_arr[1], m_pos_mean_y_parser, {"z"});
         amrex::Real pos_mean_z = 0;
@@ -155,7 +156,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
 
         const GetInitialMomentum get_momentum(m_name);
         InitBeamFixedWeight(m_num_particles, get_momentum, pos_mean_x, pos_mean_y, pos_mean_z,
-                            m_position_std, m_total_charge, m_do_symmetrize, can, zmin, zmax);
+                            m_position_std, m_total_charge, m_z_foc, m_do_symmetrize, can, zmin, zmax);
 
     } else if (m_injection_type == "from_file") {
 #ifdef HIPACE_USE_OPENPMD

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -265,6 +265,7 @@ InitBeamFixedWeight (int num_to_add,
                      const amrex::Real pos_mean_z,
                      const amrex::RealVect pos_std,
                      const amrex::Real total_charge,
+                     const amrex::Real z_foc,
                      const bool do_symmetrize,
                      const bool can, const amrex::Real zmin, const amrex::Real zmax)
 {
@@ -300,13 +301,13 @@ InitBeamFixedWeight (int num_to_add,
             num_to_add,
             [=] AMREX_GPU_DEVICE (int i, const amrex::RandomEngine& engine) noexcept
             {
-                const amrex::Real x = amrex::RandomNormal(0, pos_std[0], engine);
-                const amrex::Real y = amrex::RandomNormal(0, pos_std[1], engine);
                 const amrex::Real z = can
                     ? (amrex::Random(engine) - 0.5_rt) * (zmax - zmin)
                     : amrex::RandomNormal(0, pos_std[2], engine);
                 amrex::Real u[3] = {0.,0.,0.};
                 get_momentum(u[0],u[1],u[2], engine, z, duz_per_uz0_dzeta);
+                const amrex::Real x = amrex::RandomNormal(0, pos_std[0], engine) - z_foc*u[0]/get_momentum.m_u_mean[2];
+                const amrex::Real y = amrex::RandomNormal(0, pos_std[1], engine) - z_foc*u[1]/get_momentum.m_u_mean[2];
 
                 const amrex::Real z_central = z + z_mean;
                 int valid_id = pid;

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -301,13 +301,17 @@ InitBeamFixedWeight (int num_to_add,
             num_to_add,
             [=] AMREX_GPU_DEVICE (int i, const amrex::RandomEngine& engine) noexcept
             {
+                amrex::Real x = amrex::RandomNormal(0, pos_std[0], engine);
+                amrex::Real y = amrex::RandomNormal(0, pos_std[1], engine);
                 const amrex::Real z = can
                     ? (amrex::Random(engine) - 0.5_rt) * (zmax - zmin)
                     : amrex::RandomNormal(0, pos_std[2], engine);
                 amrex::Real u[3] = {0.,0.,0.};
                 get_momentum(u[0],u[1],u[2], engine, z, duz_per_uz0_dzeta);
-                const amrex::Real x = amrex::RandomNormal(0, pos_std[0], engine) - z_foc*u[0]/get_momentum.m_u_mean[2];
-                const amrex::Real y = amrex::RandomNormal(0, pos_std[1], engine) - z_foc*u[1]/get_momentum.m_u_mean[2];
+
+                // Propagate each electron ballistically for z_foc
+                x -= z_foc*u[0]/get_momentum.m_u_mean[2];
+                y -= z_foc*u[1]/get_momentum.m_u_mean[2];
 
                 const amrex::Real z_central = z + z_mean;
                 int valid_id = pid;


### PR DESCRIPTION
This PR adds the option to focus the beam at arbitrary position `z_foc`. Only implemented fix fixed-weight Gaussian beam, as it is the most useful in practice. For the rest, reformatting would be helpful anyway.

Plot: Beam width vs. z position.
Blue: old implementation (focused at z=0), the line is just shifted in z by 2 cm.
dashed Orange: new implementation, using `z_foc`.
<img width="477" alt="Screenshot 2023-01-20 at 12 15 05" src="https://user-images.githubusercontent.com/26292713/213682631-f8fe1aa4-df90-400c-a5bf-f715170e8e0c.png">
