### PR TITLE
Cleaning collisions and preparing UpdateMomentumPerez for beams

### DIFF
--- a/src/particles/collisions/ComputeTemperature.H
+++ b/src/particles/collisions/ComputeTemperature.H
@@ -13,10 +13,9 @@ AMREX_GPU_HOST_DEVICE
 T_R ComputeTemperature (
     T_index const Is, T_index const Ie, T_index const * AMREX_RESTRICT I,
     T_R const * AMREX_RESTRICT ux, T_R const * AMREX_RESTRICT uy, T_R const * AMREX_RESTRICT psi,
-    T_R const m, const PhysConst& cst )
+    T_R const m, T_R const clight, T_R const inv_c2 )
 {
     using namespace amrex::literals;
-    T_R const c2i = 1._rt/(cst.c * cst.c);
 
     const int N = Ie - Is;
     if ( N == 0 ) { return T_R(0.0); }
@@ -28,9 +27,9 @@ T_R ComputeTemperature (
     for (int i = Is; i < (int) Ie; ++i)
     {
         // particle's Lorentz factor
-        gm = (1.0_rt + ux[I[i]]*ux[I[i]]*c2i + uy[I[i]]*uy[I[i]]*c2i
+        gm = (1.0_rt + (ux[I[i]]*ux[I[i]] + uy[I[i]]*uy[I[i]])*inv_c2
               + psi[I[i]]*psi[I[i]]) / (2.0_rt * psi[I[i]] );
-        const amrex::Real uz = cst.c * (gm - psi[I[i]]);
+        const amrex::Real uz = clight * (gm - psi[I[i]]);
         us = ( ux[ I[i] ] * ux[ I[i] ] +
                uy[ I[i] ] * uy[ I[i] ] +
                uz         * uz);

--- a/src/particles/collisions/CoulombCollision.cpp
+++ b/src/particles/collisions/CoulombCollision.cpp
@@ -11,7 +11,6 @@ CoulombCollision::CoulombCollision(
 {
     using namespace amrex::literals;
 
-    // TODO: ionization level
     // TODO: Fix dt
 
     // read collision species
@@ -50,7 +49,14 @@ CoulombCollision::doCoulombCollision (
 
     using namespace amrex::literals;
     const PhysConst cst = get_phys_const();
-    bool normalized_units = Hipace::GetInstance().m_normalized_units;
+    bool normalized_units = Hipace::m_normalized_units;
+
+    const amrex::Real clight = cst.c;
+    const amrex::Real inv_c = 1.0_rt / cst.c;
+    const amrex::Real inv_c2 = 1.0_rt / ( cst.c * cst.c );
+    constexpr amrex::Real inv_c_SI = 1.0_rt / PhysConstSI::c;
+    constexpr amrex::Real inv_c2_SI = 1.0_rt / ( PhysConstSI::c * PhysConstSI::c );
+
     if ( is_same_species ) // species_1 == species_2
     {
         // Logically particles per-cell, and return indices of particles in each cell
@@ -75,7 +81,7 @@ CoulombCollision::doCoulombCollision (
             const bool can_ionize1 = species1.m_can_ionize;
 
             // volume is used to calculate density, but weights already represent density in normalized units
-            const amrex::Real dV = geom.CellSize(0)*geom.CellSize(1)*geom.CellSize(2);
+            const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
             // static_cast<double> to avoid precision problems in FP32
             const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
                                              PhysConstSI::q_e*PhysConstSI::q_e /
@@ -107,7 +113,8 @@ CoulombCollision::doCoulombCollision (
                         indices1, indices1,
                         ux1, uy1, psi1, ux1, uy1, psi1, w1, w1, ion_lev1, ion_lev1,
                         q1, q1, m1, m1, -1.0_rt, -1.0_rt, can_ionize1, can_ionize1,
-                        dt, CoulombLog, dV, cst, normalized_units, background_density_SI, is_same_species, engine );
+                        dt, CoulombLog, inv_dV, clight, inv_c, inv_c_SI, inv_c2, inv_c2_SI,
+                        normalized_units, background_density_SI, is_same_species, engine );
                 }
                 );
             count++;
@@ -154,7 +161,7 @@ CoulombCollision::doCoulombCollision (
             const bool can_ionize2 = species2.m_can_ionize;
 
             // volume is used to calculate density, but weights already represent density in normalized units
-            const amrex::Real dV = geom.CellSize(0)*geom.CellSize(1)*geom.CellSize(2);
+            const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
             // static_cast<double> to avoid precision problems in FP32
             const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
                                              PhysConstSI::q_e*PhysConstSI::q_e /
@@ -197,7 +204,8 @@ CoulombCollision::doCoulombCollision (
                         indices1, indices2,
                         ux1, uy1, psi1, ux2, uy2, psi2, w1, w2, ion_lev1, ion_lev2,
                         q1, q2, m1, m2, -1.0_rt, -1.0_rt, can_ionize1, can_ionize2,
-                        dt, CoulombLog, dV, cst, normalized_units, background_density_SI, is_same_species, engine );
+                        dt, CoulombLog, inv_dV, clight, inv_c, inv_c_SI, inv_c2, inv_c2_SI,
+                        normalized_units, background_density_SI, is_same_species, engine );
                 }
                 );
             count++;

--- a/src/particles/collisions/ElasticCollisionPerez.H
+++ b/src/particles/collisions/ElasticCollisionPerez.H
@@ -41,8 +41,12 @@
  * @param[in] can_ionize2 whether species 2 can be ionized
  * @param[in] dt is the time step length between two collision calls.
  * @param[in] L Coulomb log. If <0, measured per cell.
- * @param[in] dV Volume of the corresponding cell.
- * @param[in] cst physical constants
+ * @param[in] inv_dV inverse volume of the corresponding cell.
+ * @param[in] clight speed of light c
+ * @param[in] inv_c 1/c
+ * @param[in] inv_c_SI 1/c in SI units
+ * @param[in] inv_c2 1/c^2
+ * @param[in] inv_c2_SI 1/c^2 in SI units
  * @param[in] normalized_units whether normalized units are used
  * @param[in] background_density_SI background plasma density (only needed for normalized units)
  * @param[in] is_same_species whether the collisions happen within the same species
@@ -63,12 +67,13 @@ void ElasticCollisionPerez (
     T_R const  m1, T_R const  m2,
     T_R const  T1, T_R const  T2,
     const bool can_ionize1, const bool can_ionize2,
-    T_R const  dt, T_R const   L, T_R const dV, const PhysConst& cst, const bool normalized_units,
+    T_R const  dt, T_R const   L, T_R const inv_dV, T_R const clight, T_R const inv_c,
+    T_R const inv_c_SI, T_R const inv_c2, T_R const inv_c2_SI, const bool normalized_units,
     const amrex::Real background_density_SI, const bool is_same_species,
     amrex::RandomEngine const& engine)
 {
     using namespace amrex::literals;
-    T_R const inv_c2 = T_R(1.0)/(cst.c*cst.c);
+
     const int NI1 = I1e - I1s;
     const int NI2 = I2e - I2s;
 
@@ -76,12 +81,12 @@ void ElasticCollisionPerez (
     T_R T1t; T_R T2t;
     if ( T1 <= T_R(0.0) && L <= T_R(0.0) )
     {
-        T1t = ComputeTemperature(I1s,I1e,I1,u1x,u1y,psi1,m1,cst);
+        T1t = ComputeTemperature(I1s,I1e,I1,u1x,u1y,psi1,m1,clight,inv_c2);
     }
     else { T1t = T1; }
     if ( T2 <= T_R(0.0) && L <= T_R(0.0) )
     {
-        T2t = ComputeTemperature(I2s,I2e,I2,u2x,u2y,psi2,m2,cst);
+        T2t = ComputeTemperature(I2s,I2e,I2,u2x,u2y,psi2,m2,clight,inv_c2);
     }
     else { T2t = T2; }
 
@@ -116,9 +121,9 @@ void ElasticCollisionPerez (
         n2 *= background_density_SI;
         n12 *= background_density_SI;
     } else {
-        n1 /= dV;
-        n2 /= dV;
-        n12 /= dV;
+        n1 *= inv_dV;
+        n2 *= inv_dV;
+        n12 *= inv_dV;
     }
 
     // compute Debye length lmdD
@@ -146,25 +151,36 @@ void ElasticCollisionPerez (
             if (can_ionize1) q1 *= ion_lev1[I1[i1]];
             if (can_ionize2) q2 *= ion_lev2[I2[i2]];
             // particle's Lorentz factor
-            const amrex::Real g1 = (
+            amrex::Real g1 = (
                 1.0_rt +
                 u1x[I1[i1]]*u1x[I1[i1]]*inv_c2 + u1y[I1[i1]]*u1y[I1[i1]]*inv_c2 +
                 psi1[I1[i1]]*psi1[I1[i1]]) / (2.0_rt * psi1[I1[i1]] );
             // particle's Lorentz factor
-            const amrex::Real g2 = (
+            amrex::Real g2 = (
                 1.0_rt +
                 u2x[I2[i2]]*u2x[I2[i2]]*inv_c2 + u2y[I2[i2]]*u2y[I2[i2]]*inv_c2 +
                 psi2[I2[i2]]*psi2[I2[i2]]) / (2.0_rt * psi2[I2[i2]] );
+
+            // Convert from pseudo-potential to momentum
+            amrex::Real u1z = clight * (g1 - psi1[I1[i1]]);
+            amrex::Real u2z = clight * (g2 - psi2[I2[i2]]);
+
             // In the longitudinal push of plasma particles, the dt is different for each particle.
             // The dt applied for collision probability is the average (in the lab frame) of these
             // dts. This is NOT clean. TODO FIXME.
             const amrex::Real dt_fac = 0.5_rt * (g1/psi1[I1[i1]] + g2/psi2[I2[i2]]);
             UpdateMomentumPerezElastic(
-                u1x[ I1[i1] ], u1y[ I1[i1] ], psi1[ I1[i1] ],
-                u2x[ I2[i2] ], u2y[ I2[i2] ], psi2[ I2[i2] ],
-                n1, n2, n12,
-                q1, m1, w1[ I1[i1] ], q2, m2, w2[ I2[i2] ],
-                dt * dt_fac, L, lmdD, cst, normalized_units, engine);
+                u1x[ I1[i1] ], u1y[ I1[i1] ], u1z, g1,
+                u2x[ I2[i2] ], u2y[ I2[i2] ], u2z, g2,
+                n1, n2, n12, q1, m1, w1[ I1[i1] ], q2, m2, w2[ I2[i2] ],
+                dt * dt_fac, L, lmdD, inv_c_SI, inv_c2_SI, normalized_units, engine);
+
+            g1 = std::sqrt( T_R(1.0) +
+                            (u1x[I1[i1]]*u1x[I1[i1]]+u1y[I1[i1]]*u1y[I1[i1]]+u1z*u1z)*inv_c2 );
+            psi1[I1[i1]] = g1 - u1z*inv_c;
+            g2 = std::sqrt( T_R(1.0) +
+                            (u2x[I2[i2]]*u2x[I2[i2]]+u2y[I2[i2]]*u2y[I2[i2]]+u2z*u2z)*inv_c2 );
+            psi2[I2[i2]] = g2 - u2z*inv_c;
 
             ++i1; if ( i1 == static_cast<int>(I1e) ) { i1 = I1s; }
             ++i2; if ( i2 == static_cast<int>(I2e) ) { i2 = I2s; }

--- a/src/particles/collisions/UpdateMomentumPerez.H
+++ b/src/particles/collisions/UpdateMomentumPerez.H
@@ -28,29 +28,15 @@
 template <typename T_R>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void UpdateMomentumPerezElastic (
-    T_R& u1x, T_R& u1y, T_R& psi1, T_R& u2x, T_R& u2y, T_R& psi2,
+    T_R& u1x, T_R& u1y, T_R& u1z, T_R const g1, T_R& u2x, T_R& u2y, T_R& u2z, T_R const g2,
     T_R const n1, T_R const n2, T_R const n12,
     T_R const q1, T_R m1, T_R const w1,
     T_R const q2, T_R m2, T_R const w2,
     T_R const dt, T_R const L,  T_R const lmdD,
-    const PhysConst& cst, const bool normalized_units,
+    T_R const inv_c_SI, T_R const inv_c2_SI, const bool normalized_units,
     amrex::RandomEngine const& engine)
 {
     using namespace amrex::literals;
-
-    T_R const inv_c2 = T_R(1.0) / ( cst.c * cst.c );
-    T_R constexpr inv_c2_SI = T_R(1.0) / ( PhysConstSI::c * PhysConstSI::c );
-    T_R const inv_c = T_R(1.0) / cst.c;
-    T_R constexpr inv_c_SI = T_R(1.0) / PhysConstSI::c;
-    // Convert from pseudo-potential to momentum
-
-    // particle's Lorentz factor
-    const amrex::Real g1 = (1.0_rt+u1x*u1x*inv_c2 + u1y*u1y*inv_c2 + psi1*psi1) / (2.0_rt*psi1);
-    amrex::Real u1z = cst.c * (g1 - psi1);
-
-    // particle's Lorentz factor
-    const amrex::Real g2 = (1.0_rt+u2x*u2x*inv_c2 + u2y*u2y*inv_c2 + psi2*psi2) / (2.0_rt*psi2);
-    amrex::Real u2z = cst.c * (g2 - psi2);
 
     T_R const diffx = amrex::Math::abs(u1x-u2x);
     T_R const diffy = amrex::Math::abs(u1y-u2y);
@@ -279,8 +265,6 @@ void UpdateMomentumPerezElastic (
         u1x  = p1fx / m1;
         u1y  = p1fy / m1;
         u1z  = p1fz / m1;
-        const amrex::Real ga = std::sqrt( T_R(1.0) + (u1x*u1x+u1y*u1y+u1z*u1z)*inv_c2_SI );
-        psi1 = ga - u1z*inv_c_SI;
         AMREX_ASSERT_WITH_MESSAGE(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z),
         "NaNs detected in the updated momentum of the collision module. "
         "Most likely due to a negative root in the calculation of gc");
@@ -292,8 +276,6 @@ void UpdateMomentumPerezElastic (
         u2x  = p2fx / m2;
         u2y  = p2fy / m2;
         u2z  = p2fz / m2;
-        const amrex::Real ga = std::sqrt( T_R(1.0) + (u2x*u2x+u2y*u2y+u2z*u2z)*inv_c2_SI );
-        psi2 = ga - u2z*inv_c_SI;
         AMREX_ASSERT_WITH_MESSAGE(!std::isnan(u1x+u1y+u1z+u2x+u2y+u2z),
         "NaNs detected in the updated momentum of the collision module. "
         "Most likely due to a negative root in the calculation of gc");


### PR DESCRIPTION
This PR does some cleaning:

1. calculation of constants as 1/c or 1/c^2 are moved outside of the compute intense kernels.
2. some divisions are avoided by defining `inv_dV` instead of using `/dV`
3. the calculation from uz from psi is moved outside of `UpdateMomentumPerez`. Although this adds a little bit of calculations, as the backtransform from uz to psi is now always calculated and not only in the rejection method whether the particles collided, this allows for the input of uz instead of psi to the function. Then, it can be used in the same way for beam and plasma particles.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
