### PR TITLE
CI: macOS w/ CTest

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,9 +46,9 @@ jobs:
         set -e
         brew tap openpmd/openpmd
         brew install openpmd-api
-        python3 -m pip install matplotlib
-        python3 -m pip install numpy
-        python3 -m pip install scipy
+        /usr/bin/env python3 -m pip install matplotlib
+        /usr/bin/env python3 -m pip install numpy
+        /usr/bin/env python3 -m pip install scipy
     - name: CCache Cache
       uses: actions/cache@v3
       # - once stored under a key, they become immutable (even if local cache path content changes)
@@ -72,7 +72,7 @@ jobs:
           -DHiPACE_PRECISION=SINGLE
         cmake --build build_sp -j 2
 
-#    - name: test HiPACE++
-#      run: |
-#        ctest --test-dir build_dp --output-on-failure
-#        ctest --test-dir build_sp --output-on-failure
+    - name: test HiPACE++
+      run: |
+        ctest --test-dir build_dp --output-on-failure
+        ctest --test-dir build_sp --output-on-failure


### PR DESCRIPTION
Enable CTest on macOS for runtime tests.

Follow-up to #874

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
