### PR TITLE
Read in Laser form OpenPMD file

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -564,6 +564,16 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
 * ``lasers.3d_on_host`` (`0` or `1`) optional (default `0`)
     When running on GPU: whether the 3D array containing the laser envelope is stored in host memory (CPU, slower but large memory available) or in device memory (GPU, faster but less memory available).
 
+* ``lasers.input_file`` (`string`) optional (default `""`)
+    Path to an openPMD file containing a laser envelope. If this parameter is set then the file will
+    be used to initialize all lasers instead of using a gaussian profile.
+
+* ``lasers.openPMD_species_name`` (`string`) optional (default `laserEnvelope`)
+    Name of the laser species inside the openPMD file to be read in.
+
+* ``lasers.iteration`` (`int`) optional (default `0`)
+    Iteration of the openPMD file to be read in.
+
 * ``<laser name>.a0`` (`float`) optional (default `0`)
     Peak normalized vector potential of the laser pulse.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -568,8 +568,8 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
     Path to an openPMD file containing a laser envelope. If this parameter is set then the file will
     be used to initialize all lasers instead of using a gaussian profile.
 
-* ``lasers.openPMD_species_name`` (`string`) optional (default `laserEnvelope`)
-    Name of the laser species inside the openPMD file to be read in.
+* ``lasers.openPMD_laser_name`` (`string`) optional (default `laserEnvelope`)
+    Name of the laser envelope field inside the openPMD file to be read in.
 
 * ``lasers.iteration`` (`int`) optional (default `0`)
     Iteration of the openPMD file to be read in.

