### PR TITLE
Add option to allocate mpi buffers in device memory

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -193,7 +193,7 @@ General parameters
     Currently, this option only affects plasma operations (gather, push and deposition).
     The tile size can be set with ``plasmas.sort_bin_size``.
 
-* ``hipace.m_comms_buffer_on_gpu`` (`bool`) optional (default `false`)
+* ``hipace.comms_buffer_on_gpu`` (`bool`) optional (default `false`)
     If the buffers used for MPI communication should be allocated on the GPU (device memory).
     By default they will be allocated on the CPU (pinned memory).
     Setting this option to true is necessary to take advatige of GPU-Enabled MPI, however for this

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -193,6 +193,12 @@ General parameters
     Currently, this option only affects plasma operations (gather, push and deposition).
     The tile size can be set with ``plasmas.sort_bin_size``.
 
+* ``hipace.m_comms_buffer_on_gpu`` (`bool`) optional (default `false`)
+    If the buffers used for MPI communication should be allocated on the GPU (device memory).
+    By default they will be allocated on the CPU (pinned memory).
+    Setting this option to true is necessary to take advatige of GPU-Enabled MPI, however for this
+    additional enviroment variables need to be set depending on the system.
+
 * ``hipace.do_beam_jz_minus_rho`` (`bool`) optional (default `0`)
     Whether the beam contribution to :math:`j_z-c\rho` is calculated and used when solving for Psi (used to caculate the transverse fields Ex-By and Ey+Bx).
     if 0, this term is assumed to be 0 (a good approximation for an ultra-relativistic beam in the z direction with small transverse momentum).

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -194,7 +194,7 @@ General parameters
     The tile size can be set with ``plasmas.sort_bin_size``.
 
 * ``hipace.comms_buffer_on_gpu`` (`bool`) optional (default `false`)
-    If the buffers used for MPI communication should be allocated on the GPU (device memory).
+    Whether the buffers used for MPI communication should be allocated on the GPU (device memory).
     By default they will be allocated on the CPU (pinned memory).
     Setting this option to true is necessary to take advatige of GPU-Enabled MPI, however for this
     additional enviroment variables need to be set depending on the system.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -193,10 +193,10 @@ General parameters
     Currently, this option only affects plasma operations (gather, push and deposition).
     The tile size can be set with ``plasmas.sort_bin_size``.
 
-* ``hipace.comms_buffer_on_gpu`` (`bool`) optional (default `false`)
+* ``hipace.comms_buffer_on_gpu`` (`bool`) optional (default `0`)
     Whether the buffers used for MPI communication should be allocated on the GPU (device memory).
     By default they will be allocated on the CPU (pinned memory).
-    Setting this option to true is necessary to take advatige of GPU-Enabled MPI, however for this
+    Setting this option to `1` is necessary to take advantge of GPU-Enabled MPI, however for this
     additional enviroment variables need to be set depending on the system.
 
 * ``hipace.do_beam_jz_minus_rho`` (`bool`) optional (default `0`)

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -196,7 +196,7 @@ General parameters
 * ``hipace.comms_buffer_on_gpu`` (`bool`) optional (default `0`)
     Whether the buffers used for MPI communication should be allocated on the GPU (device memory).
     By default they will be allocated on the CPU (pinned memory).
-    Setting this option to `1` is necessary to take advantge of GPU-Enabled MPI, however for this
+    Setting this option to `1` is necessary to take advantage of GPU-Enabled MPI, however for this
     additional enviroment variables need to be set depending on the system.
 
 * ``hipace.do_beam_jz_minus_rho`` (`bool`) optional (default `0`)

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -372,7 +372,7 @@ public:
     amrex::Parser m_salame_parser;
     /** Function to get the target Ez field for SALAME */
     amrex::ParserExecutor<3> m_salame_target_func;
-    /** If MPI communication buffers should be allocated in device memory */
+    /** Whether MPI communication buffers should be allocated in device memory */
     bool m_comms_buffer_on_gpu = false;
     /** Arena for MPI communications */
     amrex::Arena* m_comms_arena = nullptr;

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -372,6 +372,10 @@ public:
     amrex::Parser m_salame_parser;
     /** Function to get the target Ez field for SALAME */
     amrex::ParserExecutor<3> m_salame_target_func;
+    /** If MPI communication buffers should be allocated in device memory */
+    bool m_comms_buffer_on_gpu = false;
+    /** Arena for MPI communications */
+    amrex::Arena* m_comms_arena = nullptr;
 
     /** \brief Check that the ghost beam particles are in the proper box, and invalidate
      * those not in the right slice.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -496,6 +496,14 @@ Hipace::Evolve ()
 void
 Hipace::SolveOneSlice (int islice, const int islice_local, int step)
 {
+#ifdef AMREX_USE_MPI
+    {
+        // Call a MPI function so that the MPI implementation has a chance to
+        // run tasks necessary to make progress with asynchronous communications.
+        int flag = 0;
+        MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag, MPI_STATUS_IGNORE);
+    }
+#endif
     HIPACE_PROFILE("Hipace::SolveOneSlice()");
 
     // Between this push and the corresponding pop at the end of this


### PR DESCRIPTION
Necessary for testing gpu aware mpi.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
