### PR TITLE
Don't use tiling in the plasma pusher

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -535,10 +535,6 @@ Hipace::SolveOneSlice (int islice, const int islice_local, int step)
 
         m_multi_plasma.DoFieldIonization(lev, m_3D_geom[lev], m_fields);
 
-        if (m_multi_plasma.IonizationOn() && m_do_tiling) {
-            m_multi_plasma.TileSort(m_slice_geom[lev].Domain(), m_slice_geom[lev]);
-        }
-
         // Push plasma particles
         m_multi_plasma.AdvanceParticles(m_fields, m_multi_laser, m_3D_geom, false, lev);
 

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -105,7 +105,7 @@ MultiPlasma::AdvanceParticles (
 {
     for (int i=0; i<m_nplasmas; i++) {
         AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice,
-                               lev, m_all_bins[i], multi_laser);
+                               lev, multi_laser);
     }
 }
 

--- a/src/particles/pusher/PlasmaParticleAdvance.H
+++ b/src/particles/pusher/PlasmaParticleAdvance.H
@@ -20,12 +20,11 @@
  * \param[in] gm Geometry of the simulation, to get the cell size etc.
  * \param[in] temp_slice if true, the temporary data (x_temp, ...) will be used
  * \param[in] lev MR level
- * \param[in] bins objects containing indices of plasma particles in each tile
  * \param[in] multi_laser Laser pulses, which affects the plasma via the ponderomotive force
  */
 void
 AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Vector<amrex::Geometry> const& gm, const bool temp_slice, int const lev,
-                        PlasmaBins& bins, const MultiLaser& multi_laser);
+                        const MultiLaser& multi_laser);
 
 #endif //  PLASMAPARTICLEADVANCE_H_

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -28,12 +28,10 @@ template struct PlasmaMomentumDerivative<DualNumber>;
 void
 AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Vector<amrex::Geometry> const& gm, const bool temp_slice, int const lev,
-                        PlasmaBins& bins, const MultiLaser& multi_laser)
+                        const MultiLaser& multi_laser)
 {
     HIPACE_PROFILE("AdvancePlasmaParticles()");
     using namespace amrex::literals;
-
-    const bool do_tiling = Hipace::m_do_tiling;
 
     const PhysConst phys_const = get_phys_const();
 
@@ -90,25 +88,25 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
         const amrex::Real clight = phys_const.c;
         const amrex::Real clight_inv = 1._rt/phys_const.c;
         const amrex::Real charge_mass_clight_ratio = plasma.m_charge/(plasma.m_mass * phys_const.c);
-
-        const int ntiles = do_tiling ? bins.numBins() : 1;
-
 #ifdef AMREX_USE_OMP
-#pragma omp parallel for if (amrex::Gpu::notInLaunchRegion())
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-        for (int itile=0; itile<ntiles; itile++){
-            BeamBins::index_type const * const indices =
-                do_tiling ? bins.permutationPtr() : nullptr;
-            BeamBins::index_type const * const offsets =
-                do_tiling ? bins.offsetsPtr() : nullptr;
-            int const num_particles =
-                do_tiling ? offsets[itile+1]-offsets[itile] : pti.numParticles();
+        {
+            int const num_particles = pti.numParticles();
+#ifdef AMREX_USE_OMP
+            int const idx_begin = (num_particles * omp_get_thread_num()) / omp_get_num_threads();
+            int const idx_end = (num_particles * (omp_get_thread_num()+1)) / omp_get_num_threads();
+#else
+            int constexpr idx_begin = 0;
+            int const idx_end = num_particles;
+#endif
+
             amrex::ParallelFor(
                 amrex::TypeList<amrex::CompileTimeOptions<0, 1, 2, 3>>{},
                 {Hipace::m_depos_order_xy},
-                num_particles,
+                idx_end - idx_begin,
                 [=] AMREX_GPU_DEVICE (long idx, auto depos_order) {
-                    const int ip = do_tiling ? indices[offsets[itile]+idx] : idx;
+                    const int ip = idx + idx_begin;
                     // only push plasma particles on their according MR level
                     if (setPositionEnforceBC.m_structs[ip].id() < 0 ||
                         setPositionEnforceBC.m_structs[ip].cpu() != lev) return;


### PR DESCRIPTION
Tiling isn't necessary here, removing it gives a 5% performance improvement for 8 threads and 512^2 cells.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
