### PR TITLE
Minor improvements for collision module.

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -409,7 +409,7 @@ When both are specified, the per-species value is used.
 Binary collisions for plasma species
 ------------------------------------
 
-WARNING: this module is in development. Currently only supports electron-electron collisions.
+WARNING: this module is in development.
 
 HiPACE++ proposes an implementation of [Perez et al., Phys. Plasmas 19, 083104 (2012)], inherited from WarpX, between plasma species.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -357,40 +357,6 @@ When both are specified, the per-species value is used.
     the specific ionization energy of each state.
     Options are: ``electron``, ``positron``, ``H``, ``D``, ``T``, ``He``, ``Li``, ``Be``, ``B``, ….
 
-* ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``-1``)
-    Period of in-situ diagnostics, for computing the main per-slice plasma quantities
-    (energy, temperature, etc.). This works in the same way as the beam insitu diagnostics.
-    For this the following quantities are calculated per slice and stored:
-    ``sum(w), [x], [x^2], [y], [y^2], [ux], [ux^2], [uy], [uy^2], [uz], [uz^2], [ga], [ga^2], np``
-    where "[]" stands for averaging over all particles in the current slice,
-    "w" stands for weight, "ux" is the momentum in the x direction, "ga" is the Lorentz factor.
-    Averages and totals over all slices are also provided for convenience under the
-    respective ``average`` and ``total`` subcategories.
-
-    Additionally, some metadata is also available:
-    ``time, step, n_slices, charge, mass, z_lo, z_hi, normalized_density_factor``.
-    ``time`` and ``step`` refers to the physical time of the simulation and step number of the
-    current time step.
-    ``n_slices`` equal to the number of slices in the zeta direction.
-    ``charge`` and ``mass`` relate to a single plasma particle and are for example equal to the
-    electron charge and mass.
-    ``z_lo`` and ``z_hi`` are the lower and upper bounds of the z-axis of the simulation domain
-    specified in the input file and can be used to generate a z/zeta-axis for plotting.
-    ``normalized_density_factor`` is equal to ``dx * dy * dz`` in normalized units and 1 in
-    SI units. It can be used to convert ``sum(w)``, which specifies the beam density in normalized
-    units and beam weight an SI units, to the beam weight in both unit systems.
-
-    The data is written to a file at ``<insitu_file_prefix>/reduced_<beam name>.<MPI rank number>.txt``.
-    The in-situ diagnostics file format consists of a header part in ASCII containing a JSON object.
-    When this is parsed into Python it can be converted to a NumPy structured datatype.
-    The rest of the file, following immediately after the closing }, is in binary format and
-    contains all of the in-situ diagnostic along with some meta data. This part can be read using the
-    structured datatype of the first section.
-    Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this format.
-
-* ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"plasma_diags/insitu"``)
-    Path of the plasma in-situ output.
-
 * ``<plasma name>.can_ionize`` (`bool`) optional (default `0`)
     Whether this plasma can ionize. Can also be set to 1 by specifying ``<plasma name>.ionization_product``.
 
@@ -756,9 +722,16 @@ Field diagnostics
 In-situ diagnostics
 ^^^^^^^^^^^^^^^^^^^
 
+<<<<<<< HEAD
 Besides the standard diagnostics, fast in-situ diagnostics are available. They are most useful when beams with large numbers of particles are used, as the important moments can be calculated in-situ (during the simulation) to largely reduce the simulation's analysis.
 In-situ diagnostics compute slice quantities (1 number per quantity per longitudinal cell).
 For particle beams, they can be used to calculate the main characterizing beam parameters (width, energy spread, emittance, etc.), from which most common beam parameters (e.g. slice and projected emittance, etc.) can be computed. Additionally, the plasma particle properties (e.g, the temperature) can be calculated.
+=======
+Besides the standard diagnostics, fast in-situ diagnostics are available. They are most useful when beams with a large number of particles is used, because then the important moments can be calculated by GPU and significantly reduce the post-analysis of the simulation.
+For particle beams, they can be used to calculate the main characterizing beam parameters (width, energy spread, emittance, etc.). Additionally, the plasma particle properties (e.g, the temperature) can be calculated.
+
+The in-situ quantities are calculated per slice and together with the weights per slice, all important quantities can be calculated.
+>>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 For particle beams, the following quantities are calculated per slice and stored:
 ``sum(w), [x], [x^2], [y], [y^2], [z], [z^2], [ux], [ux^2], [uy], [uy^2], [uz], [uz^2], [x*ux], [y*uy], [z*uz], [ga], [ga^2], np``.
