### PR TITLE
plasmas.names is now an optional parameter, default no_plasma, and same for beam and laser

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -251,7 +251,7 @@ Then, properties can be set per plasma species with ``<plasma name>.<plasma prop
 or sometimes for all plasma species at the same time with ``plasmas.<plasma property> = ...``.
 When both are specified, the per-species value is used.
 
-* ``plasmas.names`` (`string`)
+* ``plasmas.names`` (`string`) optional (default `no_plasma`)
     The names of the plasmas, separated by a space.
     To run without plasma, choose the name ``no_plasma``.
 
@@ -353,7 +353,7 @@ Beam parameters
 For the beam parameters, first the names of the beams need to be specified. Afterwards, the beam
 parameters for each beam are specified via ``<beam name>.<beam property> = ...``
 
-* ``beams.names`` (`string`)
+* ``beams.names`` (`string`) optional (default `no_beam`)
     The names of the particle beams, separated by a space.
     To run without beams, choose the name ``no_beam``.
 
@@ -533,7 +533,7 @@ Unlike for ``beams`` and ``plasmas``, all the laser pulses are currently stored 
 which you can find in the output openPMD file as `laser_real` (for the real part of the envelope) and `laser_imag` for its imaginary part.
 Parameters starting with ``lasers.`` apply to all laser pulses, parameters starting with ``<laser name>`` apply to a single laser pulse.
 
-* ``lasers.names`` (list of `string`)
+* ``lasers.names`` (list of `string`) optional (default `no_laser`)
     The names of the laser pulses, separated by a space.
     To run without a laser, choose the name ``no_laser``.
 

--- a/examples/beam_in_vacuum/inputs_SI
+++ b/examples/beam_in_vacuum/inputs_SI
@@ -35,8 +35,4 @@ beam2.u_mean = 0. 0. 1.e3
 beam2.u_std = 0. 0. 0.
 beam2.ppc = 2 2 1
 
-plasmas.names = no_plasma
-
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/beam_in_vacuum/inputs_normalized
+++ b/examples/beam_in_vacuum/inputs_normalized
@@ -26,8 +26,4 @@ beam.u_mean = 0. 0. 1.e3
 beam.u_std = 0. 0. 0.
 beam.ppc = 2 2 1
 
-plasmas.names = no_plasma
-
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/beam_in_vacuum/inputs_normalized_transverse
+++ b/examples/beam_in_vacuum/inputs_normalized_transverse
@@ -36,8 +36,4 @@ beam2.u_std = 80. 120. 14.
 beam2.position_mean = 0. 0. 0
 beam2.position_std = 8. 0.3 1.41
 
-plasmas.names = no_plasma
-
-lasers.names = no_laser
-
 diagnostic.diag_type = xz

--- a/examples/blowout_wake/inputs_SI
+++ b/examples/blowout_wake/inputs_SI
@@ -41,6 +41,4 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/blowout_wake/inputs_ionization_SI
+++ b/examples/blowout_wake/inputs_ionization_SI
@@ -50,6 +50,4 @@ ion.mass_Da = 1.008
 ion.initial_ion_level = 0
 ion.ionization_product = elec
 
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/blowout_wake/inputs_normalized
+++ b/examples/blowout_wake/inputs_normalized
@@ -37,6 +37,4 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/gaussian_weight/inputs_SI
+++ b/examples/gaussian_weight/inputs_SI
@@ -25,8 +25,4 @@ beam.u_mean = 0. 0. 1.e3
 beam.u_std = 0. 0. 0.
 beam.ppc = 2 2 1
 
-plasmas.names = no_plasma
-
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/gaussian_weight/inputs_normalized
+++ b/examples/gaussian_weight/inputs_normalized
@@ -26,8 +26,4 @@ beam.radius = 40.
 beam.u_mean = 0. 0. 1.e3
 beam.u_std = 3. 4. 0.
 
