### PR TITLE
Remove unnecessary copy of BeamBins

### DIFF
--- a/src/particles/beam/MultiBeam.cpp
+++ b/src/particles/beam/MultiBeam.cpp
@@ -66,14 +66,13 @@ MultiBeam::findParticlesInEachSlice (int nlev, int ibox, amrex::Box bx,
                                      amrex::Vector<amrex::Geometry> const& geom,
                                      const amrex::Vector<BoxSorter>& a_box_sorter_vec)
 {
-    amrex::Vector<amrex::Vector<BeamBins>> bins;
+    amrex::Vector<amrex::Vector<BeamBins>> bins(nlev);
     for (int lev = 0; lev < nlev; ++lev) {
-        amrex::Vector<BeamBins> bins_per_level;
+        bins[lev].resize(m_nbeams);
         for (int i=0; i<m_nbeams; i++) {
-            bins_per_level.emplace_back(::findParticlesInEachSlice(lev, ibox, bx, m_all_beams[i],
-                                                                   geom, a_box_sorter_vec[i]));
+            bins[lev][i] = ::findParticlesInEachSlice(lev, ibox, bx, m_all_beams[i],
+                                                      geom, a_box_sorter_vec[i]);
         }
-        bins.emplace_back(bins_per_level);
     }
     amrex::Gpu::streamSynchronize();
     return bins;

--- a/src/particles/sorting/BoxSort.cpp
+++ b/src/particles/sorting/BoxSort.cpp
@@ -6,12 +6,15 @@
  * License: BSD-3-Clause-LBNL
  */
 #include "BoxSort.H"
+#include "utils/HipaceProfilerWrapper.H"
 
 #include <AMReX_ParticleTransformation.H>
 
 void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
                                     const amrex::BoxArray a_ba, const amrex::Geometry& a_geom)
 {
+    HIPACE_PROFILE("sortBeamParticlesByBox()");
+
     if (! m_particle_locator.isValid(a_ba)) m_particle_locator.build(a_ba, a_geom);
     auto assign_grid = m_particle_locator.getGridAssignor();
 


### PR DESCRIPTION
This was found using https://github.com/AMReX-Codes/amrex/pull/3105.

The second `emplace_back` was making a copy of the `bins_per_level` vector, causing about 1 GB on the GPU to be allocated for a simulation containing 10^8 beam particles.

Additionally profiling for the beam-particle box-sorting was added because it requires a significant amount of memory.

```
Device Memory Usage:
-------------------------------------------------------------------
Name                                      Nalloc  Nfree  Max Memory
-------------------------------------------------------------------
sortBeamParticlesByBox()                      44     44      11 GiB
BeamParticleContainer::InitParticles          10     10    7390 MiB
PlasmaParticleContainer::InitParticles        84     84    3395 MiB
DenseBins<T>::buildGPU                        36     36    1209 MiB
Fields::AllocData()                            3      3     706 MiB
Hipace::ExplicitMGSolveBxBy()                 45     45     341 MiB
FFTPoissonSolverDirichlet::define()            3      3      96 MiB
AnyDST::CreatePlan()                           2      2      64 MiB
ResizeRandomSeed                               1      0      40 MiB
hpmg::MultiGrid::solve1()                  12035  12035     486 KiB
Hipace::InitData()                             7      7     243 KiB
MultiPlasma::InitData()                        2      2     243 KiB
main()                                         3      3    1312   B
Fields::Copy()                                 1      1      64   B
DepositCurrent_PlasmaParticleContainer()    4000   4000      16   B
Unprofiled                                     1      1      16   B
-------------------------------------------------------------------

Pinned Memory Usage:
--------------------------------------------------------
Name                           Nalloc  Nfree  Max Memory
--------------------------------------------------------
main()                             47     47    1344   B
Hipace::ExplicitMGSolveBxBy()       1      1    1280   B
sortBeamParticlesByBox()           24     24     256   B
Hipace::InitData()                 39     39     160   B
Fields::Copy()                      1      1      64   B
MultiPlasma::InitData()             2      2      16   B
hpmg::MultiGrid::solve1()       12035  12035      16   B
--------------------------------------------------------

Cpu Memory Usage:
-------------------------------------
Name        Nalloc  Nfree  Max Memory
-------------------------------------
Unprofiled       1      1    8192 KiB
-------------------------------------
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
