### PR TITLE
Increase tolerance on production runs

### DIFF
--- a/tests/production.SI.2Rank.sh
+++ b/tests/production.SI.2Rank.sh
@@ -24,6 +24,7 @@ mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_pwfa \
 
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --evaluate \
+    --rtol=1.e-8 \
     --file_name ${TEST_NAME}_pwfa \
     --test-name ${TEST_NAME}_pwfa
 
@@ -35,6 +36,7 @@ mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_lwfa \
 
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --evaluate \
+    --rtol=1.e-8 \
     --file_name ${TEST_NAME}_lwfa \
     --test-name ${TEST_NAME}_lwfa
 

--- a/tests/production.SI.2Rank.sh
+++ b/tests/production.SI.2Rank.sh
@@ -24,7 +24,7 @@ mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_pwfa \
 
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --evaluate \
-    --rtol=1.e-8 \
+    --rtol=5.e-6 \
     --file_name ${TEST_NAME}_pwfa \
     --test-name ${TEST_NAME}_pwfa
 
@@ -36,7 +36,7 @@ mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_lwfa \
 
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --evaluate \
-    --rtol=1.e-8 \
+    --rtol=5.e-6 \
     --file_name ${TEST_NAME}_lwfa \
     --test-name ${TEST_NAME}_lwfa
 


### PR DESCRIPTION
CI production runs fail randomly, could be because of platform-dependent RNG for fixed-weight Gaussian particle beam. This PR increases the tolerance (by a lot), so the test should just catch large discrepancies. We could instead use an external beam to avoid the RNG issue, or have a separate tolerance for most sensitive fields, or just skip them.