### PR TITLE
Support new AMReX particle interfaces

### DIFF
--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -27,13 +27,15 @@ struct BeamIdx
     };
 };
 
-struct BeamBins : amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>::ParticleType> {
+struct BeamBins : amrex::DenseBins<
+        amrex::ParticleTile<amrex::Particle<0, 0>, BeamIdx::nattribs, 0>::ParticleType> {
 
     template<class...Args>
     void build (Args&&...args) {
         // call build function of the underlying DenseBins object
         // with all of the arguments forwarded
-        amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>::ParticleType>::build(args...);
+        amrex::DenseBins<amrex::ParticleTile<
+            amrex::Particle<0, 0>, BeamIdx::nattribs, 0>::ParticleType>::build(args...);
 
         // after every build call copy offsets array form GPU to CPU
         const auto offset_size = numBins() + 1;
@@ -57,12 +59,12 @@ struct BeamBins : amrex::DenseBins<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 
 
 /** \brief Container for particles of 1 beam species. */
 class BeamParticleContainer
-    : public amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>
+    : public amrex::ParticleTile<amrex::Particle<0, 0>, BeamIdx::nattribs, 0>
 {
 public:
     /** Constructor */
     explicit BeamParticleContainer (std::string name) :
-        amrex::ParticleTile<0,0,BeamIdx::nattribs,0>(),
+        amrex::ParticleTile<amrex::Particle<0, 0>, BeamIdx::nattribs, 0>(),
         m_name(name)
     {
         ReadParameters();

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -174,9 +174,9 @@ private:
 class PlasmaParticleIterator : public amrex::ParIter<0,0,PlasmaIdx::nattribs,PlasmaIdx::int_nattribs>
 {
 public:
-    using amrex::ParIter<0,0,PlasmaIdx::nattribs,PlasmaIdx::int_nattribs>::ParIter;
     /** Constructor */
-    PlasmaParticleIterator (ContainerType& pc, int level): ParIter(pc, level, DfltMfi) {}
+    PlasmaParticleIterator (ContainerType& pc, int level)
+        : amrex::ParIter<0,0,PlasmaIdx::nattribs,PlasmaIdx::int_nattribs>(pc, level, DfltMfi) {}
 };
 
 #endif

--- a/src/particles/sorting/BoxSort.cpp
+++ b/src/particles/sorting/BoxSort.cpp
@@ -50,7 +50,7 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
 
     amrex::Gpu::exclusive_scan(m_box_counts.begin(), m_box_counts.end(), m_box_offsets.begin());
 
-    amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0> tmp{};
+    amrex::ParticleTile<amrex::Particle<0, 0>, BeamIdx::nattribs, 0> tmp{};
     tmp.resize(np);
 
     auto p_box_offsets = m_box_offsets.dataPtr();
@@ -62,8 +62,8 @@ void BoxSorter::sortParticlesByBox (BeamParticleContainer& a_beam,
         p_dst_indices[i] += p_box_offsets[dst_box];
     });
 
-    amrex::scatterParticles<amrex::ParticleTile<0, 0, BeamIdx::nattribs, 0>>(tmp, a_beam, np,
-                                                                             dst_indices.dataPtr());
+    amrex::scatterParticles<amrex::ParticleTile<amrex::Particle<0, 0>, BeamIdx::nattribs, 0>>(
+        tmp, a_beam, np, dst_indices.dataPtr());
 
     a_beam.swap(tmp);
 #ifdef AMREX_USE_GPU


### PR DESCRIPTION
This PR fixes compilation errors caused by the new ParticleTile interface in AMReX. It does not implement full-SoA particles that are now possible.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