@@ -773,6 +746,7 @@ Additionally, some metadata is also available:
 ``time, step, n_slices, charge, mass, z_lo, z_hi, normalized_density_factor``.
 ``time`` and ``step`` refers to the physical time of the simulation and step number of the
 current timestep.
+<<<<<<< HEAD
 ``n_slices`` is the number of slices in the zeta direction.
 ``charge`` and ``mass`` relate to a single particle and are for example equal to the
 electron charge and mass.
@@ -781,10 +755,21 @@ specified in the input file and can be used to generate a z/zeta-axis for plotti
 ``normalized_density_factor`` is equal to ``dx * dy * dz`` in normalized units and 1 in
 SI units. It can be used to convert ``sum(w)``, which specifies the particle density in normalized
 units and particle weight in SI units, to the particle weight in both unit systems.
+=======
+``n_slices`` equal to the number of slices in the zeta direction.
+``charge`` and ``mass`` relate to a single particle and are for example equal to the
+electron charge and mass.
+``z_lo`` and ``z_hi`` are the lower and upper bounds of the z-axis of the simulation domain
+specified in the input file and can be used to generate a z/zeta-axis for plotting.
+``normalized_density_factor`` is equal to ``dx * dy * dz`` in normalized units and 1 in
+SI units. It can be used to convert ``sum(w)``, which specifies the beam density in normalized
+units and beam weight an SI units, to the beam weight in both unit systems.
+>>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 The data is written to a file at ``<insitu_file_prefix>/reduced_<beam/plasma name>.<MPI rank number>.txt``.
 The in-situ diagnostics file format consists of a header part in ASCII containing a JSON object.
 When this is parsed into Python it can be converted to a NumPy structured datatype.
+<<<<<<< HEAD
 The rest of the file, following immediately after the closing ``}``, is in binary format and
 contains all of the in-situ diagnostics along with some metadata. This part can be read using the
 structured datatype of the first section.
@@ -792,12 +777,26 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 
 * ``<beam name> or beams.insitu_period`` (`int`) optional (default ``0``)
     Period of the beam in-situ diagnostics. `0` means no beam in-situ diagnostics.
+=======
+The rest of the file, following immediately after the closing }, is in binary format and
+contains all of the in-situ diagnostic along with some meta data. This part can be read using the
+structured datatype of the first section.
+Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this format. Functions to calculate the most useful properties are also provided in that file.
+
+* ``<beam name> or beams.insitu_period`` (`int`) optional (default ``-1``)
+    Period of the beam in-situ diagnostics. `-1` means no in-situ diagnostics.
+>>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 * ``<beam name> or beams.insitu_file_prefix`` (`string`) optional (default ``"diags/insitu"``)
     Path of the beam in-situ output. Must not be the same as `hipace.file_prefix`.
 
+<<<<<<< HEAD
 * ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``0``)
     Period of the plasma in-situ diagnostics. `0` means no plasma in-situ diagnostics.
+=======
+* ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``-1``)
+    Period of the plasma in-situ diagnostics. `-1` means no in-situ diagnostics.
+>>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 * ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"plasma_diags/insitu"``)
     Path of the plasma in-situ output. Must not be the same as `hipace.file_prefix`.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -357,6 +357,40 @@ When both are specified, the per-species value is used.
     the specific ionization energy of each state.
     Options are: ``electron``, ``positron``, ``H``, ``D``, ``T``, ``He``, ``Li``, ``Be``, ``B``, ….
 
+* ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``-1``)
+    Period of in-situ diagnostics, for computing the main per-slice plasma quantities
+    (energy, temperature, etc.). This works in the same way as the beam insitu diagnostics.
+    For this the following quantities are calculated per slice and stored:
+    ``sum(w), [x], [x^2], [y], [y^2], [ux], [ux^2], [uy], [uy^2], [uz], [uz^2], [ga], [ga^2], np``
+    where "[]" stands for averaging over all particles in the current slice,
+    "w" stands for weight, "ux" is the momentum in the x direction, "ga" is the Lorentz factor.
+    Averages and totals over all slices are also provided for convenience under the
+    respective ``average`` and ``total`` subcategories.
+
+    Additionally, some metadata is also available:
+    ``time, step, n_slices, charge, mass, z_lo, z_hi, normalized_density_factor``.
+    ``time`` and ``step`` refers to the physical time of the simulation and step number of the
+    current time step.
+    ``n_slices`` equal to the number of slices in the zeta direction.
+    ``charge`` and ``mass`` relate to a single plasma particle and are for example equal to the
+    electron charge and mass.
+    ``z_lo`` and ``z_hi`` are the lower and upper bounds of the z-axis of the simulation domain
+    specified in the input file and can be used to generate a z/zeta-axis for plotting.
+    ``normalized_density_factor`` is equal to ``dx * dy * dz`` in normalized units and 1 in
+    SI units. It can be used to convert ``sum(w)``, which specifies the beam density in normalized
+    units and beam weight an SI units, to the beam weight in both unit systems.
+
+    The data is written to a file at ``<insitu_file_prefix>/reduced_<beam name>.<MPI rank number>.txt``.
+    The in-situ diagnostics file format consists of a header part in ASCII containing a JSON object.
+    When this is parsed into Python it can be converted to a NumPy structured datatype.
+    The rest of the file, following immediately after the closing }, is in binary format and
+    contains all of the in-situ diagnostic along with some meta data. This part can be read using the
+    structured datatype of the first section.
+    Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this format.
+
+* ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"plasma_diags/insitu"``)
+    Path of the plasma in-situ output.
+
 * ``<plasma name>.can_ionize`` (`bool`) optional (default `0`)
     Whether this plasma can ionize. Can also be set to 1 by specifying ``<plasma name>.ionization_product``.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -722,16 +722,9 @@ Field diagnostics
 In-situ diagnostics
 ^^^^^^^^^^^^^^^^^^^
 
-<<<<<<< HEAD
 Besides the standard diagnostics, fast in-situ diagnostics are available. They are most useful when beams with large numbers of particles are used, as the important moments can be calculated in-situ (during the simulation) to largely reduce the simulation's analysis.
 In-situ diagnostics compute slice quantities (1 number per quantity per longitudinal cell).
 For particle beams, they can be used to calculate the main characterizing beam parameters (width, energy spread, emittance, etc.), from which most common beam parameters (e.g. slice and projected emittance, etc.) can be computed. Additionally, the plasma particle properties (e.g, the temperature) can be calculated.
-=======
-Besides the standard diagnostics, fast in-situ diagnostics are available. They are most useful when beams with a large number of particles is used, because then the important moments can be calculated by GPU and significantly reduce the post-analysis of the simulation.
-For particle beams, they can be used to calculate the main characterizing beam parameters (width, energy spread, emittance, etc.). Additionally, the plasma particle properties (e.g, the temperature) can be calculated.
-
-The in-situ quantities are calculated per slice and together with the weights per slice, all important quantities can be calculated.
->>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 For particle beams, the following quantities are calculated per slice and stored:
 ``sum(w), [x], [x^2], [y], [y^2], [z], [z^2], [ux], [ux^2], [uy], [uy^2], [uz], [uz^2], [x*ux], [y*uy], [z*uz], [ga], [ga^2], np``.
@@ -746,7 +739,6 @@ Additionally, some metadata is also available:
 ``time, step, n_slices, charge, mass, z_lo, z_hi, normalized_density_factor``.
 ``time`` and ``step`` refers to the physical time of the simulation and step number of the
 current timestep.
-<<<<<<< HEAD
 ``n_slices`` is the number of slices in the zeta direction.
 ``charge`` and ``mass`` relate to a single particle and are for example equal to the
 electron charge and mass.
@@ -755,21 +747,10 @@ specified in the input file and can be used to generate a z/zeta-axis for plotti
 ``normalized_density_factor`` is equal to ``dx * dy * dz`` in normalized units and 1 in
 SI units. It can be used to convert ``sum(w)``, which specifies the particle density in normalized
 units and particle weight in SI units, to the particle weight in both unit systems.
-=======
-``n_slices`` equal to the number of slices in the zeta direction.
-``charge`` and ``mass`` relate to a single particle and are for example equal to the
-electron charge and mass.
-``z_lo`` and ``z_hi`` are the lower and upper bounds of the z-axis of the simulation domain
-specified in the input file and can be used to generate a z/zeta-axis for plotting.
-``normalized_density_factor`` is equal to ``dx * dy * dz`` in normalized units and 1 in
-SI units. It can be used to convert ``sum(w)``, which specifies the beam density in normalized
-units and beam weight an SI units, to the beam weight in both unit systems.
->>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 The data is written to a file at ``<insitu_file_prefix>/reduced_<beam/plasma name>.<MPI rank number>.txt``.
 The in-situ diagnostics file format consists of a header part in ASCII containing a JSON object.
 When this is parsed into Python it can be converted to a NumPy structured datatype.
