### PR TITLE
Use only one MultiFab for all field slices

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -753,10 +753,8 @@ Hipace::ResetAllQuantities ()
     if (m_use_laser) ResetLaser();
 
     for (int lev = 0; lev <= finestLevel(); ++lev) {
-        for (amrex::MultiFab& slice : m_fields.getSlices(lev)) {
-            if (slice.nComp() != 0) {
-                slice.setVal(0., m_fields.m_slices_nguards);
-            }
+        if (m_fields.getSlices(lev).nComp() != 0) {
+            m_fields.getSlices(lev).setVal(0., m_fields.m_slices_nguards);
         }
     }
 }
@@ -790,9 +788,7 @@ Hipace::InitializeSxSyWithBeam (const int lev)
     HIPACE_PROFILE("Hipace::InitializeSxSyWithBeam()");
     using namespace amrex::literals;
 
-    amrex::MultiFab& slicemf = m_fields.getSlices(lev, WhichSlice::This);
-    const amrex::MultiFab& nslicemf = m_fields.getSlices(lev, WhichSlice::Next);
-    const amrex::MultiFab& pslicemf = m_fields.getSlices(lev, WhichSlice::Previous1);
+    amrex::MultiFab& slicemf = m_fields.getSlices(lev);
 
     const amrex::Real dx = Geom(lev).CellSize(Direction::x);
     const amrex::Real dy = Geom(lev).CellSize(Direction::y);
@@ -802,9 +798,7 @@ Hipace::InitializeSxSyWithBeam (const int lev)
 
         amrex::Box const& bx = mfi.tilebox();
 
-        Array3<amrex::Real> const isl_arr = slicemf.array(mfi);
-        Array3<const amrex::Real> const nsl_arr = nslicemf.const_array(mfi);
-        Array3<const amrex::Real> const psl_arr = pslicemf.const_array(mfi);
+        Array3<amrex::Real> const arr = slicemf.array(mfi);
 
         const int Sx = Comps[WhichSlice::This]["Sx"];
         const int Sy = Comps[WhichSlice::This]["Sy"];
@@ -819,20 +813,16 @@ Hipace::InitializeSxSyWithBeam (const int lev)
         amrex::ParallelFor(bx,
             [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
             {
-                const amrex::Real dx_jzb = (isl_arr(i+1,j,jzb)-isl_arr(i-1,j,jzb))/(2._rt*dx);
-                const amrex::Real dy_jzb = (isl_arr(i,j+1,jzb)-isl_arr(i,j-1,jzb))/(2._rt*dy);
-                const amrex::Real dz_jxb = (psl_arr(i,j,prev_jxb)-nsl_arr(i,j,next_jxb))/(2._rt*dz);
-                const amrex::Real dz_jyb = (psl_arr(i,j,prev_jyb)-nsl_arr(i,j,next_jyb))/(2._rt*dz);
+                const amrex::Real dx_jzb = (arr(i+1,j,jzb)-arr(i-1,j,jzb))/(2._rt*dx);
+                const amrex::Real dy_jzb = (arr(i,j+1,jzb)-arr(i,j-1,jzb))/(2._rt*dy);
+                const amrex::Real dz_jxb = (arr(i,j,prev_jxb)-arr(i,j,next_jxb))/(2._rt*dz);
+                const amrex::Real dz_jyb = (arr(i,j,prev_jyb)-arr(i,j,next_jyb))/(2._rt*dz);
 
                 // calculate contribution to Sx and Sy by all beams (same as with PC solver)
                 // sy, to compute Bx
-                isl_arr(i,j,Sy) =   mu0 * (
-                                    - dy_jzb
-                                    + dz_jyb);
+                arr(i,j,Sy) =   mu0 * ( - dy_jzb + dz_jyb);
                 // sx, to compute By
-                isl_arr(i,j,Sx) = - mu0 * (
-                                    - dx_jzb
-                                    + dz_jxb);
+                arr(i,j,Sx) = - mu0 * ( - dx_jzb + dz_jxb);
             });
     }
 }