--- a/src/laser/Laser.H
+++ b/src/laser/Laser.H
@@ -17,7 +17,7 @@ class Laser
 {
 public:
 
-    Laser (std::string name);
+    Laser (std::string name, bool laser_from_file);
 
     std::string m_name {""};
     amrex::Real m_a0 {0.}; /**< Laser peak normalized amplitude */

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -14,9 +14,10 @@
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
 
-Laser::Laser (std::string name)
+Laser::Laser (std::string name, bool laser_from_file)
 {
     m_name = name;
+    if (laser_from_file) return;
     amrex::ParmParse pp(m_name);
     queryWithParser(pp, "a0", m_a0);
     queryWithParser(pp, "w0", m_w0);

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -134,6 +134,10 @@ public:
      */
     void Init3DEnvelope (int step, amrex::Box bx, const amrex::Geometry& gm);
 
+    void GetEnvelopeFromFileHelper (const amrex::Box& domain);
+    template<typename input_type>
+    void GetenvelopeFromFile (const amrex::Box& domain);
+
     /** \brief Copy from 2D slice on device to 3D array on host, and vice-versa
      *
      * \param[in] isl slice index, referring to the 3D slice
@@ -194,6 +198,20 @@ private:
     std::string m_solver_type = "multigrid";
     bool m_use_phase {true};
     amrex::Box m_slice_box;
+
+
+    bool m_laser_from_file = false;
+
+    /** full 3D laser data stored on the host */
+    amrex::FArrayBox m_F_input_file;
+
+    bool m_input_file_is_read = false;
+
+    std::string m_input_file_path;
+    std::string m_file_envelope_name;
+    int m_file_num_iteration;
+
+
 
     /** Nb fields in 3D array: new_real, new_imag, old_real, old_imag */
     int m_nfields_3d {4};

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -134,18 +134,18 @@ public:
      */
     void Init3DEnvelope (int step, amrex::Box bx, const amrex::Geometry& gm);
 
-    /** \brief Read in a laser forom an openPMD file
+    /** \brief Read in a laser from an openPMD file
      *
      * \param[in] domain size of the level 0 domain
      */
     void GetEnvelopeFromFileHelper (const amrex::Box& domain);
 
-    /** \brief Read in a laser forom an openPMD file
+    /** \brief Read in a laser from an openPMD file
      *
      * \param[in] domain size of the level 0 domain
      */
     template<typename input_type>
-    void GetenvelopeFromFile (const amrex::Box& domain);
+    void GetEnvelopeFromFile (const amrex::Box& domain);
 
     /** \brief Copy from 2D slice on device to 3D array on host, and vice-versa
      *

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -134,7 +134,16 @@ public:
      */
     void Init3DEnvelope (int step, amrex::Box bx, const amrex::Geometry& gm);
 
+    /** \brief Read in a laser forom an openPMD file
+     *
+     * \param[in] domain size of the level 0 domain
+     */
     void GetEnvelopeFromFileHelper (const amrex::Box& domain);
+
+    /** \brief Read in a laser forom an openPMD file
+     *
+     * \param[in] domain size of the level 0 domain
+     */
     template<typename input_type>
     void GetenvelopeFromFile (const amrex::Box& domain);
 
@@ -199,19 +208,18 @@ private:
     bool m_use_phase {true};
     amrex::Box m_slice_box;
 
-
+    /** if the lasers are initialized from openPMD file */
     bool m_laser_from_file = false;
-
+    /** if the input file was already read */
+    bool m_input_file_is_read = false;
     /** full 3D laser data stored on the host */
     amrex::FArrayBox m_F_input_file;
-
-    bool m_input_file_is_read = false;
-
+    /** path to input openPMD file */
     std::string m_input_file_path;
-    std::string m_file_envelope_name;
-    int m_file_num_iteration;
-
-
+    /** name of the openPMD species in the file */
+    std::string m_file_envelope_name = laserEnvelope;
+    /** index of the iteration in the openPMD file */
+    int m_file_num_iteration = 0;
 
     /** Nb fields in 3D array: new_real, new_imag, old_real, old_imag */
     int m_nfields_3d {4};

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -217,7 +217,7 @@ private:
     /** path to input openPMD file */
     std::string m_input_file_path;
     /** name of the openPMD species in the file */
-    std::string m_file_envelope_name = laserEnvelope;
+    std::string m_file_envelope_name = "laserEnvelope";
     /** index of the iteration in the openPMD file */
     int m_file_num_iteration = 0;
 

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -64,7 +64,7 @@ MultiLaser::ReadParameters ()
     }
 
     if (m_laser_from_file) {
-        queryWithParser(pp, "openPMD_species_name", m_file_envelope_name);
+        queryWithParser(pp, "openPMD_laser_name", m_file_envelope_name);
         queryWithParser(pp, "iteration", m_file_num_iteration);
     }
 }
@@ -224,9 +224,9 @@ MultiLaser::GetEnvelopeFromFileHelper (const amrex::Box& domain) {
     }
 
     if (input_type == openPMD::Datatype::CFLOAT) {
-        GetenvelopeFromFile<std::complex<float>>(domain);
+        GetEnvelopeFromFile<std::complex<float>>(domain);
     } else if (input_type == openPMD::Datatype::CDOUBLE) {
-        GetenvelopeFromFile<std::complex<double>>(domain);
+        GetEnvelopeFromFile<std::complex<double>>(domain);
     } else {
         amrex::Abort("Unknown Datatype used in Laser input file. Must use CDOUBLE or CFLOAT\n");
     }
@@ -234,7 +234,7 @@ MultiLaser::GetEnvelopeFromFileHelper (const amrex::Box& domain) {
 
 template<typename input_type>
 void
-MultiLaser::GetenvelopeFromFile (const amrex::Box& domain) {
+MultiLaser::GetEnvelopeFromFile (const amrex::Box& domain) {
     auto series = openPMD::Series( m_input_file_path , openPMD::Access::READ_ONLY );
     auto laser = series.iterations[m_file_num_iteration].meshes[m_file_envelope_name];
     auto laser_comp = laser[openPMD::RecordComponent::SCALAR];


### PR DESCRIPTION
Add capability to read in a laser envelope openPMD file genrated by LASY

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