-<<<<<<< HEAD
 The rest of the file, following immediately after the closing ``}``, is in binary format and
 contains all of the in-situ diagnostics along with some metadata. This part can be read using the
 structured datatype of the first section.
@@ -777,26 +758,12 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 
 * ``<beam name> or beams.insitu_period`` (`int`) optional (default ``0``)
     Period of the beam in-situ diagnostics. `0` means no beam in-situ diagnostics.
-=======
-The rest of the file, following immediately after the closing }, is in binary format and
-contains all of the in-situ diagnostic along with some meta data. This part can be read using the
-structured datatype of the first section.
-Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this format. Functions to calculate the most useful properties are also provided in that file.
-
-* ``<beam name> or beams.insitu_period`` (`int`) optional (default ``-1``)
-    Period of the beam in-situ diagnostics. `-1` means no in-situ diagnostics.
->>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 * ``<beam name> or beams.insitu_file_prefix`` (`string`) optional (default ``"diags/insitu"``)
     Path of the beam in-situ output. Must not be the same as `hipace.file_prefix`.
 
-<<<<<<< HEAD
 * ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``0``)
     Period of the plasma in-situ diagnostics. `0` means no plasma in-situ diagnostics.
-=======
-* ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``-1``)
-    Period of the plasma in-situ diagnostics. `-1` means no in-situ diagnostics.
->>>>>>> 9fd091219 (improve doc, add assert, add functions to tools)
 
 * ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"plasma_diags/insitu"``)
     Path of the plasma in-situ output. Must not be the same as `hipace.file_prefix`.

