### PR TITLE
Cut box to plasma radius in init

### DIFF
--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -60,7 +60,21 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
 
     for(amrex::MFIter mfi = MakeMFIter(lev, DfltMfi); mfi.isValid(); ++mfi)
     {
-        const amrex::Box& tile_box  = mfi.tilebox(box_nodal, box_grow);
+        amrex::Box tile_box  = mfi.tilebox(box_nodal, box_grow);
+
+        if (a_radius != std::numeric_limits<amrex::Real>::infinity()) {
+            amrex::IntVect lo_limit {
+                static_cast<int>(std::round((-a_radius - plo[0])/dx[0] - 2)),
+                static_cast<int>(std::round((-a_radius - plo[1])/dx[1] - 2)),
+                tile_box.smallEnd(2)
+            };
+            amrex::IntVect hi_limit {
+                static_cast<int>(std::round(( a_radius - plo[0])/dx[0] + 2)),
+                static_cast<int>(std::round(( a_radius - plo[1])/dx[1] + 2)),
+                tile_box.bigEnd(2)
+            };
+            tile_box &= amrex::Box(lo_limit, hi_limit, box_nodal);
+        }
 
         const auto lo = amrex::lbound(tile_box);
         const auto hi = amrex::ubound(tile_box);


### PR DESCRIPTION
This can speed up initialization of a high-ppc plasma with a small radius if `plasma.radius` is used.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