@@ -858,12 +848,10 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice, const int isl
     AMREX_ALWAYS_ASSERT(Comps[which_slice]["Bx"] + 1 == Comps[which_slice]["By"]);
     AMREX_ALWAYS_ASSERT(Comps[which_slice]["Sy"] + 1 == Comps[which_slice]["Sx"]);
 
-    amrex::MultiFab& slicemf_BxBySySx = m_fields.getSlices(lev, which_slice);
-    amrex::MultiFab BxBy (slicemf_BxBySySx, amrex::make_alias, Comps[which_slice]["Bx"], 2);
-    amrex::MultiFab SySx (slicemf_BxBySySx, amrex::make_alias, Comps[which_slice]["Sy"], 2);
-
-    amrex::MultiFab& slicemf_chi = m_fields.getSlices(lev, which_slice_chi);
-    amrex::MultiFab Mult (slicemf_chi, amrex::make_alias, Comps[which_slice_chi]["chi"], ncomp_chi);
+    amrex::MultiFab& slicemf = m_fields.getSlices(lev);
+    amrex::MultiFab BxBy (slicemf, amrex::make_alias, Comps[which_slice]["Bx"], 2);
+    amrex::MultiFab SySx (slicemf, amrex::make_alias, Comps[which_slice]["Sy"], 2);
+    amrex::MultiFab Mult (slicemf, amrex::make_alias, Comps[which_slice_chi]["chi"], ncomp_chi);
 
     if (lev!=0) {
         m_fields.SetBoundaryCondition(Geom(), lev, "Bx", islice,
@@ -883,9 +871,9 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice, const int isl
         }
 
         // construct slice geometry
-        const amrex::RealBox slice_box{slicemf_BxBySySx.boxArray()[0], m_slice_geom[lev].CellSize(),
+        const amrex::RealBox slice_box{slicemf.boxArray()[0], m_slice_geom[lev].CellSize(),
                                        m_slice_geom[lev].ProbLo()};
-        amrex::Geometry slice_geom{slicemf_BxBySySx.boxArray()[0], slice_box,
+        amrex::Geometry slice_geom{slicemf.boxArray()[0], slice_box,
                                    m_slice_geom[lev].CoordInt(), {0,0,0}};
 
         if (!m_mlalaplacian[lev]){
@@ -896,8 +884,8 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice, const int isl
             // make_unique requires explicit types
             m_mlalaplacian[lev] = std::make_unique<amrex::MLALaplacian>(
                 amrex::Vector<amrex::Geometry>{slice_geom},
-                amrex::Vector<amrex::BoxArray>{slicemf_BxBySySx.boxArray()},
-                amrex::Vector<amrex::DistributionMapping>{slicemf_BxBySySx.DistributionMap()},
+                amrex::Vector<amrex::BoxArray>{slicemf.boxArray()},
+                amrex::Vector<amrex::DistributionMapping>{slicemf.DistributionMap()},
                 lpinfo,
                 amrex::Vector<amrex::FabFactory<amrex::FArrayBox> const*>{}, 2);
 
@@ -928,15 +916,14 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice, const int isl
     } else
 #endif
     {
-        AMREX_ALWAYS_ASSERT(slicemf_BxBySySx.boxArray().size() == 1);
-        AMREX_ALWAYS_ASSERT(slicemf_chi.boxArray().size() == 1);
+        AMREX_ALWAYS_ASSERT(slicemf.boxArray().size() == 1);
         if (m_hpmg.size()<maxLevel()+1) {
             m_hpmg.resize(maxLevel()+1);
         }
         if (!m_hpmg[lev]) {
             m_hpmg[lev] = std::make_unique<hpmg::MultiGrid>(m_slice_geom[lev].CellSize(0),
                                                             m_slice_geom[lev].CellSize(1),
-                                                            slicemf_BxBySySx.boxArray()[0]);
+                                                            slicemf.boxArray()[0]);
         }
         const int max_iters = 200;
         m_hpmg[lev]->solve1(BxBy[0], SySx[0], Mult[0], m_MG_tolerance_rel, m_MG_tolerance_abs,
@@ -953,10 +940,8 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice_local, const int lev
 
     amrex::Real relative_Bfield_error_prev_iter = 1.0;
     amrex::Real relative_Bfield_error = m_fields.ComputeRelBFieldError(
-        m_fields.getSlices(lev, WhichSlice::Previous1),
-        m_fields.getSlices(lev, WhichSlice::Previous1),
-        m_fields.getSlices(lev, WhichSlice::Previous2),
-        m_fields.getSlices(lev, WhichSlice::Previous2),
+        m_fields.getSlices(lev), m_fields.getSlices(lev),
+        m_fields.getSlices(lev), m_fields.getSlices(lev),
         Comps[WhichSlice::Previous1]["Bx"], Comps[WhichSlice::Previous1]["By"],
         Comps[WhichSlice::Previous2]["Bx"], Comps[WhichSlice::Previous2]["By"],
         Geom(lev));
@@ -973,23 +958,23 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice_local, const int lev
     }
 
     /* creating temporary Bx and By arrays for the current and previous iteration */
-    amrex::MultiFab Bx_iter(m_fields.getSlices(lev, WhichSlice::This).boxArray(),
-                            m_fields.getSlices(lev, WhichSlice::This).DistributionMap(), 1,
-                            m_fields.getSlices(lev, WhichSlice::This).nGrowVect());
-    amrex::MultiFab By_iter(m_fields.getSlices(lev, WhichSlice::This).boxArray(),
-                            m_fields.getSlices(lev, WhichSlice::This).DistributionMap(), 1,
-                            m_fields.getSlices(lev, WhichSlice::This).nGrowVect());
+    amrex::MultiFab Bx_iter(m_fields.getSlices(lev).boxArray(),
+                            m_fields.getSlices(lev).DistributionMap(), 1,
+                            m_fields.getSlices(lev).nGrowVect());
+    amrex::MultiFab By_iter(m_fields.getSlices(lev).boxArray(),
+                            m_fields.getSlices(lev).DistributionMap(), 1,
+                            m_fields.getSlices(lev).nGrowVect());
     Bx_iter.setVal(0.0, m_fields.m_slices_nguards);
     By_iter.setVal(0.0, m_fields.m_slices_nguards);
-    amrex::MultiFab Bx_prev_iter(m_fields.getSlices(lev, WhichSlice::This).boxArray(),
-                                 m_fields.getSlices(lev, WhichSlice::This).DistributionMap(), 1,
-                                 m_fields.getSlices(lev, WhichSlice::This).nGrowVect());
-    amrex::MultiFab::Copy(Bx_prev_iter, m_fields.getSlices(lev, WhichSlice::This),
+    amrex::MultiFab Bx_prev_iter(m_fields.getSlices(lev).boxArray(),
+                                 m_fields.getSlices(lev).DistributionMap(), 1,
+                                 m_fields.getSlices(lev).nGrowVect());
+    amrex::MultiFab::Copy(Bx_prev_iter, m_fields.getSlices(lev),
                           Comps[WhichSlice::This]["Bx"], 0, 1, m_fields.m_slices_nguards);
-    amrex::MultiFab By_prev_iter(m_fields.getSlices(lev, WhichSlice::This).boxArray(),
-                                 m_fields.getSlices(lev, WhichSlice::This).DistributionMap(), 1,
-                                 m_fields.getSlices(lev, WhichSlice::This).nGrowVect());
-    amrex::MultiFab::Copy(By_prev_iter, m_fields.getSlices(lev, WhichSlice::This),
+    amrex::MultiFab By_prev_iter(m_fields.getSlices(lev).boxArray(),
+                                 m_fields.getSlices(lev).DistributionMap(), 1,
+                                 m_fields.getSlices(lev).nGrowVect());
+    amrex::MultiFab::Copy(By_prev_iter, m_fields.getSlices(lev),
                           Comps[WhichSlice::This]["By"], 0, 1, m_fields.m_slices_nguards);
 
     const int islice = islice_local + boxArray(lev)[ibox].smallEnd(Direction::z);
@@ -1029,8 +1014,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice_local, const int lev
         m_fields.SolvePoissonBy(By_iter, Geom(), lev, islice);
 
         relative_Bfield_error = m_fields.ComputeRelBFieldError(
-            m_fields.getSlices(lev, WhichSlice::This),
-            m_fields.getSlices(lev, WhichSlice::This),
+            m_fields.getSlices(lev), m_fields.getSlices(lev),
             Bx_iter, By_iter,
             Comps[WhichSlice::This]["Bx"], Comps[WhichSlice::This]["By"],
             0, 0, Geom(lev));

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -53,7 +53,7 @@ inline std::array<assert_map, WhichSlice::N> Comps{};
 
 /** \brief number of fields in each slice
  */
-inline std::array<int, WhichSlice::N> N_Comps {0,0,0,0,0,0};
+inline int N_Comps {0};
 
 /** \brief Direction of each dimension. Can be used for clean handling 2D vs. 3D in the future */
 struct Direction{
@@ -83,10 +83,6 @@ GetPosOffset (const int dir, const amrex::Geometry& geom, const amrex::Box& box)
  */
 class Fields
 {
-private:
-    /** Number of slices in temporary slice object */
-    static constexpr int m_nslices = WhichSlice::N;
-
 public:
     /** Constructor */
     explicit Fields (Hipace const* a_hipace);
@@ -106,28 +102,22 @@ public:
     /** Class to handle transverse FFT Poisson solver on 1 slice */
     amrex::Vector<std::unique_ptr<FFTPoissonSolver>> m_poisson_solver;
     /** get function for the 2D slices */
-    amrex::Vector<std::array<amrex::MultiFab, m_nslices>>& getSlices () {return m_slices; }
+    amrex::Vector<amrex::MultiFab>& getSlices () {return m_slices; }
     /** get function for the 2D slices
      * \param[in] lev MR level
      */
-    std::array<amrex::MultiFab, m_nslices>& getSlices (int lev) {return m_slices[lev]; }
-    /** get function for the 2D slices
-     * \param[in] lev MR level
-     * \param[in] islice slice index
-     */
-    amrex::MultiFab& getSlices (int lev, int islice) {return m_slices[lev][islice]; }
+    amrex::MultiFab& getSlices (int lev) {return m_slices[lev]; }
     /** get function for the 2D slices (const version)
      * \param[in] lev MR level
-     * \param[in] islice slice index
      */
-    const amrex::MultiFab& getSlices (int lev, int islice) const {return m_slices[lev][islice]; }
+    const amrex::MultiFab& getSlices (int lev) const {return m_slices[lev]; }
     /** get amrex::MultiFab of a field in a slice
      * \param[in] lev MR level
      * \param[in] islice slice index
      * \param[in] comp component name of field (see Comps)
      */
     amrex::MultiFab getField (const int lev, const int islice, const std::string comp) {
-        return amrex::MultiFab(getSlices(lev, islice), amrex::make_alias, Comps[islice][comp], 1);
+        return amrex::MultiFab(getSlices(lev), amrex::make_alias, Comps[islice][comp], 1);
     }
     /** get amrex::MultiFab of the poisson staging area
      * \param[in] lev MR level
@@ -140,12 +130,10 @@ public:
     /** check whether the fields are initialized correctly */
     void checkInit() {
         for (auto& slices_lev : m_slices) {
-            for (auto& slice : slices_lev) {
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-                    slice.nComp() == 0 || slice.nGrowVect() == m_slices_nguards,
-                    "m_slices[lev][islice].nGrowVect() must be equal to m_slices_nguards"
-                    "for initialized slices");
-            }
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                slices_lev.nComp() == 0 || slices_lev.nGrowVect() == m_slices_nguards,
+                "m_slices[lev].nGrowVect() must be equal to m_slices_nguards"
+                "for initialized slices");
         }
     }
     /** \brief Copy between the full FArrayBox and slice MultiFab.
@@ -317,7 +305,7 @@ public:
     void setVal (const amrex::Real val, const int lev, const int islice, Args...comps) {
         static constexpr int ncomps = sizeof...(comps);
         const amrex::GpuArray<int, ncomps> c_idx = {Comps[islice][comps]...};
-        amrex::MultiFab& mfab = getSlices(lev, islice);
+        amrex::MultiFab& mfab = getSlices(lev);
 
         for (amrex::MFIter mfi(mfab, DfltMfi); mfi.isValid(); ++mfi) {
             const Array3<amrex::Real> array = mfab.array(mfi);
@@ -343,7 +331,7 @@ public:
     void mult (const amrex::Real val, const int lev, const int islice, Args...comps) {
         static constexpr int ncomps = sizeof...(comps);
         const amrex::GpuArray<int, ncomps> c_idx = {Comps[islice][comps]...};
-        amrex::MultiFab& mfab = getSlices(lev, islice);
+        amrex::MultiFab& mfab = getSlices(lev);
 
         for (amrex::MFIter mfi(mfab, DfltMfi); mfi.isValid(); ++mfi) {
             const Array3<amrex::Real> array = mfab.array(mfi);
@@ -370,18 +358,16 @@ public:
         static constexpr int ncomps = sizeof...(comps);
         const amrex::GpuArray<int, ncomps> c_idx_src = {Comps[islice_src][comps]...};
         const amrex::GpuArray<int, ncomps> c_idx_dst = {Comps[islice_dst][comps]...};
-        const amrex::MultiFab& mfab_src = getSlices(lev, islice_src);
-        amrex::MultiFab& mfab_dst = getSlices(lev, islice_dst);
+        amrex::MultiFab& mfab = getSlices(lev);
 
-        for (amrex::MFIter mfi(mfab_dst, DfltMfi); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real const> array_src = mfab_src.const_array(mfi);
-            const Array3<amrex::Real> array_dst = mfab_dst.array(mfi);
+        for (amrex::MFIter mfi(mfab, DfltMfi); mfi.isValid(); ++mfi) {
+            const Array3<amrex::Real> array = mfab.array(mfi);
             // only one Kernel for all fields
             amrex::ParallelFor(mfi.growntilebox(),
                 [=] AMREX_GPU_DEVICE(int i, int j, int)
                 {
                     for (int n=0; n<ncomps; ++n) {
-                        array_dst(i,j,c_idx_dst[n]) = array_src(i,j,c_idx_src[n]);
+                        array(i,j,c_idx_dst[n]) = array(i,j,c_idx_src[n]);
                     }
                 });
         }
@@ -406,33 +392,18 @@ public:
             c_idx_src[i] = Comps[islice_src][comps_src[i]];
             c_idx_dst[i] = Comps[islice_dst][comps_dst[i]];
         }
+        amrex::MultiFab& mfab = getSlices(lev);
 
-        const amrex::MultiFab& mfab_src = getSlices(lev, islice_src);
-        amrex::MultiFab& mfab_dst = getSlices(lev, islice_dst);
-
-        for (amrex::MFIter mfi(mfab_dst, DfltMfi); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real> array_dst = mfab_dst.array(mfi);
+        for (amrex::MFIter mfi(mfab, DfltMfi); mfi.isValid(); ++mfi) {
+            const Array3<amrex::Real> array = mfab.array(mfi);
             // only one Kernel for all fields
-            if (islice_dst != islice_src) {
-                const Array3<amrex::Real const> array_src = mfab_src.const_array(mfi);
-                amrex::ParallelFor(mfi.growntilebox(),
-                    [=] AMREX_GPU_DEVICE(int i, int j, int)
-                    {
-                        for (int n=0; n<ncomps; ++n) {
-                            array_dst(i,j,c_idx_dst[n]) = array_src(i,j,c_idx_src[n]);
-                        }
-                    });
-            } else {
-                amrex::ParallelFor(mfi.growntilebox(),
-                    [=] AMREX_GPU_DEVICE(int i, int j, int)
-                    {
-                        for (int n=0; n<ncomps; ++n) {
-                            // array_src == array_dst here
-                            array_dst(i,j,c_idx_dst[n]) = array_dst(i,j,c_idx_src[n]);
-                        }
-                    });
-            }
-
+            amrex::ParallelFor(mfi.growntilebox(),
+                [=] AMREX_GPU_DEVICE(int i, int j, int)
+                {
+                    for (int n=0; n<ncomps; ++n) {
+                        array(i,j,c_idx_dst[n]) = array(i,j,c_idx_src[n]);
+                    }
+                });
         }
     }
 
@@ -455,33 +426,18 @@ public:
             c_idx_src[i] = Comps[islice_src][comps_src[i]];
             c_idx_dst[i] = Comps[islice_dst][comps_dst[i]];
         }
+        amrex::MultiFab& mfab = getSlices(lev);
 
-        const amrex::MultiFab& mfab_src = getSlices(lev, islice_src);
-        amrex::MultiFab& mfab_dst = getSlices(lev, islice_dst);
-
-        for (amrex::MFIter mfi(mfab_dst, DfltMfi); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real> array_dst = mfab_dst.array(mfi);
+        for (amrex::MFIter mfi(mfab, DfltMfi); mfi.isValid(); ++mfi) {
+            const Array3<amrex::Real> array = mfab.array(mfi);
             // only one Kernel for all fields
-            if (islice_dst != islice_src) {
-                const Array3<amrex::Real const> array_src = mfab_src.const_array(mfi);
-                amrex::ParallelFor(mfi.growntilebox(),
-                    [=] AMREX_GPU_DEVICE(int i, int j, int)
-                    {
-                        for (int n=0; n<ncomps; ++n) {
-                            array_dst(i,j,c_idx_dst[n]) += array_src(i,j,c_idx_src[n]);
-                        }
-                    });
-            } else {
-                amrex::ParallelFor(mfi.growntilebox(),
-                    [=] AMREX_GPU_DEVICE(int i, int j, int)
-                    {
-                        for (int n=0; n<ncomps; ++n) {
-                            // array_src == array_dst here
-                            array_dst(i,j,c_idx_dst[n]) += array_dst(i,j,c_idx_src[n]);
-                        }
-                    });
-            }
-
+            amrex::ParallelFor(mfi.growntilebox(),
+                [=] AMREX_GPU_DEVICE(int i, int j, int)
+                {
+                    for (int n=0; n<ncomps; ++n) {
+                        array(i,j,c_idx_dst[n]) += array(i,j,c_idx_src[n]);
+                    }
+                });
         }
     }
 
@@ -496,7 +452,7 @@ public:
     void FillBoundary (const amrex::Periodicity& period, const int lev, const int islice,
                        Args...comps) {
         std::array<int, sizeof...(comps)> c_idx = {Comps[islice][comps]...};
-        amrex::MultiFab& mfab = getSlices(lev, islice);
+        amrex::MultiFab& mfab = getSlices(lev);
 
         // optimize adjacent fields to one FillBoundary call
         std::sort(c_idx.begin(), c_idx.end());
@@ -524,8 +480,8 @@ public:
     bool m_extended_solve = false;
 
 private:
-    /** Vector over levels, array of 4 slices required to compute current slice */
-    amrex::Vector<std::array<amrex::MultiFab, m_nslices>> m_slices;
+    /** Vector over levels of all required fields to compute current slice */
+    amrex::Vector<amrex::MultiFab> m_slices;
     /** Whether to use Dirichlet BC for the Poisson solver. Otherwise, periodic */
     bool m_do_dirichlet_poisson = true;
     /** Temporary density arrays. one per OpenMP thread, used when tiling is on. */

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -293,7 +293,7 @@ MultiLaser::AdvanceSliceMG (const Fields& fields, const amrex::Geometry& geom, a
         Array3<Complex> rhs_arr = m_rhs.array();
 
         constexpr int lev = 0;
-        const amrex::FArrayBox& isl_fab = fields.getSlices(lev, WhichSlice::This)[mfi];
+        const amrex::FArrayBox& isl_fab = fields.getSlices(lev)[mfi];
         Array3<amrex::Real const> const isl_arr = isl_fab.array();
         const int chi = Comps[WhichSlice::This]["chi"];
 
@@ -493,7 +493,7 @@ MultiLaser::AdvanceSliceFFT (const Fields& fields, const amrex::Geometry& geom, 
         Array3<amrex::Real> np1jp2_arr = np1jp2.array(mfi);
 
         constexpr int lev = 0;
-        const amrex::FArrayBox& isl_fab = fields.getSlices(lev, WhichSlice::This)[mfi];
+        const amrex::FArrayBox& isl_fab = fields.getSlices(lev)[mfi];
         Array3<amrex::Real const> const isl_arr = isl_fab.array();
         const int chi = Comps[WhichSlice::This]["chi"];
 

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -49,7 +49,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     // Extract FabArray for this box (because there is currently no transverse
     // parallelization, the index we want in the slice multifab is always 0.
     // Fix later.
-    amrex::FArrayBox& isl_fab = fields.getSlices(lev, which_slice)[0];
+    amrex::FArrayBox& isl_fab = fields.getSlices(lev)[0];
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(isl_fab.box().ixType().cellCentered(),
         "jx, jy, jz and rho must be nodal in all directions.");
 

--- a/src/particles/deposition/ExplicitDeposition.cpp
+++ b/src/particles/deposition/ExplicitDeposition.cpp
@@ -24,7 +24,7 @@ ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields, const Multi
 
     for (PlasmaParticleIterator pti(plasma, lev); pti.isValid(); ++pti) {
 
-        amrex::FArrayBox& isl_fab = fields.getSlices(lev, WhichSlice::This)[pti];
+        amrex::FArrayBox& isl_fab = fields.getSlices(lev)[pti];
         const Array3<amrex::Real> arr = isl_fab.array();
 
         const int Sx = Comps[WhichSlice::This]["Sx"];

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -52,7 +52,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLas
         // Extract the fields currents
         // Do not access the field if the kernel later does not deposit into it,
         // the field might not be allocated. Use 0 as dummy component instead
-        amrex::FArrayBox& isl_fab = fields.getSlices(lev, which_slice)[pti];
+        amrex::FArrayBox& isl_fab = fields.getSlices(lev)[pti];
         const int  jx_cmp = deposit_jx_jy ? Comps[which_slice]["jx"]  : -1;
         const int  jy_cmp = deposit_jx_jy ? Comps[which_slice]["jy"]  : -1;
         const int  jz_cmp = deposit_jz    ? Comps[which_slice]["jz"]  : -1;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -191,7 +191,7 @@ IonizationModule (const int lev,
     for (amrex::MFIter mfi_ion = MakeMFIter(lev, DfltMfi); mfi_ion.isValid(); ++mfi_ion)
     {
         // Extract field array from FabArray
-        const amrex::FArrayBox& slice_fab = fields.getSlices(lev, WhichSlice::This)[mfi_ion];
+        const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[mfi_ion];
         Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
         const int psi_comp = Comps[WhichSlice::This]["Psi"];
         const int ez_comp = Comps[WhichSlice::This]["Ez"];

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -37,7 +37,7 @@ AdvanceBeamParticlesSlice (BeamParticleContainer& beam, const Fields& fields,
     // Extract field array from FabArrays in MultiFabs.
     // (because there is currently no transverse parallelization, the index
     // we want in the slice multifab is always 0. Fix later.
-    const amrex::FArrayBox& slice_fab = fields.getSlices(lev, WhichSlice::This)[0];
+    const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[0];
     Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
     const int psi_comp = Comps[WhichSlice::This]["Psi"];
     const int ez_comp = Comps[WhichSlice::This]["Ez"];

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -47,7 +47,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
     for (PlasmaParticleIterator pti(plasma, lev); pti.isValid(); ++pti)
     {
         // Extract field array from FabArray
-        const amrex::FArrayBox& slice_fab = fields.getSlices(lev, WhichSlice::This)[pti];
+        const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[pti];
         Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
         const int psi_comp = Comps[WhichSlice::This]["Psi"];
         const int ez_comp = Comps[WhichSlice::This]["Ez"];

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -48,7 +48,7 @@ GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, i
     const amrex::GpuArray<amrex::Real, 3> dx_arr = {dx[0], dx[1], dx[2]};
 
     // Extract the longitudinal beam current
-    amrex::MultiFab& S = fields.getSlices(lev, WhichSlice::This);
+    amrex::MultiFab& S = fields.getSlices(lev);
 
     const amrex::Real z = plo[2] + islice*dx_arr[2];
     const amrex::Real delta_z = (z - pos_mean[2]) / pos_std[2];


### PR DESCRIPTION
- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
