### PR TITLE
MR with SALAME and PC

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -163,13 +163,6 @@ public:
     void ResetLaser ();
 
     /**
-       \brief Calls FillBoundary on charges and currents on WhichSlice::This
-     *
-     * \param[in] lev MR level
-     */
-    void FillBoundaryChargeCurrents (int lev);
-
-    /**
        \brief Returns true on the head rank, otherwise false.
      */
     static bool HeadRank ()

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -138,29 +138,6 @@ public:
      */
     void SolveOneSlice (int islice, const int islice_local, int step);
 
-    /** \brief Full evolve on 1 subslice with explicit solver
-     *
-     * The algorithm used was derived in [Wang, T. et al. arXiv preprint arXiv:2012.00881 (2020)],
-     * it is implemented in the WAND-PIC quasistatic PIC code.
-     *
-     * \param[in] lev MR level
-     * \param[in] step current time step
-     * \param[in] islice longitudinal slice
-     * \param[in] islice_local local index of the slice
-     */
-    void ExplicitSolveOneSubSlice (const int lev, const int step,
-                                   const int islice, const int islice_local);
-
-    /** \brief Full evolve on 1 subslice with predictor-corrector solver
-     *
-     * \param[in] lev MR level
-     * \param[in] step current time step
-     * \param[in] islice longitudinal slice
-     * \param[in] islice_local local index of the slice
-     */
-    void PredictorCorrectorSolveOneSubSlice (const int lev, const int step,
-                                             const int islice, const int islice_local);
-
     /**
      * \brief Initialize Sx and Sy with the beam contributions
      *

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -377,11 +377,11 @@ private:
      *
      * \param[in] islice longitudinal slice
      * \param[in] islice_local local index of the slice
-     * \param[in] lev current level
+     * \param[in] current_N_level number of MR levels active on the current slice
      * \param[in] step current time step
      */
     void PredictorCorrectorLoopToSolveBxBy (const int islice, const int islice_local,
-                                            const int lev, const int step);
+                                            const int current_N_level, const int step);
 
     int leftmostBoxWithParticles () const;
 };

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -160,9 +160,6 @@ Hipace::Hipace () :
 
     MakeGeometry();
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_N_level == 1 || !m_multi_beam.AnySpeciesSalame(),
-        "Cannot use SALAME algorithm with mesh refinement");
-
     m_use_laser = m_multi_laser.m_use_laser;
 }
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -542,14 +542,14 @@ Hipace::SolveOneSlice (int islice, const int islice_local, int step)
         m_grid_current.DepositCurrentSlice(m_fields, m_3D_geom[lev], lev, islice);
     }
 
-    // Psi Ez Bz solve
+    // Psi ExmBy EypBx Ez Bz solve
     m_fields.SolvePoissonPsiExmByEypBxEzBz(m_3D_geom, current_N_level);
 
     // Bx By solve
     if (m_explicit) {
         for (int lev=0; lev<current_N_level; ++lev) {
             // The algorithm used was derived in
-            // [Wang, T. et al. arXiv preprint arXiv:2012.00881 (2020)],
+            // [Wang, T. et al. Phys. Rev. Accel. Beams 25, 104603 (2022)],
             // it is implemented in the WAND-PIC quasistatic PIC code.
 
             // Set Sx and Sy to beam contribution

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -575,7 +575,7 @@ Hipace::SolveOneSlice (int islice, const int islice_local, int step)
         }
     } else {
         // Solves Bx and By in the current slice and modifies the force terms of the plasma particles
-        PredictorCorrectorLoopToSolveBxBy(islice, islice_local, 0, step);
+        PredictorCorrectorLoopToSolveBxBy(islice, islice_local, current_N_level, step);
     }
 
     if (m_multi_beam.isSalameNow(step, islice_local)) {

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -25,7 +25,7 @@ class MultiLaser;
 
 /** \brief describes which slice with respect to the currently calculated is used */
 struct WhichSlice {
-    enum slice { Next=0, This, Previous1, Previous2, RhomJzIons, Salame, N };
+    enum slice { Next=0, This, Previous, RhomJzIons, Salame, PCIter, PCPrevIter, N };
 };
 
 struct assert_map : std::map<std::string, int> {
@@ -154,6 +154,14 @@ public:
                 const amrex::Gpu::DeviceVector<int>& diag_comps_vect, const int ncomp,
                 bool do_laser, MultiLaser& multi_laser);
 
+     /** \brief Initialize all required fields to zero and interpolate from lev-1 to lev if needed
+     *
+     * \param[in] lev the MR level
+     * \param[in] islice current slice index
+     * \param[in] geom 3D Geometry
+     */
+    void InitializeSlices (int lev, int islice, const amrex::Vector<amrex::Geometry>& geom);
+
     /** \brief Shift slices by 1 element: slices (1,2) are then stored in (2,3).
      *
      * When looping over slices from head to tail, the same slice MultiFabs are used
@@ -173,34 +181,37 @@ public:
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
+     * \param[in] which_slice slice of the field
      * \param[in] component which can be Psi, Ez, By, Bx ...
      * \param[in,out] staging_area Target MultiFab where the boundary condition is applied
      */
     void SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                               std::string component, amrex::MultiFab&& staging_area);
