### PR TITLE
Workaround std::gcd and std::lcm constexpr issue

### DIFF
--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -80,8 +80,7 @@ private:
 #endif
 
     // round up the capacity of a buffer so there are never any alignment problems
-    static constexpr std::size_t buffer_size_roundup =
-        std::lcm(alignof(amrex::Real), alignof(int)) / std::gcd(alignof(amrex::Real), alignof(int));
+    static constexpr std::size_t buffer_size_roundup = alignof(amrex::Real) / alignof(int);
 
     // 2D array for all metadata
     amrex::Gpu::PinnedVector<std::size_t> m_metadata {};


### PR DESCRIPTION
It seems that `std::gcd` and `std::lcm` are not fully constexpr on some platforms, so this PR replaces the general formular with a simplified version that produces the same result, assuming that `alignof(int) = 4` and `alignof(amrex::Real) = 4 or 8`.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
