### PR TITLE
Use parser for beam density

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -439,10 +439,17 @@ which are valid only for certain beam types, are introduced further below under
     either ``total_charge`` or ``density`` must be specified.
     The absolute value of this parameter is used when initializing the beam.
 
+* ``<beam name>.density(x,y,z)`` (`float`)
+    The (number) density profile of the beam, as a function of spatial dimensions `x`, `y` and `z`.
+    This function uses the parser, see above.
+    Only used when ``<beam name>.injection_type == fixed_ppc`` and ``<beam name>.profile == parsed``.
+
 * ``<beam name>.profile`` (`string`)
     Beam profile.
     When ``<beam name>.injection_type == fixed_ppc``, possible options are ``flattop``
-    (flat-top radially and longitudinally) or ``gaussian`` (Gaussian in all directions).
+    (flat-top radially and longitudinally), ``gaussian`` (Gaussian in all directions),
+    or ``parsed`` (arbitrary analytic function provided by the user).
+    When ``parsed``, ``<beam name>.density(x,y,z)`` must be specified.
     When ``<beam name>.injection_type == fixed_weight``, possible options are ``can``
     (uniform longitudinally, Gaussian transversally) and ``gaussian`` (Gaussian in all directions).
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -434,6 +434,15 @@ which are valid only for certain beam types, are introduced further below under
 * ``<beam name>.charge`` (`float`) optional (default `-q_e`)
     The charge of a beam particle. Can also be set with ``<beam name>.element``.
 
+* ``<beam name>.profile`` (`string`)
+    Beam profile.
+    When ``<beam name>.injection_type == fixed_ppc``, possible options are ``flattop``
+    (flat-top radially and longitudinally), ``gaussian`` (Gaussian in all directions),
+    or ``parsed`` (arbitrary analytic function provided by the user).
+    When ``parsed``, ``<beam name>.density(x,y,z)`` must be specified.
+    When ``<beam name>.injection_type == fixed_weight``, possible options are ``can``
+    (uniform longitudinally, Gaussian transversally) and ``gaussian`` (Gaussian in all directions).
+
 * ``<beam name>.density`` (`float`)
     Peak density of the beam. Note: When ``<beam name>.injection_type == fixed_weight``
     either ``total_charge`` or ``density`` must be specified.
@@ -443,15 +452,6 @@ which are valid only for certain beam types, are introduced further below under
     The (number) density profile of the beam, as a function of spatial dimensions `x`, `y` and `z`.
     This function uses the parser, see above.
     Only used when ``<beam name>.injection_type == fixed_ppc`` and ``<beam name>.profile == parsed``.
-
-* ``<beam name>.profile`` (`string`)
-    Beam profile.
-    When ``<beam name>.injection_type == fixed_ppc``, possible options are ``flattop``
-    (flat-top radially and longitudinally), ``gaussian`` (Gaussian in all directions),
-    or ``parsed`` (arbitrary analytic function provided by the user).
-    When ``parsed``, ``<beam name>.density(x,y,z)`` must be specified.
-    When ``<beam name>.injection_type == fixed_weight``, possible options are ``can``
-    (uniform longitudinally, Gaussian transversally) and ``gaussian`` (Gaussian in all directions).
 
 * ``<beam name>.n_subcycles`` (`int`) optional (default `10`)
     Number of sub-cycles performed in the beam particle pusher. The particles will be pushed

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -443,16 +443,6 @@ which are valid only for certain beam types, are introduced further below under
     When ``<beam name>.injection_type == fixed_weight``, possible options are ``can``
     (uniform longitudinally, Gaussian transversally) and ``gaussian`` (Gaussian in all directions).
 
-* ``<beam name>.density`` (`float`)
-    Peak density of the beam. Note: When ``<beam name>.injection_type == fixed_weight``
-    either ``total_charge`` or ``density`` must be specified.
-    The absolute value of this parameter is used when initializing the beam.
-
-* ``<beam name>.density(x,y,z)`` (`float`)
-    The (number) density profile of the beam, as a function of spatial dimensions `x`, `y` and `z`.
-    This function uses the parser, see above.
-    Only used when ``<beam name>.injection_type == fixed_ppc`` and ``<beam name>.profile == parsed``.
-
 * ``<beam name>.n_subcycles`` (`int`) optional (default `10`)
     Number of sub-cycles performed in the beam particle pusher. The particles will be pushed
     ``n_subcycles`` times with a time step of `dt/n_subcycles`. This can be used to improve accuracy
@@ -514,6 +504,10 @@ Option: ``fixed_weight``
     The absolute value of this parameter is used when initializing the beam.
     Note that ``<beam name>.zmin`` and ``<beam name>.zmax`` can reduce the total charge.
 