+                               const int which_slice, std::string component,
+                               amrex::MultiFab&& staging_area);
 
     /** \brief Interpolate values from coarse grid (lev-1) to the boundary of the fine grid (lev).
      * This may include ghost cells.
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
+     * \param[in] which_slice slice of the field to interpolate
      * \param[in] component which can be Psi or rho etc.
      * \param[in] outer_edge start writing interpolated values at domain + outer_edge
      * \param[in] inner_edge stop writing interpolated values at domain + inner_edge
      */
     void LevelUpBoundary (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                          std::string component, const amrex::IntVect outer_edge,
-                          const amrex::IntVect inner_edge);
+                          const int which_slice, const std::string& component,
+                          const amrex::IntVect outer_edge, const amrex::IntVect inner_edge);
 
     /** \brief Interpolate the full field from the coarse grid (lev-1) to the fine grid (lev).
      *
      * \param[in] geom Geometry
      * \param[in] lev current level
-     * \param[in] component which can be jx_beam or jy_beam etc.
      * \param[in] which_slice slice of the field to interpolate
+     * \param[in] component which can be jx_beam or jy_beam etc.
      */
     void LevelUp (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                  const int which_slice, const std::string component);
+                  const int which_slice, const std::string& component);
 
     /** \brief Compute ExmBy and EypBx on the slice container from J by solving a Poisson equation
      * ExmBy and EypBx are solved in the same function because both rely on Psi.
@@ -220,20 +231,20 @@ public:
                          const int which_slice = WhichSlice::This);
     /** \brief Compute Bx on the slice container from J by solving a Poisson equation
      *
-     * \param[in,out] Bx_iter Bx field during current iteration of the predictor-corrector loop
      * \param[in] geom Geometry
      * \param[in] lev current level
+     * \param[in] which_slice slice to put the result into
      */
-    void SolvePoissonBx (amrex::MultiFab& Bx_iter, amrex::Vector<amrex::Geometry> const& geom,
-                         const int lev);
+    void SolvePoissonBx (amrex::Vector<amrex::Geometry> const& geom, const int lev,
+                         const int which_slice);
     /** \brief Compute By on the slice container from J by solving a Poisson equation
      *
-     * \param[in,out] By_iter By field during current iteration of the predictor-corrector loop
      * \param[in] geom Geometry
      * \param[in] lev current level
+     * \param[in] which_slice slice to put the result into
      */
-    void SolvePoissonBy (amrex::MultiFab& By_iter, amrex::Vector<amrex::Geometry> const& geom,
-                         const int lev);
+    void SolvePoissonBy (amrex::Vector<amrex::Geometry> const& geom, const int lev,
+                          const int which_slice);
     /** \brief Compute Bz on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry
@@ -254,41 +265,25 @@ public:
      * of it and shifts the current to the previous iteration afterwards.
      * This modifies component Bx or By of slice 1 in m_fields.m_slices
      *
-     * \param[in] B_iter B field during current iteration of the predictor-corrector loop
-     * \param[in,out] B_prev_iter B field during previous iteration of the pred.-cor. loop
-     * \param[in] field_comp field component to be mixed (usually Bx or By)
      * \param[in] relative_Bfield_error relative B field error used to determine the mixing factor
      * \param[in] relative_Bfield_error_prev_iter relative B field error of the previous iteration
      * \param[in] predcorr_B_mixing_factor mixing factor for B fields in predcorr loop
      * \param[in] lev current level
      */
