### PR TITLE
Reorder plasma for deposition

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -354,10 +354,10 @@ When both are specified, the per-species value is used.
     arrays of size ``sort_bin_size`` (+ guard cells) that are atomic-added to the main current
     arrays.
 
-* ``<plasma name> or plasmas.reorder_interval`` (`int`) optional (default `-1`)
+* ``<plasma name> or plasmas.reorder_interval`` (`int`) optional (default `0`)
     Reorder particles periodically to speed-up current deposition on GPU for a high-temperature plasma.
     An interval of 1 means reordering is done on every slice.
-    To disable reordering set this to -1.
+    To disable reordering set this to 0.
 
 * ``<plasma name> or plasmas.reorder_idx_type`` (2 `int`) optional (default `0 0` or `1 1`)
     Change if plasma particles are binned to cells (0), nodes (1) or both (2)

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -367,7 +367,7 @@ When both are specified, the per-species value is used.
     resulting in node centered reordering giving better performance.
     For shape factors 0 and 2, 1^2 and 3^2 cells are deposited such that cell centered reordering is better.
     The default is chosen accordingly.
-    If `` hipace.depos_derivative_type = 1``, the explicit deposition deposits an additional cell in each direction,
+    If ``hipace.depos_derivative_type = 1``, the explicit deposition deposits an additional cell in each direction,
     making the opposite index type ideal. Since the normal deposition still requires the original index type,
     the compromise option ``2 2`` can be chosen. This will however require more memory in the binning process.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -354,14 +354,22 @@ When both are specified, the per-species value is used.
     arrays of size ``sort_bin_size`` (+ guard cells) that are atomic-added to the main current
     arrays.
 
-* ``<plasma name> or plasmas.reorder_interval`` (`int`) optional (default `0`)
+* ``<plasma name> or plasmas.reorder_period`` (`int`) optional (default `0`)
     Reorder particles periodically to speed-up current deposition on GPU for a high-temperature plasma.
-    An interval of 1 means reordering is done on every slice.
+    A good starting point is a period of 4 to reorder plasma particles on every fourth zeta-slice.
     To disable reordering set this to 0.
 
 * ``<plasma name> or plasmas.reorder_idx_type`` (2 `int`) optional (default `0 0` or `1 1`)
     Change if plasma particles are binned to cells (0), nodes (1) or both (2)
     for both x and y direction as part of the reordering.
+    The ideal index type depends on the particle shape factor used for deposition.
+    For shape factors 1 and 3, 2^2 and 4^2 cells are deposited per particle respectively,
+    resulting in node centered reordering giving better performance.
+    For shape factors 0 and 2, 1^2 and 3^2 cells are deposited such that cell centered reordering is better.
+    The default is chosen accordingly.
+    If `` hipace.depos_derivative_type = 1``, the explicit deposition deposits an additional cell in each direction,
+    making the opposite index type ideal. Since the normal deposition still requires the original index type,
+    the compromise option ``2 2`` can be chosen. This will however require more memory in the binning process.
 
 Binary collisions for plasma species
 ------------------------------------

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -354,6 +354,15 @@ When both are specified, the per-species value is used.
     arrays of size ``sort_bin_size`` (+ guard cells) that are atomic-added to the main current
     arrays.
 
+* ``<plasma name> or plasmas.reorder_interval`` (`int`) optional (default `-1`)
+    Reorder particles periodically to speed-up current deposition on GPU for a high-temperature plasma.
+    An interval of 1 means reordering is done on every slice.
+    To disable reordering set this to -1.
+
+* ``<plasma name> or plasmas.reorder_idx_type`` (2 `int`) optional (default `0 0` or `1 1`)
+    Change if plasma particles are binned to cells (0), nodes (1) or both (2)
+    for both x and y direction as part of the reordering.
+
 Binary collisions for plasma species
 ------------------------------------
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -46,6 +46,19 @@ struct Hipace_early_init
     /** Struct containing physical constants (which values depends on the unit system, determined
      * at runtime): SI or normalized units. */
     PhysConst m_phys_const;
+
+    /** Order of the field gather and current deposition shape factor in the transverse directions
+     */
+    static int m_depos_order_xy;
+    /** Order of the field gather and current deposition shape factor in the longitudinal direction
+     */
+    static int m_depos_order_z;
+    /** Type of derivative used in explicit deposition. 0: analytic, 1: nodal, 2: centered
+     */
+    static int m_depos_derivative_type;
+    /* if the loop over depos_order is included in the loop over particles
+     */
+    static bool m_outer_depos_loop;
 };
 
 /** \brief Singleton class, that intialize, runs and finalizes the simulation */
@@ -308,18 +321,6 @@ public:
     static amrex::Real m_initial_time;
     /** Level of verbosity */
     static int m_verbose;
