### PR TITLE
Keep version up to date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,9 @@ endif()
 # fancy binary name for build variants
 set_hipace_binary_name()
 
+add_custom_target(touch_version_file
+        COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${HiPACE_SOURCE_DIR}/src/HipaceVersion.H)
+add_dependencies(HiPACE touch_version_file)
 
 # Defines #####################################################################
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ endif()
 set_hipace_binary_name()
 
 add_custom_target(touch_version_file
-        COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${HiPACE_SOURCE_DIR}/src/HipaceVersion.H)
+        COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${HiPACE_SOURCE_DIR}/src/HipaceVersion.H.in)
 add_dependencies(HiPACE touch_version_file)
 
 # Defines #####################################################################

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -38,7 +38,7 @@ namespace {
 }
 #endif
 
-Hipace* Hipace::m_instance = nullptr;
+Hipace* Hipace::m_instance =  nullptr;
 
 bool Hipace::m_normalized_units = false;
 int Hipace::m_max_step = 0;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -75,7 +75,7 @@ bool Hipace::m_do_tiling = true;
 
 Hipace_early_init::Hipace_early_init (Hipace* instance)
 {
-    Hipace::m_instance =  instance;
+    Hipace::m_instance = instance;
     amrex::ParmParse pph("hipace");
     queryWithParser(pph ,"normalized_units", Hipace::m_normalized_units);
     if (Hipace::m_normalized_units) {

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -38,7 +38,7 @@ namespace {
 }
 #endif
 
-Hipace* Hipace::m_instance =  nullptr;
+Hipace* Hipace::m_instance = nullptr;
 
 bool Hipace::m_normalized_units = false;
 int Hipace::m_max_step = 0;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -75,7 +75,7 @@ bool Hipace::m_do_tiling = true;
 
 Hipace_early_init::Hipace_early_init (Hipace* instance)
 {
-    Hipace::m_instance = instance;
+    Hipace::m_instance =  instance;
     amrex::ParmParse pph("hipace");
     queryWithParser(pph ,"normalized_units", Hipace::m_normalized_units);
     if (Hipace::m_normalized_units) {


### PR DESCRIPTION
After re-compiling HiPACE++ without `rm -rf build`, the HiPACE++ version number printed in standard output of a HiPACE++ run 
```
HiPACE++ (v23.03-20-gd9992acafb1a) running in double precision
```
(where the commit hash is given by `d9992acafb1a`) is sometimes incorrect. This happens in particular when, on a given branch, on does (this is a very standard workflow to pull the latest changes)
```
# build/ contains a compiled version of the code on the current branch
git pull # get more recent commits, changing a few files
cmake --build build
```
If the changes pulled in `git pull` do not include any change in `src/HipaceVersion.H.in`, this file is not recompiled and the version printed will correspond to the one before the `git pull`. I believe this is a problem, because then the code is not in a dirty version, and does run with the latest changes, but simply prints the wrong version. This PR proposes a fix by always recompiling `src/HipaceVersion.H.in`. It seems to fix the issue, but slightly increases the compilation time, in particular for the corner case when one recompiles multiple times without changing anything. Locally, it tool 0.44 s before this change, and now takes 2.4 s with this change as some CMake operations alway have to be done. Nevertheless, I believe this is a minor drawback to avoid misleading version info.

This may also affect WarpX?