### PR TITLE
[mini] fix print statement for small DSTs using rocFFT

### DIFF
--- a/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
@@ -347,8 +347,8 @@ namespace AnyDST
 
             std::size_t mb = 1024*1024;
 
-            amrex::Print() << "using C2R cuFFT of sizes " << s_1 << " and "
-                << s_2 << " with " << (buffersize+mb-1)/mb << " MiB of work area\n";
+            amrex::Print() << "using C2R rocFFT of sizes " << s_1[0] << " and "
+                << s_2[0] << " with " << (buffersize+mb-1)/mb << " MiB of work area\n";
 
             // Store meta-data in dst_plan
             dst_plan.m_position_array = position_array;


### PR DESCRIPTION
The print statement for small DSTs using rocFFT was wrong (it was not adjusted from cuFFT).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