--- a/src/particles/collisions/CoulombCollision.cpp
+++ b/src/particles/collisions/CoulombCollision.cpp
@@ -45,6 +45,9 @@ CoulombCollision::doCoulombCollision (
 {
     HIPACE_PROFILE("CoulombCollision::doCoulombCollision()");
     AMREX_ALWAYS_ASSERT(lev == 0);
+
+    if (species1.TotalNumberOfParticles() == 0 || species2.TotalNumberOfParticles() == 0) return;
+
     using namespace amrex::literals;
     const PhysConst cst = get_phys_const();
     bool normalized_units = Hipace::GetInstance().m_normalized_units;
@@ -64,10 +67,12 @@ CoulombCollision::doCoulombCollision (
             amrex::Real* const uy1 = soa1.GetRealData(PlasmaIdx::uy_half_step).data();
             amrex::Real* const psi1 = soa1.GetRealData(PlasmaIdx::psi_half_step).data();
             const amrex::Real* const w1 = soa1.GetRealData(PlasmaIdx::w).data();
+            const int* const ion_lev1 = soa1.GetIntData(PlasmaIdx::ion_lev).data();
             PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
             PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
             amrex::Real q1 = species1.GetCharge();
             amrex::Real m1 = species1.GetMass();
+            const bool can_ionize1 = species1.m_can_ionize;
 
             // volume is used to calculate density, but weights already represent density in normalized units
             const amrex::Real dV = geom.CellSize(0)*geom.CellSize(1)*geom.CellSize(2);
@@ -100,8 +105,8 @@ CoulombCollision::doCoulombCollision (
                         cell_start1, cell_half1,
                         cell_half1, cell_stop1,
                         indices1, indices1,
-                        ux1, uy1, psi1, ux1, uy1, psi1, w1, w1,
-                        q1, q1, m1, m1, -1.0_rt, -1.0_rt,
+                        ux1, uy1, psi1, ux1, uy1, psi1, w1, w1, ion_lev1, ion_lev1,
+                        q1, q1, m1, m1, -1.0_rt, -1.0_rt, can_ionize1, can_ionize1,
                         dt, CoulombLog, dV, cst, normalized_units, background_density_SI, is_same_species, engine );
                 }
                 );
@@ -127,10 +132,12 @@ CoulombCollision::doCoulombCollision (
             amrex::Real* const uy1 = soa1.GetRealData(PlasmaIdx::uy_half_step).data();
             amrex::Real* const psi1 = soa1.GetRealData(PlasmaIdx::psi_half_step).data();
             const amrex::Real* const w1 = soa1.GetRealData(PlasmaIdx::w).data();
+            const int* const ion_lev1 = soa1.GetIntData(PlasmaIdx::ion_lev).data();
             PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
             PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
             amrex::Real q1 = species1.GetCharge();
             amrex::Real m1 = species1.GetMass();
+            const bool can_ionize1 = species1.m_can_ionize;
 
             // Get particles SoA data for species 2
             auto& ptile2 = species2.ParticlesAt(lev, pti.index(), pti.LocalTileIndex());
@@ -139,10 +146,12 @@ CoulombCollision::doCoulombCollision (
             amrex::Real* const uy2 = soa2.GetRealData(PlasmaIdx::uy_half_step).data();
             amrex::Real* const psi2= soa2.GetRealData(PlasmaIdx::psi_half_step).data();
             const amrex::Real* const w2 = soa2.GetRealData(PlasmaIdx::w).data();
+            const int* const ion_lev2 = soa2.GetIntData(PlasmaIdx::ion_lev).data();
             PlasmaBins::index_type * const indices2 = bins2.permutationPtr();
             PlasmaBins::index_type const * const offsets2 = bins2.offsetsPtr();
             amrex::Real q2 = species2.GetCharge();
             amrex::Real m2 = species2.GetMass();
+            const bool can_ionize2 = species2.m_can_ionize;
 
             // volume is used to calculate density, but weights already represent density in normalized units
             const amrex::Real dV = geom.CellSize(0)*geom.CellSize(1)*geom.CellSize(2);
@@ -186,8 +195,8 @@ CoulombCollision::doCoulombCollision (
                     ElasticCollisionPerez(
                         cell_start1, cell_stop1, cell_start2, cell_stop2,
                         indices1, indices2,
-                        ux1, uy1, psi1, ux2, uy2, psi2, w1, w2,
-                        q1, q2, m1, m2, -1.0_rt, -1.0_rt,
+                        ux1, uy1, psi1, ux2, uy2, psi2, w1, w2, ion_lev1, ion_lev2,
+                        q1, q2, m1, m2, -1.0_rt, -1.0_rt, can_ionize1, can_ionize2,
                         dt, CoulombLog, dV, cst, normalized_units, background_density_SI, is_same_species, engine );
                 }
                 );

--- a/src/particles/collisions/ElasticCollisionPerez.H
+++ b/src/particles/collisions/ElasticCollisionPerez.H
@@ -139,6 +139,9 @@ void ElasticCollisionPerez (
         int i1 = I1s; int i2 = I2s;
         for (int k = 0; k < amrex::max(NI1,NI2); ++k)
         {
+            // adjust the charge to the ionization level of the ion. This assumes that the impact
+            // parameter is much larger than the atomic radius, as the bound electrons are not
+            // treated separately
             if (can_ionize1) q1 *= ion_lev1[I1[i1]];
             if (can_ionize2) q2 *= ion_lev2[I2[i2]];
             // particle's Lorentz factor

--- a/src/particles/collisions/ElasticCollisionPerez.H
+++ b/src/particles/collisions/ElasticCollisionPerez.H
@@ -29,12 +29,16 @@
  * @param[in,out] psi2 pseudo-potential array of species 2.
  * @param[in] w1 array of weights.
  * @param[in] w2 array of weights.
+ * @param[in] ion_lev1 current ionization level of species 1
+ * @param[in] ion_lev2 current ionization level of species 2
  * @param[in] q1 Physical charge of species 1.
  * @param[in] q2 Physical charge of species 2.
  * @param[in] m1 Physical mass of species 1.
  * @param[in] m2 Physical mass of species 2.
  * @param[in] T1 temperature of species 1 (Joule). If <0, measured per-cell.
  * @param[in] T2 temperature of species 2 (Joule). If <0, measured per-cell.
+ * @param[in] can_ionize1 whether species 1 can be ionized
+ * @param[in] can_ionize2 whether species 2 can be ionized
  * @param[in] dt is the time step length between two collision calls.
  * @param[in] L Coulomb log. If <0, measured per cell.
  * @param[in] dV Volume of the corresponding cell.
@@ -54,9 +58,11 @@ void ElasticCollisionPerez (
     T_R *u1x, T_R *u1y, T_R *psi1,
     T_R *u2x, T_R *u2y, T_R *psi2,
     T_R const *w1, T_R const *w2,
-    T_R const  q1, T_R const  q2,
+    int const *ion_lev1, int const *ion_lev2,
+    T_R q1, T_R q2,
     T_R const  m1, T_R const  m2,
     T_R const  T1, T_R const  T2,
+    const bool can_ionize1, const bool can_ionize2,
     T_R const  dt, T_R const   L, T_R const dV, const PhysConst& cst, const bool normalized_units,
     const amrex::Real background_density_SI, const bool is_same_species,
     amrex::RandomEngine const& engine)
@@ -133,6 +139,8 @@ void ElasticCollisionPerez (
         int i1 = I1s; int i2 = I2s;
         for (int k = 0; k < amrex::max(NI1,NI2); ++k)
         {
+            if (can_ionize1) q1 *= ion_lev1[I1[i1]];
+            if (can_ionize2) q2 *= ion_lev2[I2[i2]];
             // particle's Lorentz factor
             const amrex::Real g1 = (
                 1.0_rt +

--- a/src/particles/collisions/UpdateMomentumPerez.H
+++ b/src/particles/collisions/UpdateMomentumPerez.H
@@ -88,6 +88,8 @@ void UpdateMomentumPerezElastic (
     T_R const vcy    = (p1y+p2y) / mass_g;
     T_R const vcz    = (p1z+p2z) / mass_g;
     T_R const vcms   = vcx*vcx + vcy*vcy + vcz*vcz;
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(vcms*inv_c2_SI < 1,
+                "Particles with velocities > c in collisional module detected");
     T_R const gc     = T_R(1.0) / std::sqrt( T_R(1.0) - vcms*inv_c2_SI );
 
     // Compute vc dot v1 and v2

--- a/src/particles/collisions/UpdateMomentumPerez.H
+++ b/src/particles/collisions/UpdateMomentumPerez.H
@@ -305,7 +305,7 @@ void UpdateMomentumPerezElastic (
         AMREX_ASSERT_WITH_MESSAGE(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z),
         "NaNs detected in the updated momentum of the collision module. "
         "Most likely due to a negative root in the calculation of gc");
-        AMREX_ASSERT_WITH_MESSAGE(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
+        AMREX_ASSERT(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
     }
 }
 

--- a/src/particles/collisions/UpdateMomentumPerez.H
+++ b/src/particles/collisions/UpdateMomentumPerez.H
@@ -88,8 +88,6 @@ void UpdateMomentumPerezElastic (
     T_R const vcy    = (p1y+p2y) / mass_g;
     T_R const vcz    = (p1z+p2z) / mass_g;
     T_R const vcms   = vcx*vcx + vcy*vcy + vcz*vcz;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(vcms*inv_c2_SI < 1,
-                "Particles with velocities > c in collisional module detected");
     T_R const gc     = T_R(1.0) / std::sqrt( T_R(1.0) - vcms*inv_c2_SI );
 
     // Compute vc dot v1 and v2
@@ -304,8 +302,10 @@ void UpdateMomentumPerezElastic (
         }
         const amrex::Real ga = std::sqrt( T_R(1.0) + (u2x*u2x+u2y*u2y+u2z*u2z)*inv_c2 );
         psi2 = ga - u2z*inv_c;
-        AMREX_ASSERT(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z));
-        AMREX_ASSERT(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
+        AMREX_ASSERT_WITH_MESSAGE(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z),
+        "NaNs detected in the updated momentum of the collision module. "
+        "Most likely due to a negative root in the calculation of gc");
+        AMREX_ASSERT_WITH_MESSAGE(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
     }
 }
 

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -403,7 +403,7 @@ IonizationModule (const int lev,
 
             if(p_ion_mask[ip] != 0) {
                 const long pid = amrex::Gpu::Atomic::Add( p_ip_elec, 1u );
-                const long pidx = pid + old_size;
+                const long pidx = pid + old_size;beam
 
                 // Copy ion data to new electron
                 int_arrdata_elec[PlasmaIdx::id ][pidx] = pid_start + pid;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -403,7 +403,7 @@ IonizationModule (const int lev,
 
             if(p_ion_mask[ip] != 0) {
                 const long pid = amrex::Gpu::Atomic::Add( p_ip_elec, 1u );
-                const long pidx = pid + old_size;beam
+                const long pidx = pid + old_size;
 
                 // Copy ion data to new electron
                 int_arrdata_elec[PlasmaIdx::id ][pidx] = pid_start + pid;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -518,36 +518,35 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
         const amrex::Real sum_w0 = amrex::get< 0>(a);
         const amrex::Real sum_w_inv = sum_w0 <= 0._rt ? 0._rt : 1._rt/sum_w0;
 
-            m_insitu_rdata[islice             ] = sum_w0;
-            m_insitu_rdata[islice+ 1*m_nslices] = amrex::get< 1>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 2*m_nslices] = amrex::get< 2>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 3*m_nslices] = amrex::get< 3>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 4*m_nslices] = amrex::get< 4>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 5*m_nslices] = amrex::get< 5>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 6*m_nslices] = amrex::get< 6>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 7*m_nslices] = amrex::get< 7>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 8*m_nslices] = amrex::get< 8>(a)*sum_w_inv;
-            m_insitu_rdata[islice+ 9*m_nslices] = amrex::get< 9>(a)*sum_w_inv;
-            m_insitu_rdata[islice+10*m_nslices] = amrex::get<10>(a)*sum_w_inv;
-            m_insitu_rdata[islice+11*m_nslices] = amrex::get<11>(a)*sum_w_inv;
-            m_insitu_rdata[islice+12*m_nslices] = amrex::get<12>(a)*sum_w_inv;
-            m_insitu_idata[islice             ] = amrex::get<13>(a);
+        m_insitu_rdata[islice             ] = sum_w0;
+        m_insitu_rdata[islice+ 1*m_nslices] = amrex::get< 1>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 2*m_nslices] = amrex::get< 2>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 3*m_nslices] = amrex::get< 3>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 4*m_nslices] = amrex::get< 4>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 5*m_nslices] = amrex::get< 5>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 6*m_nslices] = amrex::get< 6>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 7*m_nslices] = amrex::get< 7>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 8*m_nslices] = amrex::get< 8>(a)*sum_w_inv;
+        m_insitu_rdata[islice+ 9*m_nslices] = amrex::get< 9>(a)*sum_w_inv;
+        m_insitu_rdata[islice+10*m_nslices] = amrex::get<10>(a)*sum_w_inv;
+        m_insitu_rdata[islice+11*m_nslices] = amrex::get<11>(a)*sum_w_inv;
+        m_insitu_rdata[islice+12*m_nslices] = amrex::get<12>(a)*sum_w_inv;
+        m_insitu_idata[islice             ] = amrex::get<13>(a);
 
