### PR TITLE
Remove z component from plasma

### DIFF
--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -21,8 +21,8 @@
 struct PlasmaIdx
 {
     enum {
-        x=0, y, z,          // position
-        w,                  // weight
+        x=0, y,             // position
+        w,                  // weight, this will be returned by pos(2)
         ux, uy,             // momentum
         psi,                // pseudo-potential at the particle position. ATTENTION what is stored is actually normalized psi+1
         x_prev, y_prev,     // positions on the last non-temp slice

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -410,7 +410,6 @@ IonizationModule (const int lev,
                 int_arrdata_elec[PlasmaIdx::cpu][pidx] = lev; // current level
                 arrdata_elec[PlasmaIdx::x      ][pidx] = arrdata_ion[PlasmaIdx::x     ][ip];
                 arrdata_elec[PlasmaIdx::y      ][pidx] = arrdata_ion[PlasmaIdx::y     ][ip];
-                arrdata_elec[PlasmaIdx::z      ][pidx] = arrdata_ion[PlasmaIdx::z     ][ip];
 
                 arrdata_elec[PlasmaIdx::w      ][pidx] = arrdata_ion[PlasmaIdx::w     ][ip];
                 arrdata_elec[PlasmaIdx::ux     ][pidx] = 0._rt;

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -211,7 +211,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
 
                 amrex::Real x = plo[0] + (i + r[0] + x_offset)*dx[0];
                 amrex::Real y = plo[1] + (j + r[1] + y_offset)*dx[1];
-                amrex::Real z = plo[2] + (k + r[2])*dx[2];
 
                 const amrex::Real rsq = x*x + y*y;
                 if (x >= a_bounds.hi(0) || x < a_bounds.lo(0) ||
@@ -227,7 +226,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 int_arrdata[PlasmaIdx::cpu][pidx] = 0; // level 0
                 arrdata[PlasmaIdx::x      ][pidx] = x;
                 arrdata[PlasmaIdx::y      ][pidx] = y;
-                arrdata[PlasmaIdx::z      ][pidx] = z;
 
                 arrdata[PlasmaIdx::w      ][pidx] = scale_fac * density_func(x, y, c_t);
                 arrdata[PlasmaIdx::ux     ][pidx] = u[0] * c_light;
@@ -279,7 +277,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                     int_arrdata[PlasmaIdx::cpu][midx] = 0; // level 0
                     arrdata[PlasmaIdx::x][midx] = x_arr[imirror];
                     arrdata[PlasmaIdx::y][midx] = y_arr[imirror];
-                    arrdata[PlasmaIdx::z][midx] = arrdata[PlasmaIdx::z][pidx];
 
                     arrdata[PlasmaIdx::w][midx] = arrdata[PlasmaIdx::w][pidx];
                     arrdata[PlasmaIdx::ux][midx] = arrdata[PlasmaIdx::ux][pidx] * ux_arr[imirror];


### PR DESCRIPTION
The z component for the plasma has always been fully useless since it is 2D. Thanks to PureSoA it is now possible to remove it. Note that `.pos(2)` will now return the weight.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
