### PR TITLE
Remove NumPy from brew cache

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,6 @@ jobs:
           /usr/local/Cellar/fftw
           /usr/local/Cellar/libomp
           /usr/local/Cellar/ninja
-          /usr/local/Cellar/numpy
           /usr/local/Cellar/open-mpi
           /usr/local/Cellar/openpmd-api
         key: brew-macos-appleclang-${{ hashFiles('.github/workflows/macos.yml') }}


### PR DESCRIPTION
It seems to cause an error in MacOS CI

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
