### PR TITLE
add weight for plasma insitu diags and radius

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -794,7 +794,7 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
     Path of the beam in-situ output. Must not be the same as `hipace.file_prefix`.
 
 * ``<beam name> or beams.insitu_radius`` (`float`) optional (default ``infinity``)
-    Maximum radius ``<beam name>.insitu_radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+    Maximum radius ``<beam name>.insitu_radius`` :math:`= \sqrt{x^2 + y^2}` within which particles are
     used for the calculation of the insitu diagnostics.
 
 * ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``0``)
@@ -804,7 +804,7 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
     Path of the plasma in-situ output. Must not be the same as `hipace.file_prefix`.
 
 * ``<plasma name> or plasmas.insitu_radius`` (`float`) optional (default ``infinity``)
-    Maximum radius ``<plasma name>.insitu_radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+    Maximum radius ``<plasma name>.insitu_radius`` :math:`= \sqrt{x^2 + y^2}` within which particles are
     used for the calculation of the insitu diagnostics.
 
 Additional physics

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -793,12 +793,19 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``<beam name> or beams.insitu_file_prefix`` (`string`) optional (default ``"diags/insitu"``)
     Path of the beam in-situ output. Must not be the same as `hipace.file_prefix`.
 
+* ``<beam name> or beams.radius`` (`float`) optional (default ``infinity``)
+    Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+    used for the calculation of the insitu diagnostics.
+
 * ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``0``)
     Period of the plasma in-situ diagnostics. `0` means no plasma in-situ diagnostics.
 
 * ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"plasma_diags/insitu"``)
     Path of the plasma in-situ output. Must not be the same as `hipace.file_prefix`.
 
+* ``<plasma name> or plasmas.radius`` (`float`) optional (default ``infinity``)
+    Maximum radius ``<plasma name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+    used for the calculation of the insitu diagnostics.
 
 Additional physics
 ------------------

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -793,8 +793,8 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``<beam name> or beams.insitu_file_prefix`` (`string`) optional (default ``"diags/insitu"``)
     Path of the beam in-situ output. Must not be the same as `hipace.file_prefix`.
 
-* ``<beam name> or beams.radius`` (`float`) optional (default ``infinity``)
-    Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+* ``<beam name> or beams.insitu_radius`` (`float`) optional (default ``infinity``)
+    Maximum radius ``<beam name>.insitu_radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
     used for the calculation of the insitu diagnostics.
 
 * ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``0``)
@@ -803,8 +803,8 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"plasma_diags/insitu"``)
     Path of the plasma in-situ output. Must not be the same as `hipace.file_prefix`.
 
-* ``<plasma name> or plasmas.radius`` (`float`) optional (default ``infinity``)
-    Maximum radius ``<plasma name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+* ``<plasma name> or plasmas.insitu_radius`` (`float`) optional (default ``infinity``)
+    Maximum radius ``<plasma name>.insitu_radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
     used for the calculation of the insitu diagnostics.
 
 Additional physics

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -210,6 +210,8 @@ private:
     /** Max longitudinal particle position of the beam */
     amrex::Real m_zmax = std::numeric_limits<amrex::Real>::infinity();
     amrex::Real m_radius {std::numeric_limits<amrex::Real>::infinity()}; /**< Radius of the beam */
+    /** radius of the beam insitu diagnostics */
+    amrex::Real m_insitu_radius {std::numeric_limits<amrex::Real>::infinity()};
     GetInitialMomentum m_get_momentum {}; /**< momentum profile of the beam */
 
     // fixed_ppc:

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -60,6 +60,7 @@ BeamParticleContainer::ReadParameters ()
     queryWithParserAlt(pp, "do_radiation_reaction", m_do_radiation_reaction, pp_alt);
     queryWithParserAlt(pp, "insitu_period", m_insitu_period, pp_alt);
     queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
+    queryWithParserAlt(pp, "insitu_radius", m_insitu_radius, pp_alt);
     queryWithParser(pp, "n_subcycles", m_n_subcycles);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_n_subcycles >= 1, "n_subcycles must be >= 1");
     queryWithParserAlt(pp, "do_reset_id_init", m_do_reset_id_init, pp_alt);
@@ -327,6 +328,7 @@ BeamParticleContainer::InSituComputeDiags (int islice)
     AMREX_ALWAYS_ASSERT(m_insitu_rdata.size()>0 && m_insitu_idata.size()>0 &&
                         m_insitu_sum_rdata.size()>0 && m_insitu_sum_idata.size()>0);
 
+    const amrex::Real insitu_radius = m_insitu_radius;
     const PhysConst phys_const = get_phys_const();
     const amrex::Real clight_inv = 1.0_rt/phys_const.c;
     const amrex::Real clightsq_inv = 1.0_rt/(phys_const.c*phys_const.c);
@@ -364,7 +366,8 @@ BeamParticleContainer::InSituComputeDiags (int islice)
         getNumParticles(WhichBeamSlice::This), reduce_data,
         [=] AMREX_GPU_DEVICE (int ip) -> ReduceTuple
         {
-            if (idp[ip] < 0) {
+            if (idp[ip] < 0 ||
+                pos_x[ip]*pos_x[ip] + pos_y[ip]*pos_y[ip] > insitu_radius*insitu_radius) {
                 return{0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt,
                     0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0};
             }

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -163,6 +163,8 @@ public:
      *  the quasi-static approximation and is removed */
     amrex::Real m_max_qsa_weighting_factor {35.};
     amrex::Real m_radius {std::numeric_limits<amrex::Real>::infinity()}; /**< radius of the plasma */
+    /** radius of the plasma insitu diagnostics */
+    amrex::Real m_insitu_radius {std::numeric_limits<amrex::Real>::infinity()};
     amrex::Real m_hollow_core_radius {0.}; /**< hollow core radius of the plasma */
     amrex::IntVect m_ppc {0,0,1}; /**< Number of particles per cell in each direction */
     amrex::RealVect m_u_mean {0,0,0}; /**< Avg momentum in each direction normalized by m*c */

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -121,6 +121,7 @@ PlasmaParticleContainer::ReadParameters ()
 
     queryWithParserAlt(pp, "radius", m_radius, pp_alt);
     queryWithParserAlt(pp, "hollow_core_radius", m_hollow_core_radius, pp_alt);
+    queryWithParserAlt(pp, "insitu_radius", m_insitu_radius, pp_alt);
     queryWithParserAlt(pp, "do_symmetrize", m_do_symmetrize, pp_alt);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_hollow_core_radius < m_radius,
                                      "The hollow core plasma radius must not be smaller than the "
@@ -448,6 +449,7 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
     AMREX_ALWAYS_ASSERT(m_insitu_rdata.size()>0 && m_insitu_idata.size()>0 &&
                         m_insitu_sum_rdata.size()>0 && m_insitu_sum_idata.size()>0);
 
+    const amrex::Real insitu_radius = m_insitu_radius;
     const PhysConst phys_const = get_phys_const();
     const amrex::Real clight_inv = 1.0_rt/phys_const.c;
     const amrex::Real clightsq_inv = 1.0_rt/(phys_const.c*phys_const.c);
@@ -482,9 +484,8 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
                 const amrex::Real uxp  = ptd.rdata(PlasmaIdx::ux )[ip] * clight_inv; // proper velocity to u
                 const amrex::Real uyp  = ptd.rdata(PlasmaIdx::uy )[ip] * clight_inv;
                 const amrex::Real psip = ptd.rdata(PlasmaIdx::psi)[ip];
-                const amrex::Real wp   = ptd.rdata(PlasmaIdx::w  )[ip];
 
-                if (ptd.id(ip) < 0) {
+                if (ptd.id(ip) < 0 || xp*xp + yp*yp > insitu_radius*insitu_radius) {
                     return{0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt,
                         0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0};
                 }
@@ -493,6 +494,7 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
                 const amrex::Real gamma = (1.0_rt + uxp*uxp*clightsq_inv
                                                   + uyp*uyp*clightsq_inv + psip*psip)/(2.0_rt*psip);
                 amrex::Real uzp = (gamma - psip); // the *c from uz cancels with the /c from the proper velocity conversion
+                const amrex::Real wp   = ptd.rdata(PlasmaIdx::w  )[ip] * gamma/psip; // quasi-static weighting factor
 
                 return {wp,
                         wp*xp,


### PR DESCRIPTION
This PR adds the quasi-static weighting factor to the plasma insitu. Additionally, a radius is added such that only particles within a certain range are used for the insitu diagnostics for both beam and plasma


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
