### PR TITLE
Fix deposit_rho_individual with neutralizing background and SALAME

### DIFF
--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -40,7 +40,9 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLas
     const amrex::Real max_qsa_weighting_factor = plasma.m_max_qsa_weighting_factor;
     const amrex::Real charge = (which_slice == WhichSlice::RhomJzIons) ? -plasma.m_charge : plasma.m_charge;
     const amrex::Real mass = plasma.m_mass;
-    const std::string rho_str = Hipace::m_deposit_rho_individual ? "rho_" + plasma.GetName() : "rho";
+    // only deposit rho individual on WhichSlice::This
+    const bool deposit_rho_individual = Hipace::m_deposit_rho_individual && which_slice == WhichSlice::This;
+    const std::string rho_str = deposit_rho_individual ? "rho_" + plasma.GetName() : "rho";
 
     // Loop over particle boxes
     for (PlasmaParticleIterator pti(plasma); pti.isValid(); ++pti)
@@ -321,7 +323,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLas
                         << n_qsa_violation << "\n";
     }
 
-    if (Hipace::m_deposit_rho && Hipace::m_deposit_rho_individual) {
+    if (deposit_rho && deposit_rho_individual && Hipace::m_deposit_rho) {
         fields.add(lev, which_slice, {"rho"}, which_slice, {rho_str.c_str()});
     }
 }


### PR DESCRIPTION
- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