-plasmas.names = no_plasma
-
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/get_started/inputs_lwfa
+++ b/examples/get_started/inputs_lwfa
@@ -32,8 +32,6 @@ laser.position_mean = 0. 0. 0
 laser.w0 = 3*kp_inv
 laser.L0 = 0.5*kp_inv
 
-beams.names = no_beam
-
 plasmas.names = plasma
 plasma.density(x,y,z) = "ne*(1+4*(x^2+y^2)/(kp^2 * Rm^4 ) ) *
                          if (z > Lramp, 1, .5*(1-cos(pi*z/Lramp))) *

--- a/examples/get_started/inputs_normalized
+++ b/examples/get_started/inputs_normalized
@@ -36,10 +36,6 @@ plasma.element = electron               # type of plasma: electron, proton, or a
 plasma.density(x,y,z) = 1.              # density function in the respective unit systems
 plasma.ppc = 1 1                        # particles per cell in x,y
 
-### Laser
-################################
-lasers.names = no_laser                 # name(s) of the laser pulses. Here, no laser pulse used.
-
 ### Diagnostics
 ################################
 diagnostic.diag_type = xz               # 2D xz slice output. Options: xyz, xz, yz

--- a/examples/get_started/inputs_pwfa
+++ b/examples/get_started/inputs_pwfa
@@ -22,7 +22,6 @@ geometry.is_periodic = true  true  false  # Is periodic?
 geometry.prob_lo     = -250.e-6 -250.e-6 -250.e-6  # physical domain
 geometry.prob_hi     =  250.e-6  250.e-6  110.e-6
 
-lasers.names = no_laser
 beams.names = driver witness
 
 driver.position_mean = 0. 0. 0.

--- a/examples/laser/inputs_SI
+++ b/examples/laser/inputs_SI
@@ -33,8 +33,4 @@ hipace.depos_order_xy = 0
 geometry.coord_sys   = 0                  # 0: Cartesian
 geometry.is_periodic = true  true  false  # Is periodic?
 
-beams.names = no_beam
-
-plasmas.names = no_plasma
-
 diagnostic.diag_type = xz

--- a/examples/linear_wake/inputs_SI
+++ b/examples/linear_wake/inputs_SI
@@ -35,6 +35,4 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/linear_wake/inputs_ion_motion_SI
+++ b/examples/linear_wake/inputs_ion_motion_SI
@@ -54,6 +54,4 @@ ions.neutralize_background = false
 "ions.density(x,y,z)" = ne
 ions.ppc = 1 1
 
-lasers.names = no_laser
-
 diagnostic.diag_type = xyz

--- a/examples/linear_wake/inputs_normalized
+++ b/examples/linear_wake/inputs_normalized
@@ -33,5 +33,3 @@ plasma.ppc = 1 1
 plasma.u_mean = 0.0 0.0 0.
 plasma.element = electron
 diagnostic.diag_type = xyz
-
-lasers.names = no_laser

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -185,7 +185,7 @@ private:
      * he central wavelength influences the solver. As long as all the lasers are on the same grid
      * (part of MultiLaser), this must be a property of MultiLaser. */
     amrex::Real m_lambda0 {0.};
-    amrex::Vector<std::string> m_names = {"no_laser"}; /**< name of the laser */
+    amrex::Vector<std::string> m_names {"no_laser"}; /**< name of the laser */
     int m_nlasers; /**< Number of laser pulses */
     amrex::Vector<Laser> m_all_lasers; /**< Each is a laser pulse */
     int m_3d_on_host {0};/** Whether the 3D laser envelope is stored in host or device memory */

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -185,7 +185,7 @@ private:
      * he central wavelength influences the solver. As long as all the lasers are on the same grid
      * (part of MultiLaser), this must be a property of MultiLaser. */
     amrex::Real m_lambda0 {0.};
