### PR TITLE
add config file for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,26 @@
+# Copyright 2023
+#
+# This file is part of HiPACE++.
+#
+# Authors: Axel Huebl, Severin Diederichs
+#
+# License: BSD-3-Clause-LBNL
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/source/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt
+
+formats:
+  - htmlzip
+#  - pdf
+#  - epub


### PR DESCRIPTION
Similar to https://github.com/ECP-WarpX/WarpX/pull/3896 for fixing the required newer OpenSSL version.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