-            m_insitu_sum_rdata[ 0] += sum_w0;
-            m_insitu_sum_rdata[ 1] += amrex::get< 1>(a);
-            m_insitu_sum_rdata[ 2] += amrex::get< 2>(a);
-            m_insitu_sum_rdata[ 3] += amrex::get< 3>(a);
-            m_insitu_sum_rdata[ 4] += amrex::get< 4>(a);
-            m_insitu_sum_rdata[ 5] += amrex::get< 5>(a);
-            m_insitu_sum_rdata[ 6] += amrex::get< 6>(a);
-            m_insitu_sum_rdata[ 7] += amrex::get< 7>(a);
-            m_insitu_sum_rdata[ 8] += amrex::get< 8>(a);
-            m_insitu_sum_rdata[ 9] += amrex::get< 9>(a);
-            m_insitu_sum_rdata[10] += amrex::get<10>(a);
-            m_insitu_sum_rdata[11] += amrex::get<11>(a);
-            m_insitu_sum_rdata[12] += amrex::get<12>(a);
-            m_insitu_sum_idata[ 0] += amrex::get<13>(a);
-        }
+        m_insitu_sum_rdata[ 0] += sum_w0;
+        m_insitu_sum_rdata[ 1] += amrex::get< 1>(a);
+        m_insitu_sum_rdata[ 2] += amrex::get< 2>(a);
+        m_insitu_sum_rdata[ 3] += amrex::get< 3>(a);
+        m_insitu_sum_rdata[ 4] += amrex::get< 4>(a);
+        m_insitu_sum_rdata[ 5] += amrex::get< 5>(a);
+        m_insitu_sum_rdata[ 6] += amrex::get< 6>(a);
+        m_insitu_sum_rdata[ 7] += amrex::get< 7>(a);
+        m_insitu_sum_rdata[ 8] += amrex::get< 8>(a);
+        m_insitu_sum_rdata[ 9] += amrex::get< 9>(a);
+        m_insitu_sum_rdata[10] += amrex::get<10>(a);
+        m_insitu_sum_rdata[11] += amrex::get<11>(a);
+        m_insitu_sum_rdata[12] += amrex::get<12>(a);
+        m_insitu_sum_idata[ 0] += amrex::get<13>(a);
     }
 }
 

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -518,35 +518,36 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
         const amrex::Real sum_w0 = amrex::get< 0>(a);
         const amrex::Real sum_w_inv = sum_w0 <= 0._rt ? 0._rt : 1._rt/sum_w0;
 