-    /** Order of the field gather and current deposition shape factor in the transverse directions
-     */
-    static int m_depos_order_xy;
-    /** Order of the field gather and current deposition shape factor in the longitudinal direction
-     */
-    static int m_depos_order_z;
-    /** Type of derivative used in explicit deposition. 0: analytic, 1: nodal, 2: centered
-     */
-    static int m_depos_derivative_type;
-    /* if the loop over depos_order is included in the loop over particles
-     */
-    static bool m_outer_depos_loop;
     /** Relative transverse B field error tolerance in the predictor corrector loop
      */
     static amrex::Real m_predcorr_B_error_tolerance;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -38,6 +38,11 @@ namespace {
 }
 #endif
 
+int Hipace_early_init::m_depos_order_xy = 2;
+int Hipace_early_init::m_depos_order_z = 0;
+int Hipace_early_init::m_depos_derivative_type = 2;
+bool Hipace_early_init::m_outer_depos_loop = false;
+
 Hipace* Hipace::m_instance = nullptr;
 
 bool Hipace::m_normalized_units = false;
@@ -47,10 +52,6 @@ amrex::Real Hipace::m_max_time = std::numeric_limits<amrex::Real>::infinity();
 amrex::Real Hipace::m_physical_time = 0.0;
 amrex::Real Hipace::m_initial_time = 0.0;
 int Hipace::m_verbose = 0;
-int Hipace::m_depos_order_xy = 2;
-int Hipace::m_depos_order_z = 0;
-int Hipace::m_depos_derivative_type = 2;
-bool Hipace::m_outer_depos_loop = false;
 amrex::Real Hipace::m_predcorr_B_error_tolerance = 4e-2;
 int Hipace::m_predcorr_max_iterations = 30;
 amrex::Real Hipace::m_predcorr_B_mixing_factor = 0.05;

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -138,6 +138,11 @@ public:
      */
     void doCoulombCollision (int lev, amrex::Box bx, amrex::Geometry geom);
 
+    /** Reorder particles to speed-up current deposition
+     * \param[in] islice zeta slice index
+     */
+    void ReorderParticles (const int islice);
+
     int m_sort_bin_size {32}; /**< Tile size to sort plasma particles */
 
     /** Number of binary collisions */

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -193,3 +193,11 @@ MultiPlasma::doCoulombCollision (int lev, amrex::Box bx, amrex::Geometry geom)
             m_all_collisions[i].m_isSameSpecies, m_all_collisions[i].m_CoulombLog);
     }
 }
+
+void
+MultiPlasma::ReorderParticles (const int islice)
+{
+    for (auto& plasma : m_all_plasmas) {
+        plasma.ReorderParticles(islice);
+    }
+}

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -162,7 +162,7 @@ public:
     /** initial number of particles before ones are added through ionization */
     std::map<int,unsigned long> m_init_num_par;
     /** After how many slices the particles are reordered. 0: off */
-    int m_reorder_interval = 2;
+    int m_reorder_interval = 0;
     /** 2D reordering index type. 0: cell, 1: node, 2: both */
     amrex::IntVect m_reorder_idx_type = {0, 0, 0};
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -161,8 +161,8 @@ public:
     amrex::Gpu::DeviceVector<amrex::Real> m_adk_power;
     /** initial number of particles before ones are added through ionization */
     std::map<int,unsigned long> m_init_num_par;
-    /** After how many slices the particles are reordered. -1: off */
-    int m_reorder_interval = -1;
+    /** After how many slices the particles are reordered. 0: off */
+    int m_reorder_interval = 2;
     /** 2D reordering index type. 0: cell, 1: node, 2: both */
     amrex::IntVect m_reorder_idx_type = {0, 0, 0};
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -162,7 +162,7 @@ public:
     /** initial number of particles before ones are added through ionization */
     std::map<int,unsigned long> m_init_num_par;
     /** After how many slices the particles are reordered. 0: off */
-    int m_reorder_interval = 0;
+    int m_reorder_period = 0;
     /** 2D reordering index type. 0: cell, 1: node, 2: both */
     amrex::IntVect m_reorder_idx_type = {0, 0, 0};
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -101,6 +101,11 @@ public:
                            const amrex::Geometry& geom,
                            const Fields& fields);
 
+    /** Reorder particles to speed-up current deposition
+     * \param[in] islice zeta slice index
+     */
+    void ReorderParticles (const int islice);
+
     /** Update m_density_func with m_density_table if applicable
      */
     void UpdateDensityFunction ();
@@ -156,6 +161,10 @@ public:
     amrex::Gpu::DeviceVector<amrex::Real> m_adk_power;
     /** initial number of particles before ones are added through ionization */
     std::map<int,unsigned long> m_init_num_par;
+    /** After how many slices the particles are reordered. -1: off */
+    int m_reorder_interval = -1;
+    /** 2D reordering index type. 0: cell, 1: node, 2: both */
+    amrex::IntVect m_reorder_idx_type = {0, 0, 0};
 
 private:
     std::string m_name; /**< name of the species */

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -153,7 +153,7 @@ PlasmaParticleContainer::ReadParameters ()
     queryWithParserAlt(pp, "reorder_interval", m_reorder_interval, pp_alt);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_reorder_interval != 0,
                                      "To avoid reordering, please use reorder_interval = -1.");
