### PR TITLE
[mini] When a checksum test fails, also print the whole new json file

### DIFF
--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -102,8 +102,9 @@ class Checksum:
                   "have different outer keys:")
             print("Benchmark: %s" % ref_benchmark.data.keys())
             print("IO file  : %s" % self.data.keys())
-            print("\n\n----------------\n\n new file:")
+            print("\n\n----------------\n\nNew file:")
             print(json.dumps(self.data, indent=2))
+            print("\n\n----------------\n")
             sys.exit(1)
 
         # Dictionaries have same inner keys (field and particle quantities)?
@@ -116,8 +117,9 @@ class Checksum:
                       % (key1, ref_benchmark.data[key1].keys()))
                 print("IO file   inner keys in %s: %s"
                       % (key1, self.data[key1].keys()))
-                print("\n\n----------------\n\n new file:")
-                print(json.dumps(self.data, indent=2))
+            print("\n\n----------------\n\nNew file:")
+            print(json.dumps(self.data, indent=2))
+            print("\n\n----------------\n")
                 sys.exit(1)
 
         # Dictionaries have same values?
@@ -138,8 +140,9 @@ class Checksum:
                           % (key1, key2, self.data[key1][key2]))
                     checksums_differ = True
         if checksums_differ:
-            print("\n\n----------------\n\n new file:")
+            print("\n\n----------------\n\nNew file:")
             print(json.dumps(self.data, indent=2))
+            print("\n\n----------------\n")
             sys.exit(1)
         print("Checksum evaluation passed.")
 

--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -103,7 +103,7 @@ class Checksum:
             print("Benchmark: %s" % ref_benchmark.data.keys())
             print("IO file  : %s" % self.data.keys())
             print("\n\n----------------\n\n new file:")
-            print(json.dumps(data, indent=2))
+            print(json.dumps(self.data, indent=2))
             sys.exit(1)
 
         # Dictionaries have same inner keys (field and particle quantities)?
@@ -117,7 +117,7 @@ class Checksum:
                 print("IO file   inner keys in %s: %s"
                       % (key1, self.data[key1].keys()))
                 print("\n\n----------------\n\n new file:")
-                print(json.dumps(data, indent=2))
+                print(json.dumps(self.data, indent=2))
                 sys.exit(1)
 
         # Dictionaries have same values?
@@ -139,7 +139,7 @@ class Checksum:
                     checksums_differ = True
         if checksums_differ:
             print("\n\n----------------\n\n new file:")
-            print(json.dumps(data, indent=2))
+            print(json.dumps(self.data, indent=2))
             sys.exit(1)
         print("Checksum evaluation passed.")
 

--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -101,6 +101,8 @@ class Checksum:
                   "have different outer keys:")
             print("Benchmark: %s" % ref_benchmark.data.keys())
             print("IO file  : %s" % self.data.keys())
+            print("\n\n----------------\n\n new file:")
+            print(json.dumps(data, indent=2))
             sys.exit(1)
 
         # Dictionaries have same inner keys (field and particle quantities)?
@@ -113,6 +115,8 @@ class Checksum:
                       % (key1, ref_benchmark.data[key1].keys()))
                 print("IO file   inner keys in %s: %s"
                       % (key1, self.data[key1].keys()))
+                print("\n\n----------------\n\n new file:")
+                print(json.dumps(data, indent=2))
                 sys.exit(1)
 
         # Dictionaries have same values?
@@ -133,6 +137,8 @@ class Checksum:
                           % (key1, key2, self.data[key1][key2]))
                     checksums_differ = True
         if checksums_differ:
+            print("\n\n----------------\n\n new file:")
+            print(json.dumps(data, indent=2))
             sys.exit(1)
         print("Checksum evaluation passed.")
 

--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -15,6 +15,7 @@ License: BSD-3-Clause-LBNL
 from benchmark import Benchmark
 from backend.openpmd_backend import Backend
 import sys
+import json
 import numpy as np
 
 class Checksum:

--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -117,9 +117,9 @@ class Checksum:
                       % (key1, ref_benchmark.data[key1].keys()))
                 print("IO file   inner keys in %s: %s"
                       % (key1, self.data[key1].keys()))
-            print("\n\n----------------\n\nNew file:")
-            print(json.dumps(self.data, indent=2))
-            print("\n\n----------------\n")
+                print("\n\n----------------\n\nNew file:")
+                print(json.dumps(self.data, indent=2))
+                print("\n\n----------------\n")
                 sys.exit(1)
 
         # Dictionaries have same values?

--- a/tests/production.SI.2Rank.sh
+++ b/tests/production.SI.2Rank.sh
@@ -30,7 +30,7 @@ $HIPACE_TEST_DIR/checksum/checksumAPI.py \
 
 # Run the LWFA test and verify checksum
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_lwfa \
-        max_step = 11 \
+        max_step = 10 \
         amr.n_cell = 64 64 100 \
         hipace.file_prefix = ${TEST_NAME}_lwfa
 

--- a/tests/production.SI.2Rank.sh
+++ b/tests/production.SI.2Rank.sh
@@ -30,7 +30,7 @@ $HIPACE_TEST_DIR/checksum/checksumAPI.py \
 
 # Run the LWFA test and verify checksum
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_lwfa \
-        max_step = 10 \
+        max_step = 11 \
         amr.n_cell = 64 64 100 \
         hipace.file_prefix = ${TEST_NAME}_lwfa
 


### PR DESCRIPTION
When a checksum test fails, besides the comparison, also print the new value of the whole json file, as shown below. This makes it easier to reset a test when we know the new values are the correct ones: just copy-paste this in the appropriate benchmark json file.
```
{
  "lev=0": {
    "Bx": 0.0014823202162578,
    "By": 1069.3464724575,
    "Bz": 0.004159618983082,
    "ExmBy": 1481014839562.7,
    "EypBx": 553982.32538732,
    "Ez": 1363519539299.9,
    "Psi": 50439325.269601,
    "Sx": 3215204180072.4,
    "Sy": 1910217.4656522,
    "chi": 30736143317711.0,
    "jx": 93844226338467.0,
    "jx_beam": 0.0,
    "jy": 80303900.485533,
    "jy_beam": 0.0,
    "jz": 110859392030390.0,
    "jz_beam": 0.0,
    "laser_imag": 27.993121599302,
    "laser_real": 172.74362453414,
    "rho": 1207132.467064,
    "rho_beam": 0.0
  }
}
```