### PR TITLE
[mini] assert for normalized units when total charge is specified

### DIFF
--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -133,6 +133,9 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         getWithParser(pp, "num_particles", m_num_particles);
         bool charge_is_specified = queryWithParser(pp, "total_charge", m_total_charge);
         bool peak_density_is_specified = queryWithParser(pp, "density", m_density);
+        if (charge_is_specified) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( Hipace::m_normalized_units == 0,
+            "The option 'beam.total_charge' is only valid in SI units."
+            "Please set 'hipace.normalized_units = 0'");
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( charge_is_specified + peak_density_is_specified == 1,
             "Please specify exlusively either total_charge or density of the beam");
         queryWithParser(pp, "do_symmetrize", m_do_symmetrize);

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -135,7 +135,8 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         bool peak_density_is_specified = queryWithParser(pp, "density", m_density);
         if (charge_is_specified) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( Hipace::m_normalized_units == 0,
             "The option 'beam.total_charge' is only valid in SI units."
-            "Please set 'hipace.normalized_units = 0'");
+            "Please either specify the peak density with '<beam name>.density', "
+            "or set 'hipace.normalized_units = 0' to run in SI units, and update the input file accordingly.");
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( charge_is_specified + peak_density_is_specified == 1,
             "Please specify exlusively either total_charge or density of the beam");
         queryWithParser(pp, "do_symmetrize", m_do_symmetrize);


### PR DESCRIPTION
The option `beam.total_charge` does not make sense in normalized units, hence we assert for it now.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
