### PR TITLE
Add output_input option

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -117,6 +117,11 @@ General parameters
     Whether the beam contribution to :math:`j_z-c\rho` is calculated and used when solving for Psi (used to caculate the transverse fields Ex-By and Ey+Bx).
     if 0, this term is assumed to be 0 (a good approximation for an ultra-relativistic beam in the z direction with small transverse momentum).
 
+* ``hipace.output_input`` (`bool`) optional (default `0`)
+    Print all input parameters before running the simulation.
+    If a parameter is present multiple times then the last occurrence will be used.
+    Note that this will include some default AMReX parameters.
+
 Geometry
 --------
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -243,6 +243,17 @@ Hipace::InitData ()
         m_adaptive_time_step.CalculateFromDensity(m_physical_time, m_dt, m_multi_plasma);
     }
     m_fields.checkInit();
+
+    amrex::ParmParse pph("hipace");
+    bool do_output_input = false;
+    queryWithParser(pph, "output_input", do_output_input);
+    if (do_output_input && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::OutStream() <<
+            "Input parameters:==================================================================\n";
+        amrex::ParmParse::dumpTable(amrex::OutStream(), true);
+        amrex::OutStream() <<
+            "===================================================================================\n";
+    }
 }
 
 void


### PR DESCRIPTION
Add option `hipace.output_input = true` to print all input parameters.

```
CUDA 11.8 loaded
MPI initialized with 4 MPI processes
MPI initialized with thread support level 0
Initializing CUDA...
CUDA initialized with 1 device.
AMReX (23.07-27-gb523c3297d00) initialized
HiPACE++ (23.07-nogit) running in double precision
using CUDA version 11.8.89
using the leapfrog plasma particle pusher
using C2R cuFFT of sizes 513 and 513 with 9 MiB of work area
Input parameters:==================================================================
max_step = 9
hipace.dt = 0
amr.n_cell = nx ny nzeta
hipace.bxby_solver = explicit
hipace.verbose = 1
hipace.depos_order_xy = 2
hipace.depos_derivative_type = 2
my_constants.n0 = 1
my_constants.wp_inv = sqrt( m_e * epsilon0 / q_e**2 / n0 )
my_constants.kp_inv = clight * wp_inv
my_constants.cfl = sqrt(3)/2
my_constants.nx = 512
my_constants.dx = 0.1*kp_inv
my_constants.ny = 512
my_constants.dy = 0.1*kp_inv
my_constants.dzeta = dx*cfl/sqrt(3)
my_constants.nzeta = 100
lasers.names = no_laser
beams.names = no_beam
plasmas.names = electron
electron.ppc = 16 16
electron.u_mean = 0 0 0
electron.u_std = 0.1 0.1 0.1
electron.element = electron
electron.density(x,y,z) = n0
electron.reorder_period = 3
electron.reorder_idx_type = 0 0
diagnostic.output_period = 0
diagnostic.diag_type = xz
hipace.do_device_synchronize = 0
amrex.vector_growth_factor = 1.05
hipace.file_prefix = diags/new/remi_scan
driver.insitu_file_prefix(nvals = 1)  :: [diags/new/remi_scan/insitu_driver]
witness.insitu_file_prefix(nvals = 1)  :: [diags/new/remi_scan/insitu_witness]
hipace.output_input = true
amrex.the_arena_is_managed = 0
amrex.v = 1
amrex.verbose = 1
amrex.max_gpu_streams = 4
device.v = 0
device.verbose = 0
device.numThreads.x = 0
device.numThreads.y = 0
device.numThreads.z = 0
device.numBlocks.x = 0
device.numBlocks.y = 0
device.numBlocks.z = 0
device.graph_init = 0
device.graph_init_nodes = 10000
amrex.regtest_reduction = 0
amrex.signal_handling = 1
amrex.throw_exception = 0
amrex.call_addr2line = 1
amrex.abort_on_unused_inputs = 0
amrex.handle_sigsegv = 1
amrex.handle_sigterm = 0
amrex.handle_sigint = 1
amrex.handle_sigabrt = 1
amrex.handle_sigfpe = 1
amrex.fpe_trap_invalid = 0
amrex.fpe_trap_zero = 0
amrex.fpe_trap_overflow = 0
amrex.use_gpu_aware_mpi = 0
amrex.the_arena_init_size = 7937064960
amrex.the_device_arena_init_size = 8388608
amrex.the_managed_arena_init_size = 8388608
amrex.the_pinned_arena_init_size = 8388608
amrex.the_comms_arena_init_size = 8388608
amrex.the_arena_release_threshold = 9223372036854775807
amrex.the_device_arena_release_threshold = 9223372036854775807
amrex.the_managed_arena_release_threshold = 9223372036854775807
amrex.the_pinned_arena_release_threshold = 42331013120
amrex.the_comms_arena_release_threshold = 9223372036854775807
amrex.the_async_arena_release_threshold = 9223372036854775807
amrex.abort_on_out_of_gpu_memory = 0
fab.init_snan = 0
DistributionMapping.v = 0
DistributionMapping.verbose = 0
DistributionMapping.efficiency = 0.90000000000000002
DistributionMapping.sfc_threshold = 0
DistributionMapping.node_size = 0
DistributionMapping.verbose_mapper = 0
fab.initval = nan
fab.do_initval = 0
fabarray.maxcomp = 25
vismf.v = 0
vismf.headerversion = 1
vismf.groupsets = 0
vismf.setbuf = 1
vismf.usesingleread = 0
vismf.usesinglewrite = 0
vismf.checkfilepositions = 0
vismf.usepersistentifstreams = 0
vismf.usesynchronousreads = 0
vismf.usedynamicsetselection = 1
vismf.iobuffersize = 2097152
vismf.allowsparsewrites = 1
amrex.async_out = 0
amrex.async_out_nfiles = 64
machine.verbose = 0
machine.very_verbose = 0
tiny_profiler.device_synchronize_around_region = 0
tiny_profiler.verbose = 0
tiny_profiler.v = 0
amrex.use_profiler_syncs = 0
geometry.is_periodic = 1 1 0
geometry.prob_lo = 0 0 0
geometry.prob_hi = 272081574.99300021 272081574.99300021 26570466.307910178
particles.do_tiling = 0
particles.use_prepost = 0
particles.do_unlink = 1
particles.do_mem_efficient_sort = 1
===================================================================================
Rank 3 started  step 0 at time = 0 with dt = 0
Rank 2 started  step 1 at time = 0 with dt = 0
Rank 1 started  step 2 at time = 0 with dt = 0
Rank 0 started  step 3 at time = 0 with dt = 0
...
```


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
