### PR TITLE
Add deposit_rho_individual option

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -732,7 +732,8 @@ Field diagnostics
     For the explicit solver, the current and charge densities of the beam and
     for all plasmas are separated: ``jx_beam jy_beam jz_beam`` and ``jx jy rhomjz`` are available.
     If ``rho`` is explicitly mentioned as ``field_data``, it is deposited by the plasma
-    to be available as a diagnostic.
+    to be available as a diagnostic. Similarly if ``rho_<plasma name>`` is explicitly mentioned,
+    the charge density of that plasma species will be separately available as a diagnostic.
     When a laser pulse is used, the real and imaginary parts of the laser complex envelope are written in ``laser_real`` and ``laser_imag``, respectively.
     The plasma proper density (n/gamma) is then also accessible via ``chi``.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -747,6 +747,11 @@ Field diagnostics
     Otherwise only ``rhomjz`` equal to :math:`\rho-j_z/c` will be available.
     If ``rho`` is explicitly mentioned in ``diagnostic.field_data``, then the default will become `1`.
 
+* ``hipace.deposit_rho_individual`` (`bool`) optional (default `0`)
+    This option works similar to ``hipace.deposit_rho``,
+    however the charge density from every plasma species will be deposited into individual fields
+    that are accessible as ``rho_<plasma name>`` in ``diagnostic.field_data``.
+
 In-situ diagnostics
 ^^^^^^^^^^^^^^^^^^^
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -218,8 +218,10 @@ public:
     inline static bool m_do_beam_jx_jy_deposition = true;
     /** Whether the jz-c*rho contribution of the beam is computed and used. If not, jz-c*rho=0 is assumed */
     inline static bool m_do_beam_jz_minus_rho = false;
-    /** Whether to deposit  rho (plasma) for diagnostics */
+    /** Whether to deposit rho (plasma) for diagnostics */
     inline static bool m_deposit_rho = false;
+    /** Whether to deposit rho for every individual plasma for diagnostics */
+    inline static bool m_deposit_rho_individual = false;
     /** Whether to use tiling for particle operations */
 #ifdef AMREX_USE_GPU
     inline static bool m_do_tiling = false;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -94,6 +94,8 @@ Hipace::Hipace () :
     queryWithParser(pph, "do_beam_jz_minus_rho", m_do_beam_jz_minus_rho);
     m_deposit_rho = m_diags.needsRho();
     queryWithParser(pph, "deposit_rho", m_deposit_rho);
+    m_deposit_rho_individual = m_diags.needsRhoIndividual();
+    queryWithParser(pph, "deposit_rho_individual", m_deposit_rho_individual);
     queryWithParser(pph, "do_device_synchronize", DO_DEVICE_SYNCHRONIZE);
     bool do_mfi_sync = false;
     queryWithParser(pph, "do_MFIter_synchronize", do_mfi_sync);
@@ -460,16 +462,16 @@ Hipace::SolveOneSlice (int islice, int step)
 
         if (m_explicit) {
             // deposit jx, jy, chi and rhomjz for all plasmas
-            m_multi_plasma.DepositCurrent(m_fields, m_multi_laser, WhichSlice::This,
-                true, false, m_deposit_rho, true, true, m_3D_geom, lev);
+            m_multi_plasma.DepositCurrent(m_fields, m_multi_laser, WhichSlice::This, true, false,
+                m_deposit_rho || m_deposit_rho_individual, true, true, m_3D_geom, lev);
 
             // deposit jz_beam and maybe rhomjz of the beam on This slice
             m_multi_beam.DepositCurrentSlice(m_fields, m_3D_geom, lev, step,
                 false, true, m_do_beam_jz_minus_rho, WhichSlice::This, WhichBeamSlice::This);
         } else {
             // deposit jx jy jz (maybe chi) and rhomjz
-            m_multi_plasma.DepositCurrent(m_fields, m_multi_laser, WhichSlice::This,
-                true, true, m_deposit_rho, m_use_laser, true, m_3D_geom, lev);
+            m_multi_plasma.DepositCurrent(m_fields, m_multi_laser, WhichSlice::This, true, true,
+                m_deposit_rho || m_deposit_rho_individual, m_use_laser, true, m_3D_geom, lev);
 
             // deposit jx jy jz and maybe rhomjz on This slice
             m_multi_beam.DepositCurrentSlice(m_fields, m_3D_geom, lev, step,

--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -130,6 +130,10 @@ public:
      */
     bool needsRho () const;
 
+    /** \brief determines if rho for every individual plasma is requested as a diagnostic
+     */
+    bool needsRhoIndividual () const;
+
     /** \brief calculate box which possibly was trimmed in case of slice IO
      *
      * \param[in] slice_dir slicing direction

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -97,6 +97,23 @@ Diagnostic::needsRho () const {
     return false;
 }
 
+bool
+Diagnostic::needsRhoIndividual () const {
+    amrex::ParmParse ppd("diagnostic");
+    for (auto& fd : m_field_data) {
+        amrex::ParmParse pp(fd.m_diag_name);
+        amrex::Vector<std::string> comps{};
+        queryWithParserAlt(pp, "field_data", comps, ppd);
+        for (auto& c : comps) {
+            // we don't know the names of all the plasmas here so just look for "rho_..."
+            if (c.find("rho_") == 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void
 Diagnostic::Initialize (const int lev, bool do_laser) {
     if (lev!=0) return;

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -83,6 +83,11 @@ Fields::AllocData (
             if (Hipace::m_deposit_rho) {
                 Comps[isl].multi_emplace(N_Comps, "rho");
             }
+            if (Hipace::m_deposit_rho_individual) {
+                for (auto& plasma_name : Hipace::GetInstance().m_multi_plasma.GetNames()) {
+                    Comps[isl].multi_emplace(N_Comps, "rho_" + plasma_name);
+                }
+            }
 
             isl = WhichSlice::Previous;
             Comps[isl].multi_emplace(N_Comps, "jx_beam", "jy_beam");
@@ -122,6 +127,11 @@ Fields::AllocData (
             }
             if (Hipace::m_deposit_rho) {
                 Comps[isl].multi_emplace(N_Comps, "rho");
+            }
+            if (Hipace::m_deposit_rho_individual) {
+                for (auto& plasma_name : Hipace::GetInstance().m_multi_plasma.GetNames()) {
+                    Comps[isl].multi_emplace(N_Comps, "rho_" + plasma_name);
+                }
             }
 
             isl = WhichSlice::Previous;
@@ -504,11 +514,7 @@ Fields::InitializeSlices (int lev, int islice, const amrex::Vector<amrex::Geomet
 {
     HIPACE_PROFILE("Fields::InitializeSlices()");
 
-    const bool explicit_solve = Hipace::GetInstance().m_explicit;
-    const bool deposit_rho = Hipace::GetInstance().m_deposit_rho;
-    const bool use_laser = Hipace::GetInstance().m_use_laser;
-
-    if (explicit_solve) {
+    if (Hipace::m_explicit) {
         if (lev != 0 && islice == geom[lev].Domain().bigEnd(Direction::z)) {
             // first slice of lev (islice goes backwards)
             // iterpolate jx_beam and jy_beam from lev-1 to lev
@@ -527,9 +533,6 @@ Fields::InitializeSlices (int lev, int islice, const amrex::Vector<amrex::Geomet
         setVal(0., lev, WhichSlice::This, "chi", "Sy", "Sx", "ExmBy", "EypBx", "Ez",
             "Bz", "Psi", "jz_beam", "rhomjz");
         setVal(0., lev, WhichSlice::Next, "jx_beam", "jy_beam");
-        if (deposit_rho) {
-            setVal(0., lev, WhichSlice::This, "rho");
-        }
     } else {
         if (lev != 0 && islice == geom[lev].Domain().bigEnd(Direction::z)) {
             // first slice of lev (islice goes backwards)
@@ -543,11 +546,16 @@ Fields::InitializeSlices (int lev, int islice, const amrex::Vector<amrex::Geomet
         }
         setVal(0., lev, WhichSlice::This,
             "ExmBy", "EypBx", "Ez", "Bx", "By", "Bz", "jx", "jy", "jz", "rhomjz", "Psi");
-        if (use_laser) {
+        if (Hipace::m_use_laser) {
             setVal(0., lev, WhichSlice::This, "chi");
         }
-        if (deposit_rho) {
-            setVal(0., lev, WhichSlice::This, "rho");
+    }
+    if (Hipace::m_deposit_rho) {
+        setVal(0., lev, WhichSlice::This, "rho");
+    }
+    if (Hipace::m_deposit_rho_individual) {
+        for (auto& plasma_name : Hipace::GetInstance().m_multi_plasma.GetNames()) {
+            setVal(0., lev, WhichSlice::This, "rho_" + plasma_name);
         }
     }
 }

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -40,6 +40,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLas
     const amrex::Real max_qsa_weighting_factor = plasma.m_max_qsa_weighting_factor;
     const amrex::Real charge = (which_slice == WhichSlice::RhomJzIons) ? -plasma.m_charge : plasma.m_charge;
     const amrex::Real mass = plasma.m_mass;
+    const std::string rho_str = Hipace::m_deposit_rho_individual ? "rho_" + plasma.GetName() : "rho";
 
     // Loop over particle boxes
     for (PlasmaParticleIterator pti(plasma); pti.isValid(); ++pti)
@@ -51,7 +52,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLas
         const int     jx_cmp = deposit_jx_jy  ? Comps[which_slice]["jx"]     : -1;
         const int     jy_cmp = deposit_jx_jy  ? Comps[which_slice]["jy"]     : -1;
         const int     jz_cmp = deposit_jz     ? Comps[which_slice]["jz"]     : -1;
-        const int    rho_cmp = deposit_rho    ? Comps[which_slice]["rho"]    : -1;
+        const int    rho_cmp = deposit_rho    ? Comps[which_slice][rho_str]  : -1;
         const int    chi_cmp = deposit_chi    ? Comps[which_slice]["chi"]    : -1;
         const int rhomjz_cmp = deposit_rhomjz ? Comps[which_slice]["rhomjz"] : -1;
 
@@ -318,5 +319,9 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLas
         if (n_qsa_violation > 0 && (Hipace::m_verbose >= 3))
             amrex::Print()<< "number of QSA violating particles on this slice: " \
                         << n_qsa_violation << "\n";
+    }
+
+    if (Hipace::m_deposit_rho && Hipace::m_deposit_rho_individual) {
+        fields.add(lev, which_slice, {"rho"}, which_slice, {rho_str.c_str()});
     }
 }


### PR DESCRIPTION
This PR adds the option to deposit the charge density of every plasma species into individual fields
Note: The existing `hipace.deposit_rho` option still works, independent of `hipace.deposit_rho_individual`.


Here I artificially separated a uniform electron distribution into 4 species with ring shaped initial profiles using the parser. The charge density of every ring can now be obtained.
Total `rho`:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/d8b55e24-3e97-426c-9854-797ced8345eb)
`rho_elec1`:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/746c573c-bfb4-4f17-ab13-eae27ad65c0d)
`rho_elec2`:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/aa178590-f637-4a73-8297-a1d3129bb7a7)
`rho_elec3`:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/dfce7cfa-62cb-49db-b412-4b4357a5fd1c)
`rho_elec4`:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/b2c78a90-55ea-42cd-9c89-0f825d102fc7)
`rho_ions`:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/2d97533f-d0d1-46d2-b7b5-41eacd867c35)


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
