### PR TITLE
always use PhysConstSI in parser

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -18,15 +18,17 @@ in the input script with ``my_constants``.
 
 Thereby, the following constants are predefined:
 
-============ =================== ================= ====================
-**variable** **name**            **SI value**      **normalized value**
-q_e          elementary charge   1.602176634e-19   1
-m_e          electron mass       9.1093837015e-31  1
-m_p          proton mass         1.67262192369e-27 1836.15267343
-epsilon0     vacuum permittivity 8.8541878128e-12  1
-mu0          vacuum permeability 1.25663706212e-06 1
-clight       speed of light      299'792'458.      1
-============ =================== ================= ====================
+============ ========================= =====================
+**variable** **name**                  **Value**
+q_e          elementary charge         1.602176634e-19
+m_e          electron mass             9.1093837015e-31
+m_p          proton mass               1.67262192369e-27
+epsilon0     vacuum permittivity       8.8541878128e-12
+mu0          vacuum permeability       1.25663706212e-06
+clight       speed of light            299'792'458.
+hbar         reduced Planck constant   1.054571817e-34
+r_e          classical electron radius 2.817940326204929e-15
+============ ========================= =====================
 
 For a list of supported functions see the
 `AMReX documentation <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parser>`__.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -49,7 +49,7 @@ Hipace_early_init::Hipace_early_init (Hipace* instance)
     } else {
         m_phys_const = make_constants_SI();
     }
-    Parser::addConstantsToParser(m_phys_const);
+    Parser::addConstantsToParser();
     Parser::replaceAmrexParamsWithParser();
 
     queryWithParser(pph, "depos_order_xy", m_depos_order_xy);

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -38,18 +38,16 @@ namespace Parser
     // {"true", 1},
     // {"false", 0}
 
-    /** \brief add Physical constants to Parser constants
-     *
-     * \param[in] phys_const the constants to add
-     */
+    /** \brief add Physical constants to Parser constants */
     inline void
-    addConstantsToParser (const PhysConst& phys_const) {
-        hipace_constants.insert({"clight", phys_const.c});
-        hipace_constants.insert({"epsilon0", phys_const.ep0});
-        hipace_constants.insert({"mu0", phys_const.mu0});
-        hipace_constants.insert({"q_e", phys_const.q_e});
-        hipace_constants.insert({"m_e", phys_const.m_e});
-        hipace_constants.insert({"m_p", phys_const.m_p});
+    addConstantsToParser () {
+        hipace_constants.insert({"clight",   PhysConstSI::c   });
+        hipace_constants.insert({"epsilon0", PhysConstSI::ep0 });
+        hipace_constants.insert({"mu0",      PhysConstSI::mu0 });
+        hipace_constants.insert({"q_e",      PhysConstSI::q_e });
+        hipace_constants.insert({"m_e",      PhysConstSI::m_e });
+        hipace_constants.insert({"m_p",      PhysConstSI::m_p });
+        hipace_constants.insert({"hbar",     PhysConstSI::hbar})
     }
 
     /** \brief replace ParmParse input with a Parsed version

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -48,6 +48,7 @@ namespace Parser
         hipace_constants.insert({"m_e",      PhysConstSI::m_e });
         hipace_constants.insert({"m_p",      PhysConstSI::m_p });
         hipace_constants.insert({"hbar",     PhysConstSI::hbar});
+        hipace_constants.insert({"r_e",      PhysConstSI::r_e});
     }
 
     /** \brief replace ParmParse input with a Parsed version

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -47,7 +47,7 @@ namespace Parser
         hipace_constants.insert({"q_e",      PhysConstSI::q_e });
         hipace_constants.insert({"m_e",      PhysConstSI::m_e });
         hipace_constants.insert({"m_p",      PhysConstSI::m_p });
-        hipace_constants.insert({"hbar",     PhysConstSI::hbar})
+        hipace_constants.insert({"hbar",     PhysConstSI::hbar});
     }
 
     /** \brief replace ParmParse input with a Parsed version


### PR DESCRIPTION
Previously, the constants such as `clight` etc in the parser were chosen according to the unit system. However, that prevents the most prevalent use case, where quantities in SI units (such as beam width or emittance) can be transformed into normalized units using the parser and the constants. This did not work because then the constants would also be normalized. 

I don't see any use case, where normalized constants are needed (they can simply be omitted).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
