### PR TITLE
fix typo found by Sarah

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -108,7 +108,7 @@ General parameters
     Transverse particle shape order. Currently, `0,1,2,3` are implemented.
 
 * ``hipace.depos_order_z`` (`int`) optional (default `0`)
-    Transverse particle shape order. Currently, only `0` is implemented.
+    Longitudinal particle shape order. Currently, only `0` is implemented.
 
 * ``hipace.depos_derivative_type`` (`int`) optional (default `2`)
     Type of derivative used in explicit deposition. `0`: analytic, `1`: nodal, `2`: centered

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -107,7 +107,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
 
                 unsigned int cellid = 0;
                 if (outer_depos_loop) {
-                    // ordering of axes form fastest to slowest:
+                    // ordering of axes from fastest to slowest:
                     // x/depos_order_1 to match deposition
                     // x%depos_order_1
                     // y
@@ -116,7 +116,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                     cellid = ((i_part * nz + uiz) * ny + uiy) * nx +
                     uix/depos_order_1 + ((uix%depos_order_1)*nx+depos_order_1-1)/depos_order_1;
                 } else {
-                    // ordering of axes form fastest to slowest:
+                    // ordering of axes from fastest to slowest:
                     // x
                     // y
                     // z (not used)


### PR DESCRIPTION
Just a small typo in the doc

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
