### PR TITLE
[mini] remove passing of ibox

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -439,7 +439,7 @@ Hipace::Evolve ()
 
             ResizeFDiagFAB(it, step);
 
-            m_multi_beam.findParticlesInEachSlice(it, bx, m_3D_geom[0]);
+            m_multi_beam.findParticlesInEachSlice(bx, m_3D_geom[0]);
             AMREX_ALWAYS_ASSERT( bx.bigEnd(Direction::z) >= bx.smallEnd(Direction::z) + 2 );
             // Solve head slice
             SolveOneSlice(bx.bigEnd(Direction::z), bx.length(Direction::z) - 1, step);

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -43,12 +43,11 @@ public:
         const bool do_beam_rhomjz_deposition, const int which_slice);
 
     /** Loop over all beam species and build and return the indices of particles sorted per slice
-     * \param[in] ibox box index
      * \param[in] bx 3D box on which per-slice sorting is done
      * \param[in] geom Geometry of the simulation domain
      */
     void
-    findParticlesInEachSlice (int ibox, amrex::Box bx, amrex::Geometry const& geom);
+    findParticlesInEachSlice (amrex::Box bx, amrex::Geometry const& geom);
     /** \brief Loop over all beam species and sort particles by box
      *
      * \param[in] a_ba BoxArray object to put the particles into

--- a/src/particles/beam/MultiBeam.cpp
+++ b/src/particles/beam/MultiBeam.cpp
@@ -58,10 +58,10 @@ MultiBeam::DepositCurrentSlice (
 }
 
 void
-MultiBeam::findParticlesInEachSlice (int ibox, amrex::Box bx, amrex::Geometry const& geom)
+MultiBeam::findParticlesInEachSlice (amrex::Box bx, amrex::Geometry const& geom)
 {
     for (int i=0; i<m_nbeams; i++) {
-        ::findParticlesInEachSlice(ibox, bx, m_all_beams[i], geom);
+        ::findParticlesInEachSlice(bx, m_all_beams[i], geom);
     }
     amrex::Gpu::streamSynchronize();
 }

--- a/src/particles/sorting/SliceSort.H
+++ b/src/particles/sorting/SliceSort.H
@@ -17,13 +17,11 @@
  *
  * Note that this does *not* rearrange particle arrays
  *
- * \param[in] ibox index of the box
  * \param[in] bx 3d box in which particles are sorted per slice
  * \param[in] beam Beam particle container
  * \param[in] geom Geometry
  */
 void
-findParticlesInEachSlice (
-    int ibox, amrex::Box bx, BeamParticleContainer& beam, amrex::Geometry const& geom);
+findParticlesInEachSlice (amrex::Box bx, BeamParticleContainer& beam, amrex::Geometry const& geom);
 
 #endif // HIPACE_SLICESORT_H_

--- a/src/particles/sorting/SliceSort.cpp
+++ b/src/particles/sorting/SliceSort.cpp
@@ -12,16 +12,15 @@
 #include <AMReX_ParticleTransformation.H>
 
 void
-findParticlesInEachSlice (
-    int ibox, amrex::Box bx, BeamParticleContainer& beam, amrex::Geometry const& geom)
+findParticlesInEachSlice (amrex::Box bx, BeamParticleContainer& beam, amrex::Geometry const& geom)
 {
     HIPACE_PROFILE("findParticlesInEachSlice()");
 
     // Slice box: only 1 cell transversally, same as bx longitudinally.
     amrex::Box cbx ({0,0,bx.smallEnd(2)}, {0,0,bx.bigEnd(2)});
 
-    const int np = beam.m_box_sorter.boxCountsPtr()[ibox];
-    const int offset = beam.m_box_sorter.boxOffsetsPtr()[ibox];
+    const int np = beam.m_box_sorter.boxCountsPtr()[beam.m_ibox];
+    const int offset = beam.m_box_sorter.boxOffsetsPtr()[beam.m_ibox];
 
     // Extract box properties
     const auto lo = lbound(cbx);


### PR DESCRIPTION
We were still passing the box of the beam to some functions that although we created a nice helperfunction `SetIbox` so we can access it directly. This small PR cleans this for `findParticlesInEachSlice`

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