-    void MixAndShiftBfields (const amrex::MultiFab& B_iter, amrex::MultiFab& B_prev_iter,
-                             const int field_comp, const amrex::Real relative_Bfield_error,
+    void MixAndShiftBfields (const amrex::Real relative_Bfield_error,
                              const amrex::Real relative_Bfield_error_prev_iter,
                              const amrex::Real predcorr_B_mixing_factor, const int lev);
 
     /** \brief Function to calculate the relative B field error
      * used in the predictor corrector loop
      *
-     * \param[in] Bx Bx field (input as MutliFab)
-     * \param[in] By By field (input as MutliFab)
-     * \param[in] Bx_iter Bx field from the previous iteration (input as MutliFab)
-     * \param[in] By_iter By field from the previous iteration (input as MutliFab)
-     * \param[in] Bx_comp component of the Bx field in the MultiFab
-     *            (usually either Bx or 0)
-     * \param[in] By_comp component of the By field in the MultiFab
-     *            (usually either By or 0)
-     * \param[in] Bx_iter_comp component of the Bx field of the previous iteration in the MultiFab
-     *            (usually either Bx or 0)
-     * \param[in] By_iter_comp component of the By field of the previous iteration in the MultiFab
-     *            (usually either By or 0)
+     * \param[in] which_slice slice of Bx and By field
+     * \param[in] which_slice_iter slice of Bx and By field from the previous iteration
      * \param[in] geom Geometry of the problem
+     * \param[in] current_N_level number of MR levels active on the current slice
      */
-    amrex::Real ComputeRelBFieldError (const amrex::MultiFab& Bx, const amrex::MultiFab& By,
-                                       const amrex::MultiFab& Bx_iter,
-                                       const amrex::MultiFab& By_iter, const int Bx_comp,
-                                       const int By_comp, const int Bx_iter_comp,
-                                       const int By_iter_comp, const amrex::Geometry& geom);
+    amrex::Real ComputeRelBFieldError (const int which_slice, const int which_slice_iter,
+        const amrex::Vector<amrex::Geometry>& geom, const int current_N_level);
 
     /** \brief set all selected fields to a value
      *

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -217,40 +217,26 @@ public:
      * ExmBy and EypBx are solved in the same function because both rely on Psi.
      *
      * \param[in] geom Geometry
-     * \param[in] lev current level
+     * \param[in] current_N_level number of MR levels active on the current slice
      */
-    void SolvePoissonExmByAndEypBx (amrex::Vector<amrex::Geometry> const& geom,
-                                    const int lev);
+    void SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geom,
+                                        const int current_N_level);
     /** \brief Compute Ez on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry
-     * \param[in] lev current level
+     * \param[in] current_N_level number of MR levels active on the current slice
      * \param[in] which_slice defines if this or the salame slice is handled
      */
-    void SolvePoissonEz (amrex::Vector<amrex::Geometry> const& geom, const int lev,
+    void SolvePoissonEz (amrex::Vector<amrex::Geometry> const& geom, const int current_N_level,
                          const int which_slice = WhichSlice::This);
     /** \brief Compute Bx on the slice container from J by solving a Poisson equation
      *
      * \param[in] geom Geometry
-     * \param[in] lev current level
+     * \param[in] current_N_level number of MR levels active on the current slice
      * \param[in] which_slice slice to put the result into
      */
-    void SolvePoissonBx (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                         const int which_slice);
-    /** \brief Compute By on the slice container from J by solving a Poisson equation
-     *
-     * \param[in] geom Geometry
-     * \param[in] lev current level
-     * \param[in] which_slice slice to put the result into
-     */
-    void SolvePoissonBy (amrex::Vector<amrex::Geometry> const& geom, const int lev,
-                          const int which_slice);
-    /** \brief Compute Bz on the slice container from J by solving a Poisson equation
-     *
-     * \param[in] geom Geometry
-     * \param[in] lev current level
-     */
-    void SolvePoissonBz (amrex::Vector<amrex::Geometry> const& geom, const int lev);
+    void SolvePoissonBxBy (amrex::Vector<amrex::Geometry> const& geom, const int current_N_level,
+                           const int which_slice);
     /** \brief Sets the initial guess of the B field from the two previous slices
      *
      * This modifies component Bx or By of slice 1 in m_fields.m_slices

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -213,15 +213,17 @@ public:
     void LevelUp (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                   const int which_slice, const std::string& component);
 
-    /** \brief Compute ExmBy and EypBx on the slice container from J by solving a Poisson equation
-     * ExmBy and EypBx are solved in the same function because both rely on Psi.
+    /** \brief Compute Psi, ExmBy, EypBx, Ez and Bz on the slice container from J by solving three
+     * poisson equations. ExmBy and EypBx computed from grad(-Psi).
+     * This function does all the necessary boundary interpolation between MR levels
      *
      * \param[in] geom Geometry
      * \param[in] current_N_level number of MR levels active on the current slice
      */
     void SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geom,
                                         const int current_N_level);
