### PR TITLE
CI: macOS Only One

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,11 +61,6 @@ jobs:
           ccache-macos-appleclang-
     - name: build HiPACE++
       run: |
-        cmake -S . -B build_dp          \
-          -DCMAKE_VERBOSE_MAKEFILE=ON   \
-          -DHiPACE_openpmd_internal=OFF
-        cmake --build build_dp -j 2
-
         cmake -S . -B build_sp          \
           -DCMAKE_VERBOSE_MAKEFILE=ON   \
           -DHiPACE_openpmd_internal=OFF \
@@ -74,5 +69,4 @@ jobs:
 
 #    - name: test HiPACE++
 #      run: |
-#        ctest --test-dir build_dp --output-on-failure
 #        ctest --test-dir build_sp --output-on-failure


### PR DESCRIPTION
Only one build for macOS CI is sufficient (#874).
Let's pick SP.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
