### PR TITLE
Fix rocfft 5.5

### DIFF
--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -36,8 +36,12 @@ Please see installation instructions below in the Developers section.
 
   - `HDF5 <https://support.hdfgroup.org/HDF5>`__ 1.8.13+ (optional; for ``.h5`` file support)
   - `ADIOS2 <https://github.com/ornladios/ADIOS2>`__ 2.7.0+ (optional; for ``.bp`` file support)
-- Nvidia GPU support: `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__ (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`__)
-- CPU-only: `FFTW3 <http://www.fftw.org/>`__ (only used serially; *not* needed for Nvidia GPUs)
+
+Platform-dependent, at least one of the following:
+
+- `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__: for NVIDIA GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`__)
+- `ROCm 5.1+ <https://github.com/RadeonOpenCompute/ROCm>`__: for AMD GPU support
+- `FFTW3 <http://www.fftw.org/>`__: for CPUs (only used serially, but multi-threading supported; *not* needed for GPUs)
 
 Optional dependencies include:
 

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -40,7 +40,7 @@ Please see installation instructions below in the Developers section.
 Platform-dependent, at least one of the following:
 
 - `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__: for NVIDIA GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`__)
-- `ROCm 5.1+ <https://github.com/RadeonOpenCompute/ROCm>`__: for AMD GPU support
+- `ROCm 5.3+ <https://github.com/RadeonOpenCompute/ROCm>`__: for AMD GPU support
 - `FFTW3 <http://www.fftw.org/>`__: for CPUs (only used serially, but multi-threading supported; *not* needed for GPUs)
 
 Optional dependencies include:

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -40,7 +40,7 @@ Please see installation instructions below in the Developers section.
 Platform-dependent, at least one of the following:
 
 - `CUDA Toolkit 11.0+ <https://developer.nvidia.com/cuda-downloads>`__: for NVIDIA GPU support (see `matching host-compilers <https://gist.github.com/ax3l/9489132>`__)
-- `ROCm 5.3+ <https://github.com/RadeonOpenCompute/ROCm>`__: for AMD GPU support
+- `ROCm 5.2+ <https://github.com/RadeonOpenCompute/ROCm>`__: for AMD GPU support
 - `FFTW3 <http://www.fftw.org/>`__: for CPUs (only used serially, but multi-threading supported; *not* needed for GPUs)
 
 Optional dependencies include:

--- a/docs/source/building/platforms/lumi_csc.rst
+++ b/docs/source/building/platforms/lumi_csc.rst
@@ -19,7 +19,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    module load LUMI
    module load partition/G
    module load PrgEnv-amd/8.3.3
-   module load rocm/5.2.3
+   module load rocm/5.3.3
    module load buildtools/22.08
    module load cray-hdf5/1.12.1.5
 

--- a/docs/source/building/platforms/lumi_csc.rst
+++ b/docs/source/building/platforms/lumi_csc.rst
@@ -19,7 +19,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    module load LUMI
    module load partition/G
    module load PrgEnv-amd/8.3.3
-   module load rocm/5.3.3
+   module load rocm/5.2.3
    module load buildtools/22.08
    module load cray-hdf5/1.12.1.5
 

--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -20,7 +20,12 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <rocfft/rocfft.h>
+#  include <cstddef>
+#  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
+#    include <rocfft/rocfft.h>
+#  else
+#    include <rocfft.h>
+#  endif
 #else
 #  include <fftw3.h>
 #endif

--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -20,10 +20,7 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-// cstddef: work-around for ROCm/rocFFT <=4.3.0
-// https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
-#  include <cstddef>
-#  include <rocfft.h>
+#  include <rocfft/rocfft.h>
 #else
 #  include <fftw3.h>
 #endif

--- a/src/fields/fft_poisson_solver/fft/AnyFFT.H
+++ b/src/fields/fft_poisson_solver/fft/AnyFFT.H
@@ -20,7 +20,6 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <cstddef>
 #  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
 #    include <rocfft/rocfft.h>
 #  else

--- a/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
+++ b/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
@@ -8,10 +8,7 @@
 #ifndef ROCFFTUTILS_H_
 #define ROCFFTUTILS_H_
 
-// cstddef: work-around for ROCm/rocFFT <=4.3.0
-// https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
-#include <cstddef>
-#include <rocfft.h>
+#include <rocfft/rocfft.h>
 
 #include <string>
 

--- a/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
+++ b/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
@@ -8,7 +8,12 @@
 #ifndef ROCFFTUTILS_H_
 #define ROCFFTUTILS_H_
 
-#include <rocfft/rocfft.h>
+#include <cstddef>
+#if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
+#  include <rocfft/rocfft.h>
+#else
+#  include <rocfft.h>
+#endif
 
 #include <string>
 

--- a/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
+++ b/src/fields/fft_poisson_solver/fft/RocFFTUtils.H
@@ -8,7 +8,6 @@
 #ifndef ROCFFTUTILS_H_
 #define ROCFFTUTILS_H_
 
-#include <cstddef>
 #if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
 #  include <rocfft/rocfft.h>
 #else

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -22,7 +22,12 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <rocfft/rocfft.h>
+#  include <cstddef>
+#  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
+#    include <rocfft/rocfft.h>
+#  else
+#    include <rocfft.h>
+#  endif
 #else
 #  include <fftw3.h>
 #endif

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -22,7 +22,6 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <cstddef>
 #  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
 #    include <rocfft/rocfft.h>
 #  else

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -22,8 +22,7 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <cstddef>
-#  include <rocfft.h>
+#  include <rocfft/rocfft.h>
 #else
 #  include <fftw3.h>
 #endif

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -19,7 +19,6 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <cstddef>
 #  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
 #    include <rocfft/rocfft.h>
 #  else

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -19,7 +19,12 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <rocfft/rocfft.h>
+#  include <cstddef>
+#  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
+#    include <rocfft/rocfft.h>
+#  else
+#    include <rocfft.h>
+#  endif
 #else
 #  include <fftw3.h>
 #endif
@@ -113,6 +118,7 @@ MultiLaser::InitData (const amrex::BoxArray& slice_ba,
                 CuFFTUtils::cufftErrorToString(result) << "\n";
         }
 #elif defined(AMREX_USE_HIP)
+        amrex::ignore_unused(fft_size); // TODO: fft solver on AMD
 #else
         // Forward FFT plan
         m_plan_fwd = LaserFFT::VendorCreate(

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -19,8 +19,7 @@
 #ifdef AMREX_USE_CUDA
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-#  include <cstddef>
-#  include <rocfft.h>
+#  include <rocfft/rocfft.h>
 #else
 #  include <fftw3.h>
 #endif


### PR DESCRIPTION
Similar to https://github.com/ECP-WarpX/WarpX/pull/3906 

This prepares HiPACE++ for ROCm >= 5.3, while maintaining ability to run with 5.2


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
