### PR TITLE
[mini] clean GetInstance() and use static inline

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -184,18 +184,6 @@ public:
      * longitudinal parallelization)
      */
     MPI_Comm m_comm_z = MPI_COMM_NULL;
-    /** Number of processors in the transverse x direction */
-    int m_numprocs_x = 1;
-    /** Number of processors in the transverse y direction */
-    int m_numprocs_y = 1;
-    /** Number of processors in the longitudinal z direction */
-    int m_numprocs_z = 0;
-    /** My rank in the transverse communicator */
-    int m_rank_xy = 0;
-    /** My rank in the longitudinal communicator */
-    int m_rank_z = 0;
-    /** Max number of grid size in the longitudinal direction */
-    int m_boxes_in_z = 1;
     /** Send buffer for particle longitudinal parallelization (pipeline) */
     char* m_psend_buffer = nullptr;
     char* m_psend_buffer_ghost = nullptr;
@@ -252,12 +240,22 @@ public:
     MultiBeam m_multi_beam;
     /** Contains all plasma species */
     MultiPlasma m_multi_plasma;
+    /** Number of processors in the transverse x direction */
+    inline static int m_numprocs_x = 1;
+    /** Number of processors in the transverse y direction */
+    inline static int m_numprocs_y = 1;
+    /** Number of processors in the longitudinal z direction */
+    inline static int m_numprocs_z = 0;
+    /** My rank in the transverse communicator */
+    inline static int m_rank_xy = 0;
+    /** My rank in the longitudinal communicator */
+    inline static int m_rank_z = 0;
+    /** Max number of grid size in the longitudinal direction */
+    inline static int m_boxes_in_z = 1;
     /** Number of time iterations */
     inline static int m_max_step = 0;
     /** Maximum simulation time */
     inline static amrex::Real m_max_time = std::numeric_limits<amrex::Real>::infinity();
-    /** Time step for the beam evolution */
-    inline static amrex::Real m_dt = 0.0;
     /** Physical time of the simulation. At the end of the time step, it is the physical time
      * at which the fields have been calculated. The beam is one step ahead. */
     inline static amrex::Real m_physical_time = 0.0;
@@ -295,6 +293,8 @@ public:
     /** How much the box is coarsened for beam injection, to avoid exceeding max int in cell count.
      * Otherwise, changing this parameter only will not affect the simulation results. */
     inline static int m_beam_injection_cr = 1;
+    /** Whether the explicit field solver is used */
+    inline static bool m_explicit = true;
     /** Relative tolerance for the multigrid solver, when using the explicit solver */
     inline static amrex::Real m_MG_tolerance_rel = 1.e-4;
     /** Absolute tolerance for the multigrid solver, when using the explicit solver */
@@ -308,6 +308,8 @@ public:
     /** Background plasma density in SI, used to compute collisions, ionization,
      * or radiation reaction in normalized units */
     inline static amrex::Real m_background_density_SI = 0.;
+    /** Time step for the beam evolution */
+    amrex::Real m_dt = 0.0;
     /** Adaptive time step instance */
     AdaptiveTimeStep m_adaptive_time_step;
     /** Laser instance (soon to be multi laser container) */
@@ -326,8 +328,6 @@ public:
     int m_leftmost_box_rcv = std::numeric_limits<int>::max();
     /** Whether to skip communications of boxes that contain no beam particles */
     int m_skip_empty_comms = false;
-    /** Whether the explicit field solver is used */
-    bool m_explicit = true;
     /** the number of SALAME iterations to be done */
     int m_salame_n_iter = 3;
     /** if the SALAME-only field should be computed exactly with plasma particles */

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -58,7 +58,7 @@ Fields::AllocData (
             m_source_nguard = amrex::IntVect{0, 0, 0};
         }
 
-        m_explicit = Hipace::GetInstance().m_explicit;
+        m_explicit = Hipace::m_explicit;
         m_any_neutral_background = Hipace::GetInstance().m_multi_plasma.AnySpeciesNeutralizeBackground();
         const bool any_salame = Hipace::GetInstance().m_multi_beam.AnySpeciesSalame();
 
