### PR TITLE
[mini] Better print statement when checksum fails

### DIFF
--- a/tests/checksum/checksum.py
+++ b/tests/checksum/checksum.py
@@ -102,9 +102,9 @@ class Checksum:
                   "have different outer keys:")
             print("Benchmark: %s" % ref_benchmark.data.keys())
             print("IO file  : %s" % self.data.keys())
-            print("\n\n----------------\n\nNew file:")
+            print("\n----------------\nNew file for " + self.test_name + ":")
             print(json.dumps(self.data, indent=2))
-            print("\n\n----------------\n")
+            print("----------------")
             sys.exit(1)
 
         # Dictionaries have same inner keys (field and particle quantities)?
@@ -117,9 +117,9 @@ class Checksum:
                       % (key1, ref_benchmark.data[key1].keys()))
                 print("IO file   inner keys in %s: %s"
                       % (key1, self.data[key1].keys()))
-                print("\n\n----------------\n\nNew file:")
+                print("\n----------------\nNew file for " + self.test_name + ":")
                 print(json.dumps(self.data, indent=2))
-                print("\n\n----------------\n")
+                print("----------------")
                 sys.exit(1)
 
         # Dictionaries have same values?
@@ -140,9 +140,9 @@ class Checksum:
                           % (key1, key2, self.data[key1][key2]))
                     checksums_differ = True
         if checksums_differ:
-            print("\n\n----------------\n\nNew file:")
+            print("\n----------------\nNew file for " + self.test_name + ":")
             print(json.dumps(self.data, indent=2))
-            print("\n\n----------------\n")
+            print("----------------")
             sys.exit(1)
         print("Checksum evaluation passed.")
 


### PR DESCRIPTION
When a checksum test fails, print the test name before showing the new json file content.
Similar to https://github.com/ECP-WarpX/WarpX/pull/3753.