### PR TITLE
break loop over time steps for max_time

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -463,7 +463,9 @@ Hipace::Evolve ()
             WriteDiagnostics(step, it, OpenPMDWriterCallType::fields);
             Notify(step, it);
         }
-
+        // exit loop over time steps, if max time is exceeded
+        if (m_physical_time > m_max_time) break;
+        
         m_multi_beam.InSituWriteToFile(step, m_physical_time, m_3D_geom[0]);
         m_multi_plasma.InSituWriteToFile(step, m_physical_time, m_3D_geom[0]);
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -465,7 +465,7 @@ Hipace::Evolve ()
         }
         // exit loop over time steps, if max time is exceeded
         if (m_physical_time > m_max_time) break;
-        
+
         m_multi_beam.InSituWriteToFile(step, m_physical_time, m_3D_geom[0]);
         m_multi_plasma.InSituWriteToFile(step, m_physical_time, m_3D_geom[0]);
 


### PR DESCRIPTION
Previously, if `max_time` as reached, only the loop over boxes was exited. Therefore, the loop over time steps continued, causing not only redundant overhead, but also causing the insitu diags to still write faulty data.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
