### PR TITLE
[mini] remove some unused parameters

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -222,9 +222,8 @@ public:
      *
      * \param[lev] MR level
      * \param[in] which_slice defines if this or the salame slice is handled
-     * \param[in] islice longitudinal slice
      */
-    void ExplicitMGSolveBxBy (const int lev, const int which_slice, const int islice);
+    void ExplicitMGSolveBxBy (const int lev, const int which_slice);
 
     /** \brief Reset plasma and field slice quantities to initial value.
      *

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -77,13 +77,12 @@ private:
      * \param[in] a_box_sorter_vec Vector (over species) of particles sorted by box
      * \param[in] geom Geometry of the simulation, to get the cell size etc.
      * \param[in] beamnames list of the names of the beam to be written to file
-     * \param[in] lev MR level
      */
     void WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration iteration,
                                 const int output_step, const int it,
                                 const amrex::Vector<BoxSorter>& a_box_sorter_vec,
                                 const amrex::Geometry& geom,
-                                const amrex::Vector< std::string > beamnames, const int lev);
+                                const amrex::Vector< std::string > beamnames);
 
     /** \brief writing openPMD field data
      *
@@ -92,11 +91,10 @@ private:
      * \param[in] slice_dir direction of slicing. 0=x, 1=y, -1=no slicing (3D array)
      * \param[in] varnames list of variable names for the fields (ExmBy, EypBx, Ey, ...)
      * \param[in,out] iteration openPMD iteration to which the data is written
-     * \param[in] output_step current time step to dump
      */
     void WriteFieldData (amrex::FArrayBox const& fab, amrex::Geometry const& geom,
                          const int slice_dir, const amrex::Vector< std::string > varnames,
-                         openPMD::Iteration iteration, const int output_step);
+                         openPMD::Iteration iteration);
 
     /** Named Beam SoA attributes per particle as defined in BeamIdx
      */
@@ -145,9 +143,8 @@ public:
         const OpenPMDWriterCallType call_type);
 
     /** \brief Resets the openPMD series of all levels
-     * \param[in] output_step current iteration
      */
-    void reset (const int output_step);
+    void reset ();
 
     /** Prefix/path for the output files */
     std::string m_file_prefix;

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -77,14 +77,14 @@ OpenPMDWriter::WriteDiagnostics (
     if (call_type == OpenPMDWriterCallType::beams ) {
         const int lev = 0;
         WriteBeamParticleData(a_multi_beam, iteration, output_step, it, a_box_sorter_vec,
-                              geom3D[lev], beamnames, lev);
+                              geom3D[lev], beamnames);
         m_last_beam_output_dumped = output_step;
         m_outputSeries->flush();
     } else if (call_type == OpenPMDWriterCallType::fields) {
         for (const auto& fd : field_diag) {
             if (fd.m_has_field) {
                 WriteFieldData(fd.m_F, fd.m_geom_io, fd.m_slice_dir, fd.m_comps_output,
-                           iteration, output_step);
+                           iteration);
             }
         }
         m_outputSeries->flush();
@@ -95,7 +95,7 @@ void
 OpenPMDWriter::WriteFieldData (
     amrex::FArrayBox const& fab, amrex::Geometry const& geom,
     const int slice_dir, const amrex::Vector< std::string > varnames,
-    openPMD::Iteration iteration, const int output_step)
+    openPMD::Iteration iteration)
 {
     // todo: periodicity/boundary, field solver, particle pusher, etc.
     auto meshes = iteration.meshes;
@@ -170,7 +170,7 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
                                       const int output_step, const int it,
                                       const amrex::Vector<BoxSorter>& a_box_sorter_vec,
                                       const amrex::Geometry& geom,
-                                      const amrex::Vector< std::string > beamnames, const int lev)
+                                      const amrex::Vector< std::string > beamnames)
 {
     HIPACE_PROFILE("WriteBeamParticleData()");
 
@@ -386,7 +386,7 @@ OpenPMDWriter::SaveRealProperty (BeamParticleContainer& pc,
     }
 }
 
-void OpenPMDWriter::reset (const int output_step)
+void OpenPMDWriter::reset ()
 {
     m_outputSeries.reset();
 }

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -179,25 +179,21 @@ public:
      * \param[in] geom Geometry
      * \param[in] lev current level
      * \param[in] component which can be Psi, Ez, By, Bx ...
-     * \param[in] islice longitudinal slice
      * \param[in,out] staging_area Target MultiFab where the boundary condition is applied
      */
     void SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                               std::string component, const int islice,
