### PR TITLE
Use less than or equal for min_density

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -309,7 +309,7 @@ When both are specified, the per-species value is used.
     ``"<plasma name>.density(x,y,z)" = "1."``.
 
 * ``<plasma name> or plasmas.min_density`` (`float`) optional (default `0`)
-    Minimal density below which particles are not injected.
+    Particles with a density less than or equal to the minimal density won't be injected.
     Useful for parsed functions to avoid redundant plasma particles with close to 0 weight.
 
 * ``<plasma name>.density_table_file`` (`string`) optional (default "")

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -90,7 +90,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                         y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                         rsq > a_radius*a_radius ||
                         rsq < a_hollow_core_radius*a_hollow_core_radius ||
-                        density_func(x, y, c_t) < min_density) continue;
+                        density_func(x, y, c_t) <= min_density) continue;
 
                     num_particles_cell += 1;
                 }
@@ -142,7 +142,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                     rsq > a_radius*a_radius ||
                     rsq < a_hollow_core_radius*a_hollow_core_radius ||
-                    density_func(x, y, c_t) < min_density) return;
+                    density_func(x, y, c_t) <= min_density) return;
 
                 int ix = i - lo.x;
                 int iy = j - lo.y;
@@ -217,7 +217,7 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                     rsq > a_radius*a_radius ||
                     rsq < a_hollow_core_radius*a_hollow_core_radius ||
-                    density_func(x, y, c_t) < min_density) return;
+                    density_func(x, y, c_t) <= min_density) return;
 
                 amrex::Real u[3] = {0.,0.,0.};
                 ParticleUtil::get_gaussian_random_momentum(u, a_u_mean, a_u_std, engine);


### PR DESCRIPTION
This will prevent particles with zero weight from being injected

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
