### PR TITLE
[mini] update LUMI docs

### DIFF
--- a/docs/source/building/platforms/lumi_csc.rst
+++ b/docs/source/building/platforms/lumi_csc.rst
@@ -75,6 +75,11 @@ You can then create your directory in ``/project/project_<project id>``, where y
     export ROCFFT_RTC_CACHE_PATH=/dev/null
     export OMP_NUM_THREADS=1
 
+    # needed for high nz runs.
+    # if too many mpi messages are send, the hardware counters can overflow, see
+    # https://docs.nersc.gov/performance/network/
+    # export FI_CXI_RX_MATCH_MODE=hybrid
+
     # setting correct CPU binding
     # (see https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/lumig-job/)
     cat << EOF > select_gpu
@@ -86,7 +91,7 @@ You can then create your directory in ``/project/project_<project id>``, where y
 
     chmod +x ./select_gpu
 
-    CPU_BIND="map_cpu:48,56,16,24,1,8,32,40"
+    CPU_BIND="map_cpu:49,57,17,25,1,9,33,41"
 
     srun --cpu-bind=${CPU_BIND} ./select_gpu $HOME/src/hipace/build/bin/hipace inputs
     rm -rf ./select_gpu


### PR DESCRIPTION
With their September update, the CPU bind has changed and must be updated, otherwise the jobs will fail.

Additionally, a new flag is introduced, which is sometimes needed if too many MPI messages are sent.
(seen in an input script with 96 ranks and 25000 longitudinal grid points).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
