### PR TITLE
Adaptbeams

### DIFF
--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -198,8 +198,8 @@ AdaptiveTimeStep::Calculate (
                                     " have non-relativistic velocities!\n";
                 }
                 beams_min_uz[ibeam] = std::max(beams_min_uz[ibeam], m_threshold_uz);
-                new_dts[ibeam] = dt;
             }
+            new_dts[ibeam] = dt;
 
             // Calculate the time step for this beam used in the next time iteration of the current
             // rank, to resolve the betatron period with m_nt_per_betatron points per period,

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -169,8 +169,8 @@ AdaptiveTimeStep::Calculate (
     if (it == 0 || initial)
     {
         for (int ibeam = 0; ibeam < nbeams; ibeam++) {
-            if (Hipace::HeadRank() || !initial) {
 
+            if (Hipace::HeadRank() || !initial) {
                 const auto& beam = beams.getBeam(ibeam);
 
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_timestep_data[ibeam][WhichDouble::SumWeights] != 0,

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -274,7 +274,7 @@ AdaptiveTimeStep::CalculateFromDensity (amrex::Real t, amrex::Real& dt, MultiPla
            2.*MathConst::pi*m_adaptive_phase_tolerance/m_nt_per_betatron)
         {
             if (i==0) amrex::AllPrint()<<"WARNING: adaptive time step exits at first substep."<<
-                                       <<" Consider increasing hipace.adaptive_phase_substeps!\n";
+                                         " Consider increasing hipace.adaptive_phase_substeps!\n";
             dt = i*dt_sub;
             return;
         }

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -168,8 +168,8 @@ AdaptiveTimeStep::Calculate (
     // from the full beam information
     if (it == 0 || initial)
     {
-        if (Hipace::HeadRank() || !initial) {
-            for (int ibeam = 0; ibeam < nbeams; ibeam++) {
+        for (int ibeam = 0; ibeam < nbeams; ibeam++) {
+            if (Hipace::HeadRank() || !initial) {
 
                 const auto& beam = beams.getBeam(ibeam);
 
@@ -200,10 +200,7 @@ AdaptiveTimeStep::Calculate (
                 beams_min_uz[ibeam] = std::max(beams_min_uz[ibeam], m_threshold_uz);
                 new_dts[ibeam] = dt;
             }
-            m_min_uz = *std::min_element(beams_min_uz.begin(), beams_min_uz.end());
-        }
 
-        for (int ibeam = 0; ibeam < nbeams; ibeam++) {
             // Calculate the time step for this beam used in the next time iteration of the current
             // rank, to resolve the betatron period with m_nt_per_betatron points per period,
             // assuming full blowout regime. The z-dependence of the plasma profile is considered.
@@ -227,6 +224,10 @@ AdaptiveTimeStep::Calculate (
                 new_time += new_dt;
                 if (min_uz > m_threshold_uz) new_dts[ibeam] = new_dt;
             }
+        }
+        // Store min uz across beams, used in the phase advance method
+        if (Hipace::HeadRank() || !initial) {
+            m_min_uz = *std::min_element(beams_min_uz.begin(), beams_min_uz.end());
         }
         /* set the new time step */
         dt = *std::min_element(new_dts.begin(), new_dts.end());

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -173,24 +173,26 @@ AdaptiveTimeStep::Calculate (
             if (Hipace::HeadRank() || !initial) {
                 const auto& beam = beams.getBeam(ibeam);
 
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_timestep_data[ibeam][WhichDouble::SumWeights] != 0,
-                                                  "The sum of all weights is 0! Probably no beam particles are initialized\n");
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    m_timestep_data[ibeam][WhichDouble::SumWeights] != 0,
+                    "The sum of all weights is 0! Probably no beam particles are initialized\n");
                 const amrex::Real mean_uz = m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUz]
                     /m_timestep_data[ibeam][WhichDouble::SumWeights];
-                const amrex::Real sigma_uz = std::sqrt(std::abs(m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared]
-                                                                /m_timestep_data[ibeam][WhichDouble::SumWeights]
-                                                                - mean_uz*mean_uz));
+                const amrex::Real sigma_uz =
+                    std::sqrt(std::abs(m_timestep_data[ibeam][WhichDouble::SumWeightsTimesUzSquared]
+                                       /m_timestep_data[ibeam][WhichDouble::SumWeights]
+                                       - mean_uz*mean_uz));
                 const amrex::Real sigma_uz_dev = mean_uz - 4.*sigma_uz;
                 const amrex::Real max_supported_uz = 1.e30;
-                amrex::Real chosen_min_uz = std::min(std::max(sigma_uz_dev,
-                                                              m_timestep_data[ibeam][WhichDouble::MinUz]),
-                                                     max_supported_uz);
+                amrex::Real chosen_min_uz =
+                    std::min(std::max(sigma_uz_dev, m_timestep_data[ibeam][WhichDouble::MinUz]),
+                             max_supported_uz);
 
                 beams_min_uz[ibeam] = chosen_min_uz*beam.m_mass*beam.m_mass/m_e/m_e;
 
                 if (Hipace::m_verbose >=2 ){
-                    amrex::Print()<<"Minimum gamma of beam " << ibeam << " to calculate new time step: "
-                                  << beams_min_uz[ibeam] << "\n";
+                    amrex::Print()<<"Minimum gamma of beam " << ibeam <<
+                        " to calculate new time step: " << beams_min_uz[ibeam] << "\n";
                 }
 
                 if (beams_min_uz[ibeam] < m_threshold_uz) {
@@ -200,13 +202,15 @@ AdaptiveTimeStep::Calculate (
                 beams_min_uz[ibeam] = std::max(beams_min_uz[ibeam], m_threshold_uz);
                 new_dts[ibeam] = dt;
 
-                // Calculate the time step for this beam used in the next time iteration of the current
-                // rank, to resolve the betatron period with m_nt_per_betatron points per period,
-                // assuming full blowout regime. The z-dependence of the plasma profile is considered.
-                // As this time step will start in numprocs_z time steps, so the beam may have
-                // propagated a significant distance. If m_adaptive_predict_step is true, we estimate
-                // this distance and use it for a more accurate time step estimation.
-
+                /*
+                  Calculate the time step for this beam used in the next time iteration
+                  of the current rank, to resolve the betatron period with m_nt_per_betatron
+                  points per period, assuming full blowout regime. The z-dependence of the
+                  plasma profile is considered. As this time step will start in numprocs_z
+                  time steps, so the beam may have propagated a significant distance.
+                  If m_adaptive_predict_step is true, we estimate this distance and use it
+                  for a more accurate time step estimation.
+                */
                 amrex::Real new_dt = dt;
                 amrex::Real new_time = t;
                 amrex::Real min_uz = beams_min_uz[ibeam];
@@ -269,7 +273,8 @@ AdaptiveTimeStep::CalculateFromDensity (amrex::Real t, amrex::Real& dt, MultiPla
         if(std::abs(phase_advance - phase_advance0) >
            2.*MathConst::pi*m_adaptive_phase_tolerance/m_nt_per_betatron)
         {
-            if (i==0) amrex::AllPrint()<<"WARNING: adaptive time step exits at first substep. Consider increasing hipace.adaptive_phase_substeps!\n";
+            if (i==0) amrex::AllPrint()<<"WARNING: adaptive time step exits at first substep."<<
+                                       <<" Consider increasing hipace.adaptive_phase_substeps!\n";
             dt = i*dt_sub;
             return;
         }


### PR DESCRIPTION
The handling of multiple beams in the adaptive time step was not very clean. This PR makes sure that the `min_uz` is computed and used separately for each beam. When the evolution of beams make it so that the adaptive time step is limited by 1 beam at the beginning of a stage and another one at the end, the new time step captures it correctly, see figures below.
![stage_gammas copy](https://user-images.githubusercontent.com/26292713/227955744-8a1de30d-1472-4092-a496-c97e70867840.jpg)
![stage_timestep](https://user-images.githubusercontent.com/26292713/227955390-76f341d1-3455-461a-aa8e-2b5e369bd4c6.jpg)
