### PR TITLE
[mini] reset ID incrementor before starting initializing a beam

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -483,6 +483,9 @@ which are valid only for certain beam types, are introduced further below under
     Whether the beam particles are pushed along the z-axis. The momentum is still fully updated.
     Note: using ``do_z_push = 0`` results in unphysical behavior.
 
+* ``<beam name> or beams.do_reset_id_init`` (`bool`) optional (default `0`)
+    Wheter to reset the ID incrementor to 1 before initializing beam particles.
+
 Option: ``fixed_weight``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -175,7 +175,8 @@ public:
     BeamBins m_slice_bins;
 
     unsigned long long m_total_num_particles {0};
-
+    /** Whether to reset the global ID incrementor to 1 before initializing this beam */
+    bool m_do_reset_id_init {false};
     unsigned long long get_total_num_particles () const {return m_total_num_particles;}
 
     /** \brief Store the finest level of every beam particle on which_slice in the cpu() attribute.

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -12,6 +12,7 @@
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/InsituUtil.H"
+#include <AMReX_AmrParticles.H>
 #include <AMReX_Particles.H>
 #ifdef HIPACE_USE_OPENPMD
 #   include <openPMD/auxiliary/Filesystem.hpp>

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -12,6 +12,7 @@
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/InsituUtil.H"
+#include <AMReX_Particles.H>
 #ifdef HIPACE_USE_OPENPMD
 #   include <openPMD/auxiliary/Filesystem.hpp>
 #endif

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -62,6 +62,7 @@ BeamParticleContainer::ReadParameters ()
     queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
     queryWithParser(pp, "n_subcycles", m_n_subcycles);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_n_subcycles >= 1, "n_subcycles must be >= 1");
+    queryWithParserAlt(pp, "do_reset_id_init", m_do_reset_id_init, pp_alt);
     queryWithParser(pp, "do_salame", m_do_salame);
     if (m_injection_type == "fixed_ppc" || m_injection_type == "from_file"){
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_duz_per_uz0_dzeta == 0.,
@@ -76,6 +77,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
     amrex::ParmParse pp(m_name);
     amrex::ParmParse pp_alt("beams");
     amrex::Real ptime {0.};
+    if (m_do_reset_id_init) ParticleType::NextID(1);
     if (m_injection_type == "fixed_ppc") {
 
         queryWithParser(pp, "ppc", m_ppc);

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -12,7 +12,6 @@
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/InsituUtil.H"
-#include "particles/particles_utils/ParticleUtil.H"
 #ifdef HIPACE_USE_OPENPMD
 #   include <openPMD/auxiliary/Filesystem.hpp>
 #endif

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -12,8 +12,7 @@
 #include "Hipace.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/InsituUtil.H"
-#include <AMReX_AmrParticles.H>
-#include <AMReX_Particles.H>
+#include "particles/particles_utils/ParticleUtil.H"
 #ifdef HIPACE_USE_OPENPMD
 #   include <openPMD/auxiliary/Filesystem.hpp>
 #endif


### PR DESCRIPTION
Add an option, see title.