### PR TITLE
add option to fully symmetrize the beam

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -511,12 +511,13 @@ Option: ``fixed_weight``
     :math:`\zeta` is hereby the particle position relative to the mean
     longitudinal position of the beam.
 
-* ``<beam name>.do_symmetrize`` (`bool`) optional (default `0`)
-    Symmetrizes the beam in the transverse phase space. For each particle with (`x`, `y`, `ux`,
+* ``<beam name>.do_symmetrize`` (`int`) optional (default `0`)
+    Symmetrizes the beam in the transverse phase space. If ``<beam name>.do_symmetrize = 1`, for each particle with (`x`, `y`, `ux`,
     `uy`), three further particles are generated with (`-x`, `y`, `-ux`, `uy`), (`x`, `-y`, `ux`,
     `-uy`), and (`-x`, `-y`, `-ux`, `-uy`). The total number of particles will still be
     ``beam_name.num_particles``, therefore this option requires that the beam particle number must be
-    divisible by 4.
+    divisible by 4. If ``<beam name>.do_symmetrize = 2`, the beam is fully symmetrized, such that 15 additional particles are generated.
+    All possible combinations of (`x`, `y`, `ux`, `uy`) are used because then also the product `x*ux` is symmetric. The total number of particles must be divisible by 16.
 
 * ``<beam name>.z_foc`` (`float`) optional (default `0.`)
     Distance at which the beam will be focused, calculated from the position at which the beam is initialized.

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -243,7 +243,7 @@ private:
     amrex::Long m_num_particles; /**< Number of particles for fixed-weight Gaussian beam */
     amrex::Real m_total_charge; /**< Total beam charge for fixed-weight Gaussian beam */
     amrex::Real m_density; /**< Peak density for fixed-weight Gaussian beam */
-    bool m_do_symmetrize {0}; /**< Option to symmetrize the beam */
+    int m_do_symmetrize {0}; /**< Option to symmetrize the beam */
     /** Array for the z position of all beam particles */
     amrex::PODVector<amrex::Real, amrex::PolymorphicArenaAllocator<amrex::Real>> m_z_array {};
 

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -145,7 +145,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
             "To symmetrize the beam, please specify a beam particle number divisible by 4.");
         if (m_do_symmetrize == 2) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_particles%16 == 0,
             "To fully symmetrize the beam, please specify a beam particle number divisible by 16.");
-                
+
         if (peak_density_is_specified)
         {
             m_total_charge = m_density*m_charge;

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -141,9 +141,11 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( charge_is_specified + peak_density_is_specified == 1,
             "Please specify exlusively either total_charge or density of the beam");
         queryWithParser(pp, "do_symmetrize", m_do_symmetrize);
-        if (m_do_symmetrize) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_particles%4 == 0,
+        if (m_do_symmetrize == 1) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_particles%4 == 0,
             "To symmetrize the beam, please specify a beam particle number divisible by 4.");
-
+        if (m_do_symmetrize == 2) AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_particles%16 == 0,
+            "To fully symmetrize the beam, please specify a beam particle number divisible by 16.");
+                
         if (peak_density_is_specified)
         {
             m_total_charge = m_density*m_charge;

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -457,52 +457,52 @@ InitBeamFixedWeightSlice (int slice, int which_slice)
             } else if (do_symmetrize == 2) {
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
                                         z_central, u[0], u[1], u[2], weight,
-                                        pid, 4*i, clight, is_valid);
+                                        pid, 16*i, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
                                         z_central, u[0], -u[1], u[2], weight,
-                                        pid, 4*i+1, clight, is_valid);
+                                        pid, 16*i+1, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
                                         z_central, -u[0], u[1], u[2], weight,
-                                        pid, 4*i+2, clight, is_valid);
+                                        pid, 16*i+2, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
                                         z_central, -u[0], -u[1], u[2], weight,
-                                        pid, 4*i+3, clight, is_valid);
+                                        pid, 16*i+3, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos-y,
                                         z_central, u[0], u[1], u[2], weight,
-                                        pid, 4*i, clight, is_valid);
+                                        pid, 16*i+4, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos-y,
                                         z_central, u[0], -u[1], u[2], weight,
