### PR TITLE
[mini] rename to avoid compiler warning

### DIFF
--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -240,8 +240,8 @@ AdaptiveTimeStep::CalculateFromDensity (amrex::Real t, amrex::Real& dt, MultiPla
     amrex::Real phase_advance0 = 0.;
 
     // Get plasma density at beginning of step
-    const amrex::Real plasma_density = plasmas.maxDensity(pc.c * t);
-    const amrex::Real omgp0 = std::sqrt(plasma_density * pc.q_e * pc.q_e / (pc.ep0 * pc.m_e));
+    const amrex::Real plasma_density0 = plasmas.maxDensity(pc.c * t);
+    const amrex::Real omgp0 = std::sqrt(plasma_density0 * pc.q_e * pc.q_e / (pc.ep0 * pc.m_e));
     amrex::Real omgb0 = omgp0 / std::sqrt(2. *m_min_uz);
 
     // Numerically integrate the phase advance from t to t+dt. The time step is reduced such that


### PR DESCRIPTION
Just renaming a variable to avoid a compiler warning

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