@@ -557,7 +557,7 @@ Fields::ShiftSlices (int lev)
 {
     HIPACE_PROFILE("Fields::ShiftSlices()");
 
-    const bool explicit_solve = Hipace::GetInstance().m_explicit;
+    const bool explicit_solve = Hipace::m_explicit;
 
     // only shift the slices that are allocated
     if (explicit_solve) {
@@ -725,7 +725,7 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
 
             amrex::Real offset = 1;
             amrex::Real factor = 1;
-            if ((component == "Bx" || component == "By") && Hipace::GetInstance().m_explicit &&
+            if ((component == "Bx" || component == "By") && Hipace::m_explicit &&
                 (getSlices(lev).box(0).length(0) % 2 == 0)) {
                 // hpmg has the boundary condition at a different place
                 // compared to the fft poisson solver

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -50,7 +50,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
     // requires sometimes just the beam currents
     // Do not access the field if the kernel later does not deposit into it,
     // the field might not be allocated. Use -1 as dummy component instead
-    const std::string beam_str = Hipace::GetInstance().m_explicit ? "_beam" : "";
+    const std::string beam_str = Hipace::m_explicit ? "_beam" : "";
     const int     jxb_cmp = do_beam_jx_jy_deposition  ? Comps[which_slice]["jx"    +beam_str] : -1;
     const int     jyb_cmp = do_beam_jx_jy_deposition  ? Comps[which_slice]["jy"    +beam_str] : -1;
     const int     jzb_cmp = do_beam_jz_deposition     ? Comps[which_slice]["jz"    +beam_str] : -1;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -298,7 +298,7 @@ IonizationModule (const int lev,
         const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
                                          PhysConstSI::q_e*PhysConstSI::q_e /
                                          (PhysConstSI::ep0 * PhysConstSI::m_e) );
-        const amrex::Real E0 = Hipace::GetInstance().m_normalized_units ?
+        const amrex::Real E0 = Hipace::m_normalized_units ?
                                wp * PhysConstSI::m_e * PhysConstSI::c / PhysConstSI::q_e : 1;
 
         int * const ion_lev = soa_ion.GetIntData(PlasmaIdx::ion_lev).data();

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -319,7 +319,7 @@ InitIonizationModule (const amrex::Geometry& geom, PlasmaParticleContainer* prod
 
     if (!m_can_ionize) return;
 
-    const bool normalized_units = Hipace::GetInstance().m_normalized_units;
+    const bool normalized_units = Hipace::m_normalized_units;
     if (normalized_units) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(background_density_SI!=0,
             "For ionization with normalized units, a background plasma density != 0 must "

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -29,7 +29,7 @@ AdvanceBeamParticlesSlice (
     const bool do_z_push = beam.m_do_z_push;
     const int n_subcycles = beam.m_n_subcycles;
     const bool radiation_reaction = beam.m_do_radiation_reaction;
-    const amrex::Real dt = Hipace::m_dt / n_subcycles;
+    const amrex::Real dt = Hipace::GetInstance().m_dt / n_subcycles;
     const amrex::Real background_density_SI = Hipace::m_background_density_SI;
     const bool normalized_units = Hipace::m_normalized_units;
 

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -91,7 +91,7 @@ AdaptiveTimeStep::Calculate (
 
     // Extract properties associated with physical size of the box
     const int nbeams = beams.get_nbeams();
-    const int numprocs_z = Hipace::GetInstance().m_numprocs_z;
+    const int numprocs_z = Hipace::m_numprocs_z;
 
     amrex::Vector<amrex::Real> new_dts;
     new_dts.resize(nbeams);

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -50,7 +50,7 @@ GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, i
 
     for ( amrex::MFIter mfi(S, DfltMfiTlng); mfi.isValid(); ++mfi ){
         const amrex::Box& bx = mfi.tilebox();
-        Array2<amrex::Real> const jz_arr = S.array(mfi, Hipace::GetInstance().m_explicit ?
+        Array2<amrex::Real> const jz_arr = S.array(mfi, Hipace::m_explicit ?
             Comps[WhichSlice::This]["jz_beam"] : Comps[WhichSlice::This]["jz"]);
 
         amrex::ParallelFor( bx,


### PR DESCRIPTION
This small cleaning PR removes some redundant `GetInstance()` calls and makes a few parameters static inline that should be static inline.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
