### PR TITLE
fix B field conversion in radiation reactions in normalized units

### DIFF
--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -227,9 +227,9 @@ AdvanceBeamParticlesSlice (
                         Exp *= E0;
                         Eyp *= E0;
                         Ezp *= E0;
-                        Bxp *= E0;
-                        Byp *= E0;
-                        Bzp *= E0;
+                        Bxp *= E0*inv_clight_SI;
+                        Byp *= E0*inv_clight_SI;
+                        Bzp *= E0*inv_clight_SI;
                     }
                     const amrex::ParticleReal gamma_intermediate = std::sqrt(
                         1._rt + ( ux_intermediate*ux_intermediate


### PR DESCRIPTION
There was a factor of c missing in the conversion from the fields in normalized units to SI units in the radiation reactions module.
This error was unnoticed because normalized units were only tested with an external field without B components.
(SI units were tested in a real blowout case).

This PR should not conflict with #991 and can be merged independently.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