+* ``<beam name>.density`` (`float`)
+    Peak density of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
+    The absolute value of this parameter is used when initializing the beam.
+
 * ``<beam name>.duz_per_uz0_dzeta`` (`float`) optional (default `0.`)
     Relative correlated energy spread per :math:`\zeta`.
     Thereby, `duz_per_uz0_dzeta *` :math:`\zeta` `* uz_mean` is added to `uz` of the each particle.
@@ -544,6 +538,15 @@ Option: ``fixed_ppc``
 * ``<beam name>.radius`` (`float`)
     Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
     injected.
+
+* ``<beam name>.density`` (`float`)
+    Peak density of the beam.
+    The absolute value of this parameter is used when initializing the beam.
+
+* ``<beam name>.density(x,y,z)`` (`float`)
+    The density profile of the beam, as a function of spatial dimensions `x`, `y` and `z`.
+    This function uses the parser, see above.
+    Only used when ``<beam name>.profile == parsed``.
 
 * ``<beam name>.min_density`` (`float`) optional (default `0`)
     Minimum density. Particles with a lower density are not injected.

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -169,6 +169,8 @@ private:
     amrex::Parser m_pos_mean_x_parser;
     /** Average y position of the fixed-weight beam depending on z */
     amrex::Parser m_pos_mean_y_parser;
+    /** Density parser for fixed-ppc beam. Owns data for m_density_func */
+    amrex::Parser m_density_parser;
     /** Width of the Gaussian beam. Only used for a fixed-weight beam */
     amrex::RealVect m_position_std {0., 0., 0.};
     /** Distance at which the beam is focused, starting from its initial position */

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -92,7 +92,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         m_min_density = std::abs(m_min_density);
         amrex::Vector<int> random_ppc {false, false, false};
         queryWithParser(pp, "random_ppc", random_ppc);
-        const GetInitialDensity get_density(m_name);
+        const GetInitialDensity get_density(m_name, m_density_parser);
         const GetInitialMomentum get_momentum(m_name);
         InitBeamFixedPPC(m_ppc, get_density, get_momentum, geom, m_zmin,
                          m_zmax, m_radius, position_mean, m_min_density, random_ppc);

--- a/src/particles/profiles/GetInitialDensity.H
+++ b/src/particles/profiles/GetInitialDensity.H
@@ -11,9 +11,10 @@
 #include <AMReX.H>
 #include <AMReX_REAL.H>
 #include <AMReX_RealVect.H>
+#include "utils/Parser.H"
 
-/** \brief Beam profile type, currently only Gaussian or Flattop */
-enum struct BeamProfileType { Gaussian, Flattop };
+/** \brief Beam profile type, currently only Gaussian or Flattop or Parsed */
+enum struct BeamProfileType { Gaussian, Flattop, Parsed };
 
 /** \brief Functor gets the initial density for beam particles for a given position
  */
@@ -42,6 +43,8 @@ struct GetInitialDensity
                                 * exp( -0.5_rt*delta_z*delta_z );
         } else if (m_profile == BeamProfileType::Flattop) {
             density = m_density;
+        } else if (m_profile == BeamProfileType::Parsed) {
+            density = m_density_func(x, y, z);
         }
         return density;
     }
@@ -49,6 +52,8 @@ struct GetInitialDensity
     amrex::RealVect  m_position_std {0.,0.,0.};  /* rms standard deviation in case of a Gaussian density distribution */
     BeamProfileType m_profile; /* beam profile type, e.g. BeamProfileType::Flattop or BeamProfileType::Gaussian*/
     amrex::Real m_density; /**< Peak density of the beam */
+    amrex::Parser m_parser; /**< owns data for m_density_func */
+    amrex::ParserExecutor<3> m_density_func; /**< Density function for the plasma */
 };
 
 #endif // GETINTIALDENSITY_H_

--- a/src/particles/profiles/GetInitialDensity.H
+++ b/src/particles/profiles/GetInitialDensity.H
@@ -22,7 +22,7 @@ struct GetInitialDensity
 {
     /** Constructor.
      */
-    GetInitialDensity (const std::string& name);
+    GetInitialDensity (const std::string& name, amrex::Parser& parser);
 
     /** \brief returns the density for a beam particle at a given position
      * \param[in] x position in x
@@ -52,7 +52,6 @@ struct GetInitialDensity
     amrex::RealVect  m_position_std {0.,0.,0.};  /* rms standard deviation in case of a Gaussian density distribution */
     BeamProfileType m_profile; /* beam profile type, e.g. BeamProfileType::Flattop or BeamProfileType::Gaussian*/
     amrex::Real m_density; /**< Peak density of the beam */
-    amrex::Parser m_parser; /**< owns data for m_density_func */
     amrex::ParserExecutor<3> m_density_func; /**< Density function for the plasma */
 };
 

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -8,27 +8,16 @@
 #include "GetInitialDensity.H"
 #include "utils/Parser.H"
 
