### PR TITLE
make CI triggers consistent

### DIFF
--- a/.github/workflows/cudaLocal.yml
+++ b/.github/workflows/cudaLocal.yml
@@ -7,7 +7,13 @@
 
 name: 🐧 local CUDA
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cudaLocal

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,6 +8,9 @@
 name: linux
 
 on:
+  push:
+    branches:
+      - development
   pull_request:
     branches:
       - development


### PR DESCRIPTION
Previously the linux CI didn’t run on push to development, preventing a ccache cache to be generated and slowing down the first CI run of all PRs. I also restricted the local CUDA CI to be run only on development since the one on my local branch seems to always get canceled.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