-    amrex::Array<amrex::Real, 2> idx_array
+    amrex::Array<int, 2> idx_array
         {Hipace::m_depos_order_xy % 2, Hipace::m_depos_order_xy % 2};
     queryWithParserAlt(pp, "reorder_idx_type", idx_array, pp_alt);
     m_reorder_idx_type = amrex::IntVect(idx_array[0], idx_array[1], 0);

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -150,7 +150,7 @@ PlasmaParticleContainer::ReadParameters ()
         }
     }
 
-    queryWithParserAlt(pp, "reorder_interval", m_reorder_interval, pp_alt);
+    queryWithParserAlt(pp, "reorder_period", m_reorder_period, pp_alt);
     amrex::Array<int, 2> idx_array
         {Hipace::m_depos_order_xy % 2, Hipace::m_depos_order_xy % 2};
     queryWithParserAlt(pp, "reorder_idx_type", idx_array, pp_alt);
@@ -172,7 +172,7 @@ void
 PlasmaParticleContainer::ReorderParticles (const int islice)
 {
     HIPACE_PROFILE("PlasmaParticleContainer::ReorderParticles()");
-    if (m_reorder_interval > 0 && islice % m_reorder_interval == 0) {
+    if (m_reorder_period > 0 && islice % m_reorder_period == 0) {
         SortParticlesForDeposition(m_reorder_idx_type);
     }
 }

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -151,8 +151,6 @@ PlasmaParticleContainer::ReadParameters ()
     }
 
     queryWithParserAlt(pp, "reorder_interval", m_reorder_interval, pp_alt);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_reorder_interval != 0,
-                                     "To avoid reordering, please use reorder_interval = -1.");
     amrex::Array<int, 2> idx_array
         {Hipace::m_depos_order_xy % 2, Hipace::m_depos_order_xy % 2};
     queryWithParserAlt(pp, "reorder_idx_type", idx_array, pp_alt);
@@ -174,7 +172,7 @@ void
 PlasmaParticleContainer::ReorderParticles (const int islice)
 {
     HIPACE_PROFILE("PlasmaParticleContainer::ReorderParticles()");
-    if (m_reorder_interval != -1 && islice % m_reorder_interval == 0) {
+    if (m_reorder_interval > 0 && islice % m_reorder_interval == 0) {
         SortParticlesForDeposition(m_reorder_idx_type);
     }
 }

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -149,6 +149,14 @@ PlasmaParticleContainer::ReadParameters ()
                                        phys_const_SI.c * phys_const_SI.c ) );
         }
     }
+
+    queryWithParserAlt(pp, "reorder_interval", m_reorder_interval, pp_alt);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_reorder_interval != 0,
+                                     "To avoid reordering, please use reorder_interval = -1.");
+    amrex::Array<amrex::Real, 2> idx_array
+        {Hipace::m_depos_order_xy % 2, Hipace::m_depos_order_xy % 2};
+    queryWithParserAlt(pp, "reorder_idx_type", idx_array, pp_alt);
+    m_reorder_idx_type = amrex::IntVect(idx_array[0], idx_array[1], 0);
 }
 
 void
@@ -160,6 +168,15 @@ PlasmaParticleContainer::InitData ()
     InitParticles(m_ppc, m_u_std, m_u_mean, m_radius, m_hollow_core_radius);
 
     m_num_exchange = TotalNumberOfParticles();
+}
+
+void
+PlasmaParticleContainer::ReorderParticles (const int islice)
+{
+    HIPACE_PROFILE("PlasmaParticleContainer::ReorderParticles()");
+    if (m_reorder_interval != -1 && islice % m_reorder_interval == 0) {
+        SortParticlesForDeposition(m_reorder_idx_type);
+    }
 }
 
 void


### PR DESCRIPTION
Using 1023 1023 3000 cells, 4 4 electron ppc at 50eV, enabling sorting every 4th slice results in a significant performance improvement:

no reordering:
```
TinyProfiler total time across processes [min...avg...max]: 110 ... 110 ... 110

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
ExplicitDeposition()                                 3000      44.04      44.04      44.04  40.02%
DepositCurrent_PlasmaParticleContainer()             3001      34.41      34.41      34.41  31.27%
AdvancePlasmaParticles()                             3000      18.24      18.24      18.24  16.57%
hpmg::MultiGrid::solve1()                            3000      6.329      6.329      6.329   5.75%
AnyDST::Execute()                                   18000      1.376      1.376      1.376   1.25%
```

with reordering:
```
TinyProfiler total time across processes [min...avg...max]: 60.98 ... 60.98 ... 60.98

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
ExplicitDeposition()                                 3000      15.68      15.68      15.68  25.71%
DepositCurrent_PlasmaParticleContainer()             3001      14.33      14.33      14.33  23.50%
AdvancePlasmaParticles()                             3000       13.8       13.8       13.8  22.63%
hpmg::MultiGrid::solve1()                            3000      6.324      6.324      6.324  10.37%
ParticleContainer::SortParticlesForDeposition()       750      2.899      2.899      2.899   4.75%
AnyDST::Execute()                                   18000      1.358      1.358      1.358   2.23%
```



- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
