### PR TITLE
Communicate lambda0 with laser from file

### DIFF
--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -212,8 +212,6 @@ private:
 
     /** if the lasers are initialized from openPMD file */
     bool m_laser_from_file = false;
-    /** if the input file was already read */
-    bool m_input_file_is_read = false;
     /** full 3D laser data stored on the host */
     amrex::FArrayBox m_F_input_file;
     /** path to input openPMD file */


### PR DESCRIPTION
Since only the head rank reads in the laser file which contains lambda0, it needs to be communicated to the other ranks otherwise it is incorrect there.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