-GetInitialDensity::GetInitialDensity (const std::string& name)
+GetInitialDensity::GetInitialDensity (const std::string& name, amrex::Parser& parser)
 {
     amrex::ParmParse pp(name);
     std::string profile;
     getWithParser(pp, "profile", profile);
 
-    if        (profile == "gaussian") {
+    if (profile == "gaussian") {
         m_profile = BeamProfileType::Gaussian;
         getWithParser(pp, "density", m_density);
         m_density = std::abs(m_density);
-    } else if (profile == "flattop") {
-        m_profile = BeamProfileType::Flattop;
-        getWithParser(pp, "density", m_density);
-        m_density = std::abs(m_density);
-    } else if (profile == "parsed") {
-        m_profile = BeamProfileType::Parsed;
-    } else {
-        amrex::Abort("Unknown beam profile!");
-    }
-
-    if (m_profile == BeamProfileType::Gaussian) {
         amrex::Array<amrex::Real, AMREX_SPACEDIM> loc_array;
         if (queryWithParser(pp, "position_mean", loc_array)) {
             for (int idim=0; idim < AMREX_SPACEDIM; ++idim) {
@@ -40,10 +29,16 @@ GetInitialDensity::GetInitialDensity (const std::string& name)
                 m_position_std[idim] = loc_array[idim];
             }
         }
-    }
-    if (m_profile == BeamProfileType::Parsed) {
+    } else if (profile == "flattop") {
+        m_profile = BeamProfileType::Flattop;
+        getWithParser(pp, "density", m_density);
+        m_density = std::abs(m_density);
+    } else if (profile == "parsed") {
+        m_profile = BeamProfileType::Parsed;
         std::string density_func_str = "0.";
         getWithParser(pp, "density(x,y,z)", density_func_str);
-        m_density_func = makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"});
+        m_density_func = makeFunctionWithParser<3>(density_func_str, parser, {"x", "y", "z"});
+    } else {
+        amrex::Abort("Unknown beam profile!");
     }
 }

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -20,6 +20,8 @@ GetInitialDensity::GetInitialDensity (const std::string& name)
         m_profile = BeamProfileType::Gaussian;
     } else if (profile == "flattop") {
         m_profile = BeamProfileType::Flattop;
+    } else if (profile == "parsed") {
+        m_profile = BeamProfileType::Parsed;
     } else {
         amrex::Abort("Unknown beam profile!");
     }
@@ -36,5 +38,10 @@ GetInitialDensity::GetInitialDensity (const std::string& name)
                 m_position_std[idim] = loc_array[idim];
             }
         }
+    }
+    if (m_profile == BeamProfileType::Parsed) {
+        std::string density_func_str = "0.";
+        getWithParser(pp, "density(x,y,z)", density_func_str);
+        m_density_func = makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"});
     }
 }

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -12,14 +12,16 @@ GetInitialDensity::GetInitialDensity (const std::string& name)
 {
     amrex::ParmParse pp(name);
     std::string profile;
-    getWithParser(pp, "density", m_density);
-    m_density = std::abs(m_density);
     getWithParser(pp, "profile", profile);
 
     if        (profile == "gaussian") {
         m_profile = BeamProfileType::Gaussian;
+        getWithParser(pp, "density", m_density);
+        m_density = std::abs(m_density);
     } else if (profile == "flattop") {
         m_profile = BeamProfileType::Flattop;
+        getWithParser(pp, "density", m_density);
+        m_density = std::abs(m_density);
     } else if (profile == "parsed") {
         m_profile = BeamProfileType::Parsed;
     } else {


### PR DESCRIPTION
This PR adds the option to parse the beam density, for the fixed-ppc option. To be used with caution as the fixed-ppc option may result in impractically large number of beam particles, e.g. several particles per cell in the whole simulation box. To avoid this, please make sure you limit the creation of beam particles to relevant regions, e.g.
```
my_constants.w = 10.e-6
my_constants.nb = 5.e23

beam.injection_type = fixed_ppc
beam.profile = parsed
beam.density(x,y,z) = nb * exp(-(x**2+z**2+y**2)/w**2)
beam.min_density = nb/100 # do not allocate beam particles where the density is <1% of the peak density
beam.radius = 200.e-6 # limit the region where beam particles are allocated, both transversely...
beam.zmin = -200.e-6 # ... and longitudinally
beam.zmax =  200.e-6
```