### PR TITLE
Adjust boundary condition for MR with 2^n-1 HPMG

### DIFF
--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -706,7 +706,8 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
 
             amrex::Real offset = 1;
             amrex::Real factor = 1;
-            if ((component == "Bx" || component == "By") && Hipace::GetInstance().m_explicit) {
+            if ((component == "Bx" || component == "By") && Hipace::GetInstance().m_explicit &&
+                (getSlices(lev)[WhichSlice::This].box(0).length(0) % 2 == 0)) {
                 // hpmg has the boundary condition at a different place
                 // compared to the fft poisson solver
                 offset = 0.5;


### PR DESCRIPTION
- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
