### PR TITLE
Output normalized momentum instead of proper velocity in insitu diagnostics

### DIFF
--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -245,7 +245,8 @@ BeamParticleContainer::InSituComputeDiags (int islice, const BeamBins& bins, int
                         m_insitu_sum_rdata.size()>0 && m_insitu_sum_idata.size()>0);
 
     PhysConst const phys_const = get_phys_const();
-    const amrex::Real clightsq = 1.0_rt/(phys_const.c*phys_const.c);
+    const amrex::Real clight_inv = 1.0_rt/phys_const.c;
+    const amrex::Real clightsq_inv = 1.0_rt/(phys_const.c*phys_const.c);
 
     auto const& ptaos = this->GetArrayOfStructs();
     const auto& pos_structs = ptaos.begin() + box_offset;
@@ -283,20 +284,20 @@ BeamParticleContainer::InSituComputeDiags (int islice, const BeamBins& bins, int
                 return{0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt,
                     0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0};
             }
-            const amrex::Real gamma = std::sqrt(1.0_rt + uxp[ip]*uxp[ip]*clightsq
-                                                       + uyp[ip]*uyp[ip]*clightsq
-                                                       + uzp[ip]*uzp[ip]*clightsq);
+            const amrex::Real gamma = std::sqrt(1.0_rt + uxp[ip]*uxp[ip]*clightsq_inv
+                                                       + uyp[ip]*uyp[ip]*clightsq_inv
+                                                       + uzp[ip]*uzp[ip]*clightsq_inv);
             return {wp[ip],
                     wp[ip]*pos_structs[ip].pos(0),
                     wp[ip]*pos_structs[ip].pos(0)*pos_structs[ip].pos(0),
                     wp[ip]*pos_structs[ip].pos(1),
                     wp[ip]*pos_structs[ip].pos(1)*pos_structs[ip].pos(1),
-                    wp[ip]*uxp[ip],
-                    wp[ip]*uxp[ip]*uxp[ip],
-                    wp[ip]*uyp[ip],
-                    wp[ip]*uyp[ip]*uyp[ip],
-                    wp[ip]*pos_structs[ip].pos(0)*uxp[ip],
-                    wp[ip]*pos_structs[ip].pos(1)*uyp[ip],
+                    wp[ip]*uxp[ip]*clight_inv,
+                    wp[ip]*uxp[ip]*uxp[ip]*clightsq_inv,
+                    wp[ip]*uyp[ip]*clight_inv,
+                    wp[ip]*uyp[ip]*uyp[ip]*clightsq_inv,
+                    wp[ip]*pos_structs[ip].pos(0)*uxp[ip]*clight_inv,
+                    wp[ip]*pos_structs[ip].pos(1)*uyp[ip]*clight_inv,
                     wp[ip]*gamma,
                     wp[ip]*gamma*gamma,
                     1};


### PR DESCRIPTION
This previously made the calculation of the emittance in SI units off by a factor of c.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