-        m_insitu_rdata[islice             ] = sum_w0;
-        m_insitu_rdata[islice+ 1*m_nslices] = amrex::get< 1>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 2*m_nslices] = amrex::get< 2>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 3*m_nslices] = amrex::get< 3>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 4*m_nslices] = amrex::get< 4>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 5*m_nslices] = amrex::get< 5>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 6*m_nslices] = amrex::get< 6>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 7*m_nslices] = amrex::get< 7>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 8*m_nslices] = amrex::get< 8>(a)*sum_w_inv;
-        m_insitu_rdata[islice+ 9*m_nslices] = amrex::get< 9>(a)*sum_w_inv;
-        m_insitu_rdata[islice+10*m_nslices] = amrex::get<10>(a)*sum_w_inv;
-        m_insitu_rdata[islice+11*m_nslices] = amrex::get<11>(a)*sum_w_inv;
-        m_insitu_rdata[islice+12*m_nslices] = amrex::get<12>(a)*sum_w_inv;
-        m_insitu_idata[islice             ] = amrex::get<13>(a);
+            m_insitu_rdata[islice             ] = sum_w0;
+            m_insitu_rdata[islice+ 1*m_nslices] = amrex::get< 1>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 2*m_nslices] = amrex::get< 2>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 3*m_nslices] = amrex::get< 3>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 4*m_nslices] = amrex::get< 4>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 5*m_nslices] = amrex::get< 5>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 6*m_nslices] = amrex::get< 6>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 7*m_nslices] = amrex::get< 7>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 8*m_nslices] = amrex::get< 8>(a)*sum_w_inv;
+            m_insitu_rdata[islice+ 9*m_nslices] = amrex::get< 9>(a)*sum_w_inv;
+            m_insitu_rdata[islice+10*m_nslices] = amrex::get<10>(a)*sum_w_inv;
+            m_insitu_rdata[islice+11*m_nslices] = amrex::get<11>(a)*sum_w_inv;
+            m_insitu_rdata[islice+12*m_nslices] = amrex::get<12>(a)*sum_w_inv;
+            m_insitu_idata[islice             ] = amrex::get<13>(a);
 
