### PR TITLE
Include SALAME beam profile in first output iteration

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -521,16 +521,16 @@ Hipace::SolveOneSlice (int islice, int step)
         PredictorCorrectorLoopToSolveBxBy(islice, current_N_level, step);
     }
 
-    // get beam diagnostics after SALAME but before beam push
-    m_multi_beam.InSituComputeDiags(step, islice, m_max_step, m_physical_time, m_max_time);
-    FillBeamDiagnostics(step);
-
     if (m_multi_beam.isSalameNow(step)) {
         // Modify the beam particle weights on this slice to flatten Ez.
         // As the beam current is modified, Bx and By are also recomputed.
         SalameModule(this, m_salame_n_iter, m_salame_do_advance, m_salame_last_slice,
                     m_salame_overloaded, current_N_level, step, islice);
     }
+
+    // get beam diagnostics after SALAME but before beam push
+    m_multi_beam.InSituComputeDiags(step, islice, m_max_step, m_physical_time, m_max_time);
+    FillBeamDiagnostics(step);
 
     // copy fields to diagnostic array
     for (int lev=0; lev<current_N_level; ++lev) {

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -436,9 +436,7 @@ Hipace::SolveOneSlice (int islice, int step)
         m_multi_buffer.get_data(islice, m_multi_beam, m_multi_laser, WhichBeamSlice::This);
     }
 
-    m_multi_beam.InSituComputeDiags(step, islice, m_max_step, m_physical_time, m_max_time);
     m_multi_plasma.InSituComputeDiags(step, islice, m_max_step, m_physical_time, m_max_time);
-    FillBeamDiagnostics(step);
 
     if (m_N_level > 1) {
         m_multi_beam.TagByLevel(current_N_level, m_3D_geom, WhichSlice::This);
@@ -522,6 +520,10 @@ Hipace::SolveOneSlice (int islice, int step)
         // Solves Bx and By in the current slice and modifies the force terms of the plasma particles
         PredictorCorrectorLoopToSolveBxBy(islice, current_N_level, step);
     }
+
+    // get beam diagnostics after SALAME but before beam push
+    m_multi_beam.InSituComputeDiags(step, islice, m_max_step, m_physical_time, m_max_time);
+    FillBeamDiagnostics(step);
 
     if (m_multi_beam.isSalameNow(step)) {
         // Modify the beam particle weights on this slice to flatten Ez.


### PR DESCRIPTION
Previously iteration 0 of the beam diagnostics (both full and insitu) did not include the SALAME beam profile because they were collected before SALAME was run. In this PR the beam diagnostics is collected after SALAME.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
