### PR TITLE
fix some issues with the collision module

### DIFF
--- a/src/particles/collisions/ElasticCollisionPerez.H
+++ b/src/particles/collisions/ElasticCollisionPerez.H
@@ -95,6 +95,7 @@ void ElasticCollisionPerez (
         n1 = n1 + n2;
         n2 = n1;
     }
+    if (n1 == 0 || n2 == 0) return;
     // compute n12 according to eq. 16 in Perez et al., Phys. Plasmas 19 (8) (2012) 083104
     {
       int i1 = I1s; int i2 = I2s;
@@ -122,7 +123,7 @@ void ElasticCollisionPerez (
 
     // compute Debye length lmdD
     T_R lmdD;
-    if ( T1t < T_R(0.0) || T2t < T_R(0.0) ) {
+    if ( T1t <= T_R(0.0) || T2t <= T_R(0.0) ) {
         lmdD = T_R(0.0);
     }
     else {

--- a/src/particles/collisions/UpdateMomentumPerez.H
+++ b/src/particles/collisions/UpdateMomentumPerez.H
@@ -279,14 +279,11 @@ void UpdateMomentumPerezElastic (
         u1x  = p1fx / m1;
         u1y  = p1fy / m1;
         u1z  = p1fz / m1;
-        if (normalized_units) { // backtransform to normalized units
-            u1x *= inv_c_SI;
-            u1y *= inv_c_SI;
-            u1z *= inv_c_SI;
-        }
-        const amrex::Real ga = std::sqrt( T_R(1.0) + (u1x*u1x+u1y*u1y+u1z*u1z)*inv_c2 );
-        psi1 = ga - u1z*inv_c;
-        AMREX_ASSERT(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z));
+        const amrex::Real ga = std::sqrt( T_R(1.0) + (u1x*u1x+u1y*u1y+u1z*u1z)*inv_c2_SI );
+        psi1 = ga - u1z*inv_c_SI;
+        AMREX_ASSERT_WITH_MESSAGE(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z),
+        "NaNs detected in the updated momentum of the collision module. "
+        "Most likely due to a negative root in the calculation of gc");
         AMREX_ASSERT(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
     }
     r = amrex::Random(engine);
@@ -295,17 +292,20 @@ void UpdateMomentumPerezElastic (
         u2x  = p2fx / m2;
         u2y  = p2fy / m2;
         u2z  = p2fz / m2;
-        if (normalized_units) { // backtransform to normalized units
-            u2x *= inv_c_SI;
-            u2y *= inv_c_SI;
-            u2z *= inv_c_SI;
-        }
-        const amrex::Real ga = std::sqrt( T_R(1.0) + (u2x*u2x+u2y*u2y+u2z*u2z)*inv_c2 );
-        psi2 = ga - u2z*inv_c;
+        const amrex::Real ga = std::sqrt( T_R(1.0) + (u2x*u2x+u2y*u2y+u2z*u2z)*inv_c2_SI );
+        psi2 = ga - u2z*inv_c_SI;
         AMREX_ASSERT_WITH_MESSAGE(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z),
         "NaNs detected in the updated momentum of the collision module. "
         "Most likely due to a negative root in the calculation of gc");
         AMREX_ASSERT(!std::isinf(u1x+u1y+u1z+u2x+u2y+u2z));
+    }
+    if (normalized_units) { // backtransform to normalized units
+        u1x *= inv_c_SI;
+        u1y *= inv_c_SI;
+        u1z *= inv_c_SI;
+        u2x *= inv_c_SI;
+        u2y *= inv_c_SI;
+        u2z *= inv_c_SI;
     }
 }
 


### PR DESCRIPTION
As reported by @AlexanderSinn, there were a few flaws in the collision module that are fixed in this PR.

1. If one species had only invalid particles in one cell, the sum of the weights could be 0, leading to a division by 0 and possible NaNs.
2. When deciding whether the Debye length is calculated, it should be 0 for a 0 temperature
3. The momentum in normalized units was only backtransformed in case the particles actually collided, but always transformed to SI units. This error was not caught as it was tested in a case were roughly only the same amount of particles were in a cell.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