-                               amrex::MultiFab&& staging_area);
+                               std::string component, amrex::MultiFab&& staging_area);
 
     /** \brief Interpolate values from coarse grid to the fine grid
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
      * \param[in] component which can be Psi or rho
-     * \param[in] islice longitudinal slice
      * \param[in] outer_edge start writing interpolated values at domain + outer_edge
      * \param[in] inner_edge stop writing interpolated values at domain + inner_edge
      */
     void InterpolateFromLev0toLev1 (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                                    std::string component, const int islice,
-                                    const amrex::IntVect outer_edge,
+                                    std::string component, const amrex::IntVect outer_edge,
                                     const amrex::IntVect inner_edge);
 
     /** \brief Compute ExmBy and EypBx on the slice container from J by solving a Poisson equation
@@ -205,45 +201,39 @@ public:
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
-     * \param[in] islice longitudinal slice
      */
     void SolvePoissonExmByAndEypBx (amrex::Vector<amrex::Geometry> const& geom,
-                                    const int lev, const int islice);
+                                    const int lev);
     /** \brief Compute Ez on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
-     * \param[in] islice longitudinal slice
      * \param[in] which_slice defines if this or the salame slice is handled
      */
     void SolvePoissonEz (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                         const int islice, const int which_slice = WhichSlice::This);
+                         const int which_slice = WhichSlice::This);
     /** \brief Compute Bx on the slice container from J by solving a Poisson equation
      *
      * \param[in,out] Bx_iter Bx field during current iteration of the predictor-corrector loop
      * \param[in] geom Geometry
      * \param[in] lev current level
-     * \param[in] islice longitudinal slice
      */
     void SolvePoissonBx (amrex::MultiFab& Bx_iter, amrex::Vector<amrex::Geometry> const& geom,
-                         const int lev, const int islice);
+                         const int lev);
     /** \brief Compute By on the slice container from J by solving a Poisson equation
      *
      * \param[in,out] By_iter By field during current iteration of the predictor-corrector loop
      * \param[in] geom Geometry
      * \param[in] lev current level
-     * \param[in] islice longitudinal slice
      */
     void SolvePoissonBy (amrex::MultiFab& By_iter, amrex::Vector<amrex::Geometry> const& geom,
-                         const int lev, const int islice);
+                         const int lev);
     /** \brief Compute Bz on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
-     * \param[in] islice longitudinal slice
      */
-    void SolvePoissonBz (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                         const int islice);
+    void SolvePoissonBz (amrex::Vector<amrex::Geometry> const& geom, const int lev);
     /** \brief Sets the initial guess of the B field from the two previous slices
      *
      * This modifies component Bx or By of slice 1 in m_fields.m_slices

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -54,7 +54,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
         // use an initial guess of zero for Bx and By in MG solver to reduce relative error
         hipace->m_fields.setVal(0., lev, WhichSlice::Salame, "Ez", "jz_beam", "Sy", "Sx", "Bx", "By");
 
-        hipace->m_fields.SolvePoissonEz(hipace->Geom(), lev, islice, WhichSlice::Salame);
+        hipace->m_fields.SolvePoissonEz(hipace->Geom(), lev, WhichSlice::Salame);
 
         hipace->m_fields.duplicate(lev, WhichSlice::Salame, {"Ez_no_salame"},
                                         WhichSlice::Salame, {"Ez"});
@@ -67,7 +67,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
 
         SalameInitializeSxSyWithBeam(hipace, lev);
 
-        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::Salame, islice);
+        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::Salame);
 
         hipace->m_fields.setVal(0., lev, WhichSlice::Salame, "Ez", "jx", "jy");
 
@@ -81,7 +81,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
             SalameGetJxJyFromBxBy(hipace, lev);
         }
 
-        hipace->m_fields.SolvePoissonEz(hipace->Geom(), lev, islice, WhichSlice::Salame);
+        hipace->m_fields.SolvePoissonEz(hipace->Geom(), lev, WhichSlice::Salame);
 
         // STEP 3: find ideal weighting factor of the SALAME beam using the computed Ez fields,
         // and update the beam with it
@@ -122,7 +122,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
         hipace->m_fields.add(lev, WhichSlice::This, {"Sy", "Sx"},
                                   WhichSlice::Salame, {"Sy_back", "Sx_back"});
 
-        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::This, islice);
+        hipace->ExplicitMGSolveBxBy(lev, WhichSlice::This);
     }
 }
 


### PR DESCRIPTION
From LUMI compiler warnings I found a bunch of unused parameters that are removed in this PR.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
