### PR TITLE
Allow for arbitrary sized diagnostics grid

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -620,3 +620,9 @@ Diagnostic parameters
     ``none`` or a subset of ``beams.names``.
     **Note:** The option ``none`` only suppressed the output of the beam data. To suppress any
     output, please use ``hipace.output_period = -1``.
+
+* ``diagnostic.patch_lo`` (3 `float`) optional (default `-infinity -infinity -infinity`)
+    Lower limit for the diagnostic grid.
+
+* ``diagnostic.patch_hi`` (3 `float`) optional (default `infinity infinity infinity`)
+    Upper limit for the diagnostic grid.

--- a/examples/blowout_wake/analysis_slice_IO.py
+++ b/examples/blowout_wake/analysis_slice_IO.py
@@ -20,61 +20,106 @@ import math
 import argparse
 from openpmd_viewer import OpenPMDTimeSeries
 
-do_plot = False
+do_plot = True
 field = 'Ez'
 
-ts1 = OpenPMDTimeSeries('full_io')
+ts1 = OpenPMDTimeSeries('full_io') #((0,0,0) (63,87,99) (0,0,0))
 F_full = ts1.get_field(field=field, iteration=ts1.iterations[-1])[0]
 F_full = np.swapaxes(F_full,0,2)
 F_full_xz = (F_full[:,F_full.shape[1]//2,:].squeeze() +
              F_full[:,F_full.shape[1]//2-1,:].squeeze())/2.
 F_full_yz = (F_full[F_full.shape[0]//2,:,:].squeeze() +
              F_full[F_full.shape[0]//2-1,:,:].squeeze())/2.
+F_full_cut_xy = F_full[20:45,:,50].squeeze()
+F_full_cut_xz = (F_full[32:49,43,:].squeeze() + F_full[32:49,44,:].squeeze())/2.
 
-ts2 = OpenPMDTimeSeries('slice_io_xz')
+ts2 = OpenPMDTimeSeries('slice_io_xz') #((0,0,0) (63,87,99) (0,0,0))
 F_slice_xz = ts2.get_field(field=field, iteration=ts2.iterations[-1])[0].transpose()
 
-ts3 = OpenPMDTimeSeries('slice_io_yz')
+ts3 = OpenPMDTimeSeries('slice_io_yz') #((0,0,0) (63,87,99) (0,0,0))
 F_slice_yz = ts3.get_field(field=field, iteration=ts3.iterations[-1])[0].transpose()
 
+ts4 = OpenPMDTimeSeries('slice_io_cut_xy') #((20,0,50) (44,87,50) (0,0,0))
+F_slice_cut_xy = ts4.get_field(field=field, iteration=ts4.iterations[-1])[0].squeeze().transpose()
+
+ts5 = OpenPMDTimeSeries('slice_io_cut_xz') #((32,27,0) (48,60,99) (0,0,0))
+F_slice_cut_xz = ts5.get_field(field=field, iteration=ts5.iterations[-1])[0].transpose()
+
 if do_plot:
-    plt.figure(figsize=(12,8))
-    plt.subplot(231)
+    plt.figure(figsize=(12,16))
+    plt.subplot(431)
     plt.title('full_xz')
     plt.imshow(F_full_xz)
     plt.colorbar()
-    plt.subplot(232)
+    plt.subplot(432)
     plt.title('slice xz')
     plt.imshow(F_slice_xz)
     plt.colorbar()
-    plt.subplot(233)
+    plt.subplot(433)
     plt.title('difference')
     plt.imshow(F_slice_xz-F_full_xz)
     plt.colorbar()
 
-    plt.subplot(234)
+    plt.subplot(434)
     plt.title('full_yz')
     plt.imshow(F_full_yz)
     plt.colorbar()
-    plt.subplot(235)
+    plt.subplot(435)
     plt.title('slice yz')
     plt.imshow(F_slice_yz)
     plt.colorbar()
-    plt.subplot(236)
+    plt.subplot(436)
     plt.title('difference')
     plt.imshow(F_slice_yz-F_full_yz)
     plt.colorbar()
     plt.tight_layout()
+
+    plt.subplot(437)
+    plt.title('full_xy')
+    plt.imshow(F_full_cut_xy)
+    plt.colorbar()
+    plt.subplot(438)
+    plt.title('cut slice xy')
+    plt.imshow(F_slice_cut_xy)
+    plt.colorbar()
+    plt.subplot(439)
+    plt.title('difference')
+    plt.imshow(F_slice_cut_xy-F_full_cut_xy)
+    plt.colorbar()
+    plt.tight_layout()
+
+    plt.subplot(4, 3, 10)
+    plt.title('full_xz')
+    plt.imshow(F_full_cut_xz)
+    plt.colorbar()
+    plt.subplot(4, 3, 11)
+    plt.title('cut slice xz')
+    plt.imshow(F_slice_cut_xz)
+    plt.colorbar()
+    plt.subplot(4, 3, 12)
+    plt.title('difference')
+    plt.imshow(F_slice_cut_xz-F_full_cut_xz)
+    plt.colorbar()
+    plt.tight_layout()
+
     plt.savefig("image.pdf", bbox_inches='tight')
 
 error_xz = np.max(np.abs(F_slice_xz-F_full_xz)) / np.max(np.abs(F_full_xz))
 error_yz = np.max(np.abs(F_slice_yz-F_full_yz)) / np.max(np.abs(F_full_yz))
+error_cut_xy = np.max(np.abs(F_slice_cut_xy-F_full_cut_xy)) / np.max(np.abs(F_full_cut_xy))
+error_cut_xz = np.max(np.abs(F_slice_cut_xz-F_full_cut_xz)) / np.max(np.abs(F_full_cut_xz))
 
 print("F_full.shape", F_full.shape)
 print("F_slice_xz.shape", F_slice_xz.shape)
 print("F_slice_yz.shape", F_slice_yz.shape)
+print("F_full_cut_xy.shape", F_full_cut_xy.shape)
+print("F_full_cut_xz.shape", F_full_cut_xz.shape)
 print("error_xz", error_xz)
 print("error_yz", error_yz)
+print("error_cut_xy", error_cut_xy)
+print("error_cut_xz", error_cut_xz)
 
 assert(error_xz < 3.e-14)
 assert(error_yz < 3.e-14)
+assert(error_cut_xy < 3.e-14)
+assert(error_cut_xz < 3.e-14)

--- a/examples/blowout_wake/analysis_slice_IO.py
+++ b/examples/blowout_wake/analysis_slice_IO.py
@@ -20,10 +20,10 @@ import math
 import argparse
 from openpmd_viewer import OpenPMDTimeSeries
 
-do_plot = True
+do_plot = False
 field = 'Ez'
 
-ts1 = OpenPMDTimeSeries('full_io') #((0,0,0) (63,87,99) (0,0,0))
+ts1 = OpenPMDTimeSeries('full_io')
 F_full = ts1.get_field(field=field, iteration=ts1.iterations[-1])[0]
 F_full = np.swapaxes(F_full,0,2)
 F_full_xz = (F_full[:,F_full.shape[1]//2,:].squeeze() +
@@ -33,16 +33,16 @@ F_full_yz = (F_full[F_full.shape[0]//2,:,:].squeeze() +
 F_full_cut_xy = F_full[20:45,:,50].squeeze()
 F_full_cut_xz = (F_full[32:49,43,:].squeeze() + F_full[32:49,44,:].squeeze())/2.
 
-ts2 = OpenPMDTimeSeries('slice_io_xz') #((0,0,0) (63,87,99) (0,0,0))
+ts2 = OpenPMDTimeSeries('slice_io_xz')
 F_slice_xz = ts2.get_field(field=field, iteration=ts2.iterations[-1])[0].transpose()
 
-ts3 = OpenPMDTimeSeries('slice_io_yz') #((0,0,0) (63,87,99) (0,0,0))
+ts3 = OpenPMDTimeSeries('slice_io_yz')
 F_slice_yz = ts3.get_field(field=field, iteration=ts3.iterations[-1])[0].transpose()
 
-ts4 = OpenPMDTimeSeries('slice_io_cut_xy') #((20,0,50) (44,87,50) (0,0,0))
+ts4 = OpenPMDTimeSeries('slice_io_cut_xy')
 F_slice_cut_xy = ts4.get_field(field=field, iteration=ts4.iterations[-1])[0].squeeze().transpose()
 
-ts5 = OpenPMDTimeSeries('slice_io_cut_xz') #((32,27,0) (48,60,99) (0,0,0))
+ts5 = OpenPMDTimeSeries('slice_io_cut_xz')
 F_slice_cut_xz = ts5.get_field(field=field, iteration=ts5.iterations[-1])[0].transpose()
 
 if do_plot:

--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -102,6 +102,11 @@ private:
     bool m_include_ghost_cells = false; /**< if ghost cells are included in output */
     bool m_initialized = false; /**< if this object is fully initialized */
     std::vector<bool> m_has_field; /**< if there is field output to write */
+    bool m_use_custom_size = false; /**< if a user defined diagnostics size should be used*/
+    /** 3D array with lower ends of the diagnostics grid */
+    amrex::Array<amrex::Real, 3> m_diag_lo {0., 0., 0.};
+    /** 3D array with upper ends of the diagnostics grid */
+    amrex::Array<amrex::Real, 3> m_diag_hi {0., 0., 0.};
 };
 
 #endif // DIAGNOSTIC_H_

--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -102,7 +102,8 @@ private:
     bool m_include_ghost_cells = false; /**< if ghost cells are included in output */
     bool m_initialized = false; /**< if this object is fully initialized */
     std::vector<bool> m_has_field; /**< if there is field output to write */
-    bool m_use_custom_size = false; /**< if a user defined diagnostics size should be used*/
+    bool m_use_custom_size_lo = false; /**< if a user defined diagnostics size should be used (lo)*/
+    bool m_use_custom_size_hi = false; /**< if a user defined diagnostics size should be used (hi)*/
     /** 3D array with lower ends of the diagnostics grid */
     amrex::Array<amrex::Real, 3> m_diag_lo {0., 0., 0.};
     /** 3D array with upper ends of the diagnostics grid */

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -108,9 +108,13 @@ private:
     /** openPMD backend: h5, bp, or json. Default depends on what is available */
     std::string m_openpmd_backend = "default";
 
-    /** Last iteration that was written to file.
+    /** Last iteration that had fields written to file.
      * This is stored to make sure we don't write the last iteration multiple times. */
-    amrex::Vector<int> m_last_output_dumped;
+    amrex::Vector<int> m_last_field_output_dumped;
+
+    /** Last iteration that had beams written to file.
+     * This is stored to make sure we don't write the last iteration multiple times. */
+    amrex::Vector<int> m_last_beam_output_dumped;
 
     /** vector of length nbeams with the numbers of particles already written to file */
     amrex::Vector<uint64_t> m_offset;

--- a/tests/slice_IO.1Rank.sh
+++ b/tests/slice_IO.1Rank.sh
@@ -40,5 +40,21 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         amr.n_cell = 64 88 100 \
         hipace.file_prefix=slice_io_yz
 
+mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
+        plasmas.sort_bin_size = 8 \
+        diagnostic.diag_type=xyz \
+        amr.n_cell = 64 88 100 \
+        diagnostic.patch_lo = -3 -100  0 \
+        diagnostic.patch_hi =  3  100  0 \
+        hipace.file_prefix=slice_io_cut_xy
+
+mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
+        plasmas.sort_bin_size = 8 \
+        diagnostic.diag_type=xz \
+        amr.n_cell = 64 88 100 \
+        diagnostic.patch_lo =  0 -3 -10 \
+        diagnostic.patch_hi =  4  3  10 \
+        hipace.file_prefix=slice_io_cut_xz
+
 # assert whether the two IO types match
 $HIPACE_EXAMPLE_DIR/analysis_slice_IO.py


### PR DESCRIPTION
```
diagnostic.patch_lo =  -4  -4  -7
diagnostic.patch_hi =   4   4   3
```
can now be used to shrink the field output (for all fields) to save on filesize.




- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [x] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
