### PR TITLE
Remove zeta refinement

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -157,12 +157,12 @@ public:
 
     /** \brief Full evolve on 1 slice
      *
-     * \param[in] islice_coarse slice number
+     * \param[in] islice slice number
      * \param[in] ibox index of the current box to be calculated
      * \param[in] step current time step
      * \param[in] bins an amrex::DenseBins object that orders particles by slice
      */
-    void SolveOneSlice (int islice_coarse, const int ibox, int step,
+    void SolveOneSlice (int islice, const int ibox, int step,
                         const amrex::Vector<amrex::Vector<BeamBins>>& bins);
 
     /** \brief Full evolve on 1 subslice with explicit solver

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -186,6 +186,8 @@ Hipace::Hipace () :
         for (int idim=0; idim<AMREX_SPACEDIM; ++idim) patch_lo[idim] = loc_array[idim];
         getWithParser(pph, "patch_hi", loc_array);
         for (int idim=0; idim<AMREX_SPACEDIM; ++idim) patch_hi[idim] = loc_array[idim];
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(GetRefRatio(1)[2] == 1,
+            "Mesh refinement in the zeta direction is not supported");
     }
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_do_MR || !m_multi_beam.AnySpeciesSalame(),
         "Cannot use SALAME algorithm with mesh refinement");

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -203,12 +203,11 @@ public:
      * ExmBy and EypBx are solved in the same function because both rely on Psi.
      *
      * \param[in] geom Geometry
-     * \param[in] m_comm_xy transverse communicator on the slice
      * \param[in] lev current level
      * \param[in] islice longitudinal slice
      */
     void SolvePoissonExmByAndEypBx (amrex::Vector<amrex::Geometry> const& geom,
-                                    const MPI_Comm& m_comm_xy, const int lev, const int islice);
+                                    const int lev, const int islice);
     /** \brief Compute Ez on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry


### PR DESCRIPTION
Because particle pushers don’t like a changing timestep, zeta refinement is incompatible with particles crossing in and out of the refined patch.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
