### PR TITLE
Interpolate jx_beam and jy_beam to level 1

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -524,6 +524,15 @@ Hipace::SolveOneSlice (int islice, const int islice_local, int step)
             if (islice < m_3D_geom[lev].Domain().smallEnd(Direction::z) ||
                 islice > m_3D_geom[lev].Domain().bigEnd(Direction::z)) {
                 continue;
+            } else if (islice == m_3D_geom[lev].Domain().bigEnd(Direction::z)) {
+                // first slice of level 1 (islice goes backwards)
+                // iterpolate jx_beam and jy_beam from level 0 to level 1
+                m_fields.LevelUp(m_3D_geom, lev, WhichSlice::Previous1, "jx_beam");
+                m_fields.LevelUp(m_3D_geom, lev, WhichSlice::Previous1, "jy_beam");
+                m_fields.LevelUp(m_3D_geom, lev, WhichSlice::This, "jx_beam");
+                m_fields.LevelUp(m_3D_geom, lev, WhichSlice::This, "jy_beam");
+                m_fields.duplicate(lev, WhichSlice::This, {"jx"     , "jy"     },
+                                        WhichSlice::This, {"jx_beam", "jy_beam"});
             }
         }
 

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -183,13 +183,23 @@ public:
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
-     * \param[in] component which can be Psi or rho
+     * \param[in] component which can be Psi or rho etc.
      * \param[in] outer_edge start writing interpolated values at domain + outer_edge
      * \param[in] inner_edge stop writing interpolated values at domain + inner_edge
      */
     void InterpolateFromLev0toLev1 (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                                     std::string component, const amrex::IntVect outer_edge,
                                     const amrex::IntVect inner_edge);
+
+    /** \brief Interpolate the full field from the coarse grid (lev-1) to the fine grid (lev).
+     *
+     * \param[in] geom Geometry
+     * \param[in] lev current level
+     * \param[in] component which can be jx_beam or jy_beam etc.
+     * \param[in] which_slice slice of the field to interpolate
+     */
+    void LevelUp (amrex::Vector<amrex::Geometry> const& geom, const int lev,
+                  const int which_slice, const std::string component);
 
     /** \brief Compute ExmBy and EypBx on the slice container from J by solving a Poisson equation
      * ExmBy and EypBx are solved in the same function because both rely on Psi.


### PR DESCRIPTION
Interpolate jx_beam and jy_beam to level 1 at the start of the refined patch because they don’t get shifted from the previous slice.

Old:
![image](https://user-images.githubusercontent.com/64009254/236647453-3bc2451b-cc7c-4ff4-a7a8-b98268910b41.png)
New:
![image](https://user-images.githubusercontent.com/64009254/236647457-9cbe6727-7144-47e8-9169-4360b626dfe5.png)
Diff:
![image](https://user-images.githubusercontent.com/64009254/236647465-0a882284-d6ad-476d-8219-b293aefa5558.png)


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
