### PR TITLE
HPMG: Support for 2^n-1 cells per direction

### DIFF
--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -147,10 +147,11 @@ public:
     /** \brief Centers the input box in x and y around the domain so that only the ghost
      * cells "overhang". Make it a slab in the z direction and set the index to 0.
      */
-    amrex::Box center_box (amrex::Box in_box, amrex::Box domain) {
+    static amrex::Box center_box (amrex::Box in_box, amrex::Box domain) {
         amrex::Box out_box = amrex::makeSlab(
             in_box + (domain.smallEnd() + domain.bigEnd() - in_box.smallEnd() - in_box.bigEnd())/2,
         2, 0);
+        out_box.setType(domain.ixType());
         AMREX_ALWAYS_ASSERT(out_box.contains(domain));
         return out_box;
     }

--- a/src/mg_solver/HpMultiGrid.cpp
+++ b/src/mg_solver/HpMultiGrid.cpp
@@ -450,14 +450,14 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
 MultiGrid::MultiGrid (Real dx, Real dy, Box a_domain)
     : m_dx(dx), m_dy(dy)
 {
-    AMREX_ALWAYS_ASSERT(a_domain.length(2) == 1 && a_domain.cellCentered() &&
-                        a_domain.length(0)%2 == a_domain.length(1)%2 &&
-                        a_domain.smallEnd(0)%2 == 0 &&
-                        a_domain.smallEnd(1)%2 == 0);
+    IntVect const a_domain_len = a_domain.length();
 
-    IndexType const index_type = a_domain.coarsenable(IntVect(2,2,1)) ?
+    AMREX_ALWAYS_ASSERT(a_domain_len[2] == 1 && a_domain.cellCentered() &&
+                        a_domain_len[0]%2 == a_domain_len[1]%2);
+
+    IndexType const index_type = (a_domain_len[0]%2 == 0) ?
         IndexType::TheCellType() : IndexType(IntVect(1,1,0));
-    m_domain.push_back(amrex::makeSlab(Box{{0,0,0}, a_domain.length()-1, index_type}, 2, 0));
+    m_domain.push_back(amrex::makeSlab(Box{{0,0,0}, a_domain_len-1, index_type}, 2, 0));
     if (!index_type.cellCentered()) {
         m_domain[0].growHi(0,2).growHi(1,2);
     }


### PR DESCRIPTION
I have tested this on CPU and Nvidia GPU using `examples/get_started/inputs_pwfa` with `amr.n_cell="255 255 256" amr.blocking_factor=1 hipace.do_tiling=0`.  We need to set blocking factor to 1 or we could also run with `amr.check_input=0`.  We might simply change the default blocking factor to 1 so that we don't have to set it in inputs files.  We also need to turn off tiling otherwise an assertion on bin size will fail.  I have not looked at the tiling code.  So I will let you guys decide how we should handle this properly.