-        m_insitu_sum_rdata[ 0] += sum_w0;
-        m_insitu_sum_rdata[ 1] += amrex::get< 1>(a);
-        m_insitu_sum_rdata[ 2] += amrex::get< 2>(a);
-        m_insitu_sum_rdata[ 3] += amrex::get< 3>(a);
-        m_insitu_sum_rdata[ 4] += amrex::get< 4>(a);
-        m_insitu_sum_rdata[ 5] += amrex::get< 5>(a);
-        m_insitu_sum_rdata[ 6] += amrex::get< 6>(a);
-        m_insitu_sum_rdata[ 7] += amrex::get< 7>(a);
-        m_insitu_sum_rdata[ 8] += amrex::get< 8>(a);
-        m_insitu_sum_rdata[ 9] += amrex::get< 9>(a);
-        m_insitu_sum_rdata[10] += amrex::get<10>(a);
-        m_insitu_sum_rdata[11] += amrex::get<11>(a);
-        m_insitu_sum_rdata[12] += amrex::get<12>(a);
-        m_insitu_sum_idata[ 0] += amrex::get<13>(a);
+            m_insitu_sum_rdata[ 0] += sum_w0;
+            m_insitu_sum_rdata[ 1] += amrex::get< 1>(a);
+            m_insitu_sum_rdata[ 2] += amrex::get< 2>(a);
+            m_insitu_sum_rdata[ 3] += amrex::get< 3>(a);
+            m_insitu_sum_rdata[ 4] += amrex::get< 4>(a);
+            m_insitu_sum_rdata[ 5] += amrex::get< 5>(a);
+            m_insitu_sum_rdata[ 6] += amrex::get< 6>(a);
+            m_insitu_sum_rdata[ 7] += amrex::get< 7>(a);
+            m_insitu_sum_rdata[ 8] += amrex::get< 8>(a);
+            m_insitu_sum_rdata[ 9] += amrex::get< 9>(a);
+            m_insitu_sum_rdata[10] += amrex::get<10>(a);
+            m_insitu_sum_rdata[11] += amrex::get<11>(a);
+            m_insitu_sum_rdata[12] += amrex::get<12>(a);
+            m_insitu_sum_idata[ 0] += amrex::get<13>(a);
+        }
     }
 }
 


### PR DESCRIPTION
comes after #968 

This PR improves the collision module:
1. For ions, the ionization level is multiplied, to get the charge correct.
2. in some settings the velocities of particles can be > c, which will cause the code to crash (due to a negative root and resulting in NaNs). In this PR a meaningful error message in the endangered region is provided. Note that so far I only noticed it in unphysical settings, so I just let the code crash with an error message.
3. in case one species does not have any plasma particles, the collision module is skipped (instead of the code crashing, as before).

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [x] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [x] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