-    /** \brief Compute Ez on the slice container from J by solving a Poisson equation
+    /** \brief Compute Ez on the slice container from J by solving a Poisson equation.
+     * This function does all the necessary boundary interpolation between MR levels
      *
      * \param[in] geom Geometry
      * \param[in] current_N_level number of MR levels active on the current slice
@@ -229,7 +231,8 @@ public:
      */
     void SolvePoissonEz (amrex::Vector<amrex::Geometry> const& geom, const int current_N_level,
                          const int which_slice = WhichSlice::This);
-    /** \brief Compute Bx on the slice container from J by solving a Poisson equation
+    /** \brief Compute Bx and By on the slice container from J by solving two Poisson equations.
+     * This function does all the necessary boundary interpolation between MR levels
      *
      * \param[in] geom Geometry
      * \param[in] current_N_level number of MR levels active on the current slice

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -738,7 +738,6 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
     }
 }
 
-
 void
 Fields::LevelUpBoundary (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                          const int which_slice, const std::string& component,
@@ -784,7 +783,6 @@ Fields::LevelUpBoundary (amrex::Vector<amrex::Geometry> const& geom, const int l
     }
 }
 
-
 void
 Fields::LevelUp (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                  const int which_slice, const std::string& component)
@@ -817,7 +815,6 @@ Fields::LevelUp (amrex::Vector<amrex::Geometry> const& geom, const int lev,
             });
     }
 }
-
 
 void
 Fields::SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geom,
@@ -922,7 +919,6 @@ Fields::SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geo
         }
     }
 }
-
 
 void
 Fields::SolvePoissonEz (amrex::Vector<amrex::Geometry> const& geom,

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -519,7 +519,7 @@ Fields::InitializeSlices (int lev, int islice, const amrex::Vector<amrex::Geomet
             duplicate(lev, WhichSlice::This, {"jx"     , "jy"     },
                            WhichSlice::This, {"jx_beam", "jy_beam"});
         }
-        // Set all quantities to 0 except:
+        // Set all quantities on WhichSlice::This to 0 except:
         // Bx and By: the previous slice serves as initial guess.
         // jx, jy, jx_beam and jy_beam on WhichSlice::This:
         // shifted from the previous WhichSlice::Next

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -36,11 +36,12 @@ public:
      * \param[in] do_beam_jz_deposition whether the beam deposits Jz
      * \param[in] do_beam_rhomjz_deposition whether the beam deposits rhomjz
      * \param[in] which_slice defines if this or the next slice is handled
+     * \param[in] only_highest if the particles deposit only on their highest MR level
      */
     void DepositCurrentSlice (
         Fields& fields, amrex::Vector<amrex::Geometry> const& geom, const int lev, const int step,
         int islice, const bool do_beam_jx_jy_deposition, const bool do_beam_jz_deposition,
-        const bool do_beam_rhomjz_deposition, const int which_slice);
+        const bool do_beam_rhomjz_deposition, const int which_slice, const bool only_highest=false);
 
     /** Loop over all beam species and build and return the indices of particles sorted per slice
      * \param[in] ibox box index

--- a/src/particles/beam/MultiBeam.cpp
+++ b/src/particles/beam/MultiBeam.cpp
@@ -41,7 +41,7 @@ void
 MultiBeam::DepositCurrentSlice (
     Fields& fields, amrex::Vector<amrex::Geometry> const& geom, const int lev, const int step,
     int islice, const bool do_beam_jx_jy_deposition, const bool do_beam_jz_deposition,
-    const bool do_beam_rhomjz_deposition, const int which_slice)
+    const bool do_beam_rhomjz_deposition, const int which_slice, const bool only_highest)
 
 {
     for (int i=0; i<m_nbeams; i++) {
@@ -52,7 +52,7 @@ MultiBeam::DepositCurrentSlice (
                                   do_beam_jx_jy_deposition && !is_salame,
                                   do_beam_jz_deposition,
                                   do_beam_rhomjz_deposition && !is_salame,
-                                  which_slice, nghost);
+                                  which_slice, nghost, only_highest);
         }
     }
 }

--- a/src/particles/deposition/BeamDepositCurrent.H
+++ b/src/particles/deposition/BeamDepositCurrent.H
@@ -27,6 +27,7 @@
  * \param[in] nghost number of ghost particles, all at the end of the particle array.
  *            Use for depositing transverse currents in the Next slice when processing
  *            islice = 0.
+ * \param[in] only_highest if the particles deposit only on their highest MR level
  */
 void
 DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