-    amrex::Vector<std::string> m_names; /**< name of the laser */
+    amrex::Vector<std::string> m_names = {"no_laser"}; /**< name of the laser */
     int m_nlasers; /**< Number of laser pulses */
     amrex::Vector<Laser> m_all_lasers; /**< Each is a laser pulse */
     int m_3d_on_host {0};/** Whether the 3D laser envelope is stored in host or device memory */

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -29,7 +29,7 @@ void
 MultiLaser::ReadParameters ()
 {
     amrex::ParmParse pp("lasers");
-    getWithParser(pp, "names", m_names);
+    queryWithParser(pp, "names", m_names);
 
     m_use_laser = m_names[0] != "no_laser";
 

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -182,7 +182,7 @@ public:
 private:
 
     amrex::Vector<BeamParticleContainer> m_all_beams; /**< contains all beam containers */
-    amrex::Vector<std::string> m_names = {"no_beam"}; /**< names of all beam containers */
+    amrex::Vector<std::string> m_names {"no_beam"}; /**< names of all beam containers */
     int m_nbeams {0}; /**< number of beam containers */
     /** number of real particles per beam, as opposed to ghost particles */
     amrex::Vector<amrex::Long> m_n_real_particles;

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -182,7 +182,7 @@ public:
 private:
 
     amrex::Vector<BeamParticleContainer> m_all_beams; /**< contains all beam containers */
-    amrex::Vector<std::string> m_names; /**< names of all beam containers */
+    amrex::Vector<std::string> m_names = {"no_beam"}; /**< names of all beam containers */
     int m_nbeams {0}; /**< number of beam containers */
     /** number of real particles per beam, as opposed to ghost particles */
     amrex::Vector<amrex::Long> m_n_real_particles;

--- a/src/particles/beam/MultiBeam.cpp
+++ b/src/particles/beam/MultiBeam.cpp
@@ -16,7 +16,7 @@ MultiBeam::MultiBeam (amrex::AmrCore* /*amr_core*/)
 {
 
     amrex::ParmParse pp("beams");
-    getWithParser(pp, "names", m_names);
+    queryWithParser(pp, "names", m_names);
     if (m_names[0] == "no_beam") return;
     DeprecatedInput("beams", "insitu_freq", "insitu_period");
     DeprecatedInput("beams", "all_from_file",

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -148,7 +148,7 @@ public:
 
     amrex::Vector<PlasmaBins> m_all_bins; /**< Logical tile bins for all plasma containers */
 private:
-    amrex::Vector<std::string> m_names = {"no_plasma"}; /**< names of all plasma containers */
+    amrex::Vector<std::string> m_names {"no_plasma"}; /**< names of all plasma containers */
     /** Background (hypothetical) density, used to compute the adaptive time step */
     amrex::Real m_adaptive_density = 0.;
 

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -148,7 +148,7 @@ public:
 
     amrex::Vector<PlasmaBins> m_all_bins; /**< Logical tile bins for all plasma containers */
 private:
-    amrex::Vector<std::string> m_names; /**< names of all plasma containers */
+    amrex::Vector<std::string> m_names = {"no_plasma"}; /**< names of all plasma containers */
     /** Background (hypothetical) density, used to compute the adaptive time step */
     amrex::Real m_adaptive_density = 0.;
 

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -17,7 +17,7 @@ MultiPlasma::MultiPlasma (amrex::AmrCore* amr_core)
 {
 
     amrex::ParmParse pp("plasmas");
-    getWithParser(pp, "names", m_names);
+    queryWithParser(pp, "names", m_names);
     queryWithParser(pp, "adaptive_density", m_adaptive_density);
     queryWithParser(pp, "sort_bin_size", m_sort_bin_size);
     queryWithParser(pp, "collisions", m_collision_names);


### PR DESCRIPTION
With this minor change, input files without a laser don't need to specify `lasers.names = no_laser`, after increasing demand from the developer and user communities.