### PR TITLE
set MG_tolerance_abs to numeric_limits min

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -234,7 +234,7 @@ public:
     /** Relative tolerance for the multigrid solver, when using the explicit solver */
     inline static amrex::Real m_MG_tolerance_rel = 1.e-4;
     /** Absolute tolerance for the multigrid solver, when using the explicit solver */
-    inline static amrex::Real m_MG_tolerance_abs = 0.;
+    inline static amrex::Real m_MG_tolerance_abs = std::numeric_limits<amrex::Real>::min();
     /** Level of verbosity for the MG solver */
     inline static int m_MG_verbose = 0;
     /** Whether to use amrex MLMG solver */


### PR DESCRIPTION
If MG_tolerance_abs would go lower than numeric_limits::min(), the MG solver would fail to converge due to loss in precision. Such a scenario could occur if the source term is zero but the initial guess is larger than zero.

Note in my testing this did not stop it from crashing in single precision.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