@@ -34,7 +35,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
                      const bool do_beam_jx_jy_deposition,
                      const bool do_beam_jz_deposition,
                      const bool do_beam_rhomjz_deposition,
-                     const int which_slice, int nghost);
+                     const int which_slice, int nghost, const bool only_highest=false);
 
 
 #endif //  BEAMDEPOSITCURRENT_H_

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -23,7 +23,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
                      const bool do_beam_jx_jy_deposition,
                      const bool do_beam_jz_deposition,
                      const bool do_beam_rhomjz_deposition,
-                     const int which_slice, int nghost)
+                     const int which_slice, int nghost, const bool only_highest)
 {
     HIPACE_PROFILE("DepositCurrentSlice_BeamParticleContainer()");
 
@@ -130,7 +130,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
 
             // Skip invalid particles and ghost particles not in the last slice
             // beam deposits only up to its finest level
-            if (ptd.id(ip) < 0 || (ptd.cpu(ip) < lev)) return;
+            if (ptd.id(ip) < 0 || (only_highest ? (ptd.cpu(ip)!=lev) : (ptd.cpu(ip)<lev))) return;
 
             // --- Get particle quantities
             const amrex::Real ux = ptd.rdata(BeamIdx::ux)[ip];

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -140,8 +140,10 @@ public:
     /** \brief Store the finest level of every plasma particle in the cpu() attribute.
      * \param[in] current_N_level number of MR levels active on the current slice
      * \param[in] geom3D Geometry object for the whole domain
+     * \param[in] to_prev if particles should be tagged to x_prev and y_prev
      */
-    void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D);
+    void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D,
+                     const bool to_prev=false);
 
     int m_sort_bin_size {32}; /**< Tile size to sort plasma particles */
 

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -190,9 +190,10 @@ MultiPlasma::ReorderParticles (const int islice)
 }
 
 void
-MultiPlasma::TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D)
+MultiPlasma::TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D,
+                         const bool to_prev)
 {
     for (auto& plasma : m_all_plasmas) {
-        plasma.TagByLevel(current_N_level, geom3D);
+        plasma.TagByLevel(current_N_level, geom3D, to_prev);
     }
 }

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -116,8 +116,10 @@ public:
     /** \brief Store the finest level of every plasma particle in the cpu() attribute.
      * \param[in] current_N_level number of MR levels active on the current slice
      * \param[in] geom3D Geometry object for the whole domain
+     * \param[in] to_prev if particles should be tagged to x_prev and y_prev
      */
