### PR TITLE
Reset plasma id at every call of Init

### DIFF
--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -55,6 +55,9 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
         y_offset = -0.5_rt;
     }
 
+    // Reset first ID to 1 as we create a fresh plasma each time we call this function
+    ParticleType::NextID(1);
+
     for(amrex::MFIter mfi = MakeMFIter(lev, DfltMfi); mfi.isValid(); ++mfi)
     {
         const amrex::Box& tile_box  = mfi.tilebox(box_nodal, box_grow);


### PR DESCRIPTION
This fixes an issue that large simulations (counting `nx*ny*nt`) run out of id. Another option would be to always use `amrex::Long` in this function for ID handling. Preliminary tests seem to show that both fix the problem (we'll know when Jupyter @ JSC is back). This one is a bit simpler.