### PR TITLE
remove OK assert

### DIFF
--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -304,8 +304,6 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
     });
 }
     }
-
-    AMREX_ASSERT(OK());
 }
 
 void


### PR DESCRIPTION
OK() checks if numParticlesOutOfRange is zero but that doesn't work anymore since #984. Previously z was always zero but now it is equal to the particle weight so the check fails.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