-    void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D);
+    void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D,
+                     const bool to_prev=false);
 
     /** returns u_mean of the plasma distribution */
     amrex::RealVect GetUMean () const {return m_u_mean;}

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -185,15 +185,18 @@ PlasmaParticleContainer::UpdateDensityFunction ()
 
 void
 PlasmaParticleContainer::TagByLevel (const int current_N_level,
-                                     amrex::Vector<amrex::Geometry> const& geom3D)
+                                     amrex::Vector<amrex::Geometry> const& geom3D,
+                                     const bool to_prev)
 {
     HIPACE_PROFILE("PlasmaParticleContainer::TagByLevel()");
 
     for (PlasmaParticleIterator pti(*this); pti.isValid(); ++pti)
     {
         auto& soa = pti.GetStructOfArrays();
-        const amrex::Real * const AMREX_RESTRICT pos_x = soa.GetRealData(PlasmaIdx::x).data();
-        const amrex::Real * const AMREX_RESTRICT pos_y = soa.GetRealData(PlasmaIdx::y).data();
+        const amrex::Real * const AMREX_RESTRICT pos_x = to_prev ?
+            soa.GetRealData(PlasmaIdx::x_prev).data() : soa.GetRealData(PlasmaIdx::x).data();
+        const amrex::Real * const AMREX_RESTRICT pos_y = to_prev ?
+            soa.GetRealData(PlasmaIdx::y_prev).data() : soa.GetRealData(PlasmaIdx::y).data();
         int * const AMREX_RESTRICT cpup = soa.GetIntData(PlasmaIdx::cpu).data();
 
         const int lev1_idx = std::min(1, current_N_level-1);

--- a/src/salame/Salame.H
+++ b/src/salame/Salame.H
@@ -17,14 +17,14 @@
  * \param[in] do_advance if the SALAME-only field should be computed exactly with plasma particles
  * \param[in,out] last_islice the slice index of the previous slice with SALAME
  * \param[in,out] overloaded if the SALAME beam was overloaded in the last slice
- * \param[in] lev MR level
+ * \param[in] current_N_level number of MR levels active on the current slice
  * \param[in] step time step of simulation
  * \param[in] islice slice index of the whole domain
  * \param[in] islice_local slice index of the local box
  */
 void
 SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last_islice,
-              bool& overloaded, const int lev, const int step, const int islice,
+              bool& overloaded, const int current_N_level, const int step, const int islice,
               const int islice_local);
 
 /** Initialize Sx and Sy with the contribution from the SALAME beam
@@ -51,12 +51,12 @@ SalameOnlyAdvancePlasma (Hipace* hipace, const int lev);
 /** Calculate the new weighting factor of the SALAME beam using the difference in E fields.
  * The average is weighted using the SALAME beam current.
  * \param[in] hipace pointer to Hipace instance
- * \param[in] lev MR level
+ * \param[in] current_N_level number of MR levels active on the current slice
  * \param[in] islice slice index of the whole domain
  * \return new beam weighting factor and new total SALAME beam current on this slice
  */
 std::pair<amrex::Real, amrex::Real>
-SalameGetW (Hipace* hipace, const int lev, const int islice);
+SalameGetW (Hipace* hipace, const int current_N_level, const int islice);
 
 /** Multiply SALAME beam weight on this slice with W
  * \param[in] W weight multiplier

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -127,7 +127,8 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
 
         for (int lev=0; lev<current_N_level; ++lev) {
             hipace->m_fields.setVal(0., lev, WhichSlice::Salame, "jz_beam");
-            // deposit SALAME beam jz only on the highest level for SalameGetW
+            // deposit SALAME beam jz only on the highest level of each particle for SalameGetW,
+            // since the most accurate field (on the highest level) is supposed to be flattened
             hipace->m_multi_beam.DepositCurrentSlice(hipace->m_fields, hipace->m_3D_geom, lev, step,
                 islice_local, false, true, false, WhichSlice::Salame, true);
         }
@@ -358,6 +359,7 @@ SalameGetW (Hipace* hipace, const int current_N_level, const int islice)
             const int Ez_no_salame = Comps[WhichSlice::Salame]["Ez_no_salame"];
             const int jz = Comps[WhichSlice::Salame]["jz_beam"];
 
+            // factor to account for different cell size with MR
             const amrex::Real factor =
                 hipace->m_3D_geom[lev].CellSize(0) * hipace->m_3D_geom[lev].CellSize(1)
                 / (hipace->m_3D_geom[0].CellSize(0) * hipace->m_3D_geom[0].CellSize(1));

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -65,18 +65,9 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
             // use an initial guess of zero for Bx and By in MG solver to reduce relative error
             hipace->m_fields.setVal(0., lev, WhichSlice::Salame,
                 "Ez", "jz_beam", "Sy", "Sx", "Bx", "By");
-
-            // interpolate jx and jy to lev from lev-1 in the domain edges and
-            // also inside ghost cells to account for x and y derivative
-            hipace->m_fields.LevelUpBoundary(hipace->m_3D_geom, lev, WhichSlice::Salame, "jx",
-                hipace->m_fields.m_slices_nguards, -hipace->m_fields.m_slices_nguards);
-            hipace->m_fields.LevelUpBoundary(hipace->m_3D_geom, lev, WhichSlice::Salame, "jy",
-                hipace->m_fields.m_slices_nguards, -hipace->m_fields.m_slices_nguards);
         }
 
-        for (int lev=0; lev<current_N_level; ++lev) {
-            hipace->m_fields.SolvePoissonEz(hipace->m_3D_geom, lev, WhichSlice::Salame);
-        }
+        hipace->m_fields.SolvePoissonEz(hipace->m_3D_geom, current_N_level, WhichSlice::Salame);
 
         for (int lev=0; lev<current_N_level; ++lev) {
             hipace->m_fields.duplicate(lev, WhichSlice::Salame, {"Ez_no_salame"},
@@ -129,18 +120,7 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
             }
         }
 
-        for (int lev=0; lev<current_N_level; ++lev) {
-            // interpolate jx and jy to lev from lev-1 in the domain edges and
-            // also inside ghost cells to account for x and y derivative
-            hipace->m_fields.LevelUpBoundary(hipace->m_3D_geom, lev, WhichSlice::Salame, "jx",
-                hipace->m_fields.m_slices_nguards, -hipace->m_fields.m_slices_nguards);
-            hipace->m_fields.LevelUpBoundary(hipace->m_3D_geom, lev, WhichSlice::Salame, "jy",
-                hipace->m_fields.m_slices_nguards, -hipace->m_fields.m_slices_nguards);
-        }
-
-        for (int lev=0; lev<current_N_level; ++lev) {
-            hipace->m_fields.SolvePoissonEz(hipace->m_3D_geom, lev, WhichSlice::Salame);
-        }
+        hipace->m_fields.SolvePoissonEz(hipace->m_3D_geom, current_N_level, WhichSlice::Salame);
 
         // STEP 3: find ideal weighting factor of the SALAME beam using the computed Ez fields,
         // and update the beam with it

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -337,6 +337,9 @@ SalameGetW (Hipace* hipace, const int current_N_level, const int islice)
 
     for (int lev=0; lev<current_N_level; ++lev) {
 
+        hipace->m_fields.LevelUpBoundary(hipace->m_3D_geom, lev, WhichSlice::Salame, "jz_beam",
+            hipace->m_fields.m_slices_nguards, -hipace->m_fields.m_slices_nguards);
+
         amrex::MultiFab& slicemf = hipace->m_fields.getSlices(lev);
 
         for ( amrex::MFIter mfi(slicemf, DfltMfiTlng); mfi.isValid(); ++mfi ){


### PR DESCRIPTION
This PR makes mash refinement compatible with the SALAME algorithm and the predictor-corrector solver, however not both at the same time. For this a few key functions had to be moved outside of the loop over MR levels, manly `SalameGetW` and `ComputeRelBFieldError`. To accommodate that the `SolveOneSlice` functions were restructured to have more, smaller loops over levels. At first it was very confusing to keep track of which function was responsible to interpolate various fields between MR boundaries, so I moved everything into the field solving functions that were combined to avoid double interpolating a field. Some FillBoundary calls were left elsewhere to not change results.


PC+MR test level 2:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/cd153233-c93d-4e8e-b2b7-25875208a3be)
Explicit+MR reference:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/ed72aeb9-3f02-4112-87a4-028cc02ce738)


SALAME+MR test (no witness vs witness+SALAME):
![image](https://github.com/Hi-PACE/hipace/assets/64009254/16b78a9d-f1a4-4257-91a8-a0a2ebe03fc6)

positron SALAME+MR:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/a9deb1d7-9bc4-4bc9-8fca-6422003f4911)


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