-                                        pid, 4*i+1, clight, is_valid);
+                                        pid, 16*i+5, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos-y,
                                         z_central, -u[0], u[1], u[2], weight,
-                                        pid, 4*i+2, clight, is_valid);
+                                        pid, 16*i+6, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos-y,
                                         z_central, -u[0], -u[1], u[2], weight,
-                                        pid, 4*i+3, clight, is_valid);
+                                        pid, 16*i+7, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos+y,
                                         z_central, u[0], u[1], u[2], weight,
-                                        pid, 4*i, clight, is_valid);
+                                        pid, 16*i+8, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos+y,
                                         z_central, u[0], -u[1], u[2], weight,
-                                        pid, 4*i+1, clight, is_valid);
+                                        pid, 16*i+9, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos+y,
                                         z_central, -u[0], u[1], u[2], weight,
-                                        pid, 4*i+2, clight, is_valid);
+                                        pid, 16*i+10, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos+y,
                                         z_central, -u[0], -u[1], u[2], weight,
-                                        pid, 4*i+3, clight, is_valid);
+                                        pid, 16*i+11, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos-y,
                                         z_central, u[0], u[1], u[2], weight,
-                                        pid, 4*i, clight, is_valid);
+                                        pid, 16*i+12, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos-y,
                                         z_central, u[0], -u[1], u[2], weight,
-                                        pid, 4*i+1, clight, is_valid);
+                                        pid, 16*i+13, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos-y,
                                         z_central, -u[0], u[1], u[2], weight,
-                                        pid, 4*i+2, clight, is_valid);
+                                        pid, 16*i+14, clight, is_valid);
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos-y,
                                         z_central, -u[0], -u[1], u[2], weight,
-                                        pid, 4*i+3, clight, is_valid);
+                                        pid, 16*i+15, clight, is_valid);
             } else {
                 AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
                                         z_central, u[0], u[1], u[2], weight,

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -158,7 +158,7 @@ public:
     bool m_use_density_table; /**< if a density value table was specified */
     /** plasma density value table, key: position=c*time, value=density function string */
     std::map<amrex::Real, std::string> m_density_table;
-    bool m_do_symmetrize = false; /**< Option to symmetrize the plasma */
+    int m_do_symmetrize = 0; /**< Option to symmetrize the plasma */
     /** maximum weighting factor gamma/(Psi +1) before particle is regarded as violating
      *  the quasi-static approximation and is removed */
     amrex::Real m_max_qsa_weighting_factor {35.};

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -331,10 +331,10 @@ InitParticles (const amrex::IntVect& a_num_particles_per_cell,
                 const amrex::Real x_mirror = x_mid2 - x;
                 const amrex::Real y_mirror = y_mid2 - y;
 
-                const amrex::Real x_arr[3] = {x, x, x, x, x, x, x, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror};
-                const amrex::Real y_arr[3] = {y, y, y, y_mirror, y_mirror, y_mirror, y_mirror, y, y, y, y, y_mirror, y_mirror, y_mirror, y_mirror};
-                const amrex::Real ux_arr[3] = {1._rt, -1._rt, -1._rt, 1._rt, 1._rt, -1._rt, -1._rt, 1._rt, 1._rt, -1._rt, -1._rt, 1._rt, 1._rt, -1._rt, -1._rt};
-                const amrex::Real uy_arr[3] = {-1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt};
+                const amrex::Real x_arr[15] = {x, x, x, x, x, x, x, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror, x_mirror};
+                const amrex::Real y_arr[15] = {y, y, y, y_mirror, y_mirror, y_mirror, y_mirror, y, y, y, y, y_mirror, y_mirror, y_mirror, y_mirror};
+                const amrex::Real ux_arr[15] = {1._rt, -1._rt, -1._rt, 1._rt, 1._rt, -1._rt, -1._rt, 1._rt, 1._rt, -1._rt, -1._rt, 1._rt, 1._rt, -1._rt, -1._rt};
+                const amrex::Real uy_arr[15] = {-1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt, 1._rt, -1._rt};
 
 #ifdef AMREX_USE_GPU
 #pragma unroll


### PR DESCRIPTION
This is a revival of #504, which might be needed for ultra low emittance beams. To be tested.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
