### PR TITLE
Add xy_integrated diagnostic type

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -732,7 +732,8 @@ Field diagnostics
     `xz` and `yz` generate 2D field outputs at the center of the y-axis and
     x-axis, respectively. In case of an even number of grid points, the value is averaged
     between the two inner grid points.
-    `xy_integrated` generates 2D field output that has been integrated along the `z` axis.
+    `xy_integrated` generates 2D field output that has been integrated along the `z` axis, i.e.,
+    it is the sum of the 2D field output over all slices multiplied with `dz`.
 
 * ``<diag name> or diagnostic.coarsening`` (3 `int`) optional (default `1 1 1`)
     Coarsening ratio of field output in x, y and z direction respectively. The coarsened output is

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -726,11 +726,13 @@ Field diagnostics
     If ``diagnostic.output_period`` is defined, that value is used as the default for this.
 
 * ``<diag name> or diagnostic.diag_type`` (`string`)
-    Type of field output. Available options are `xyz`, `xz`, `yz`. `xyz` generates a 3D field
-    output. Use 3D output with parsimony, it may increase disk Space usage and simulation time
-    significantly. `xz` and `yz` generate 2D field outputs at the center of the y-axis and
+    Type of field output. Available options are `xyz`, `xz`, `yz` and `xy_integrated`.
+    `xyz` generates a 3D field output.
+    Use 3D output with parsimony, it may increase disk Space usage and simulation time significantly.
+    `xz` and `yz` generate 2D field outputs at the center of the y-axis and
     x-axis, respectively. In case of an even number of grid points, the value is averaged
     between the two inner grid points.
+    `xy_integrated` generates 2D field output that has been integrated along the `z` axis.
 
 * ``<diag name> or diagnostic.coarsening`` (3 `int`) optional (default `1 1 1`)
     Coarsening ratio of field output in x, y and z direction respectively. The coarsened output is

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -939,7 +939,7 @@ Hipace::FillFieldDiagnostics (const int lev, int islice)
             m_fields.Copy(lev, islice, fd.m_geom_io, fd.m_F,
                 fd.m_F.box(), m_3D_geom[lev],
                 fd.m_comps_output_idx, fd.m_nfields,
-                fd.m_do_laser, m_multi_laser);
+                fd.m_do_laser, m_multi_laser, fd.m_slice_dir);
         }
     }
 }

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -51,6 +51,8 @@ Diagnostic::Diagnostic (int nlev)
             fd.m_slice_dir = 1;
         } else if (str_type == "yz") {
             fd.m_slice_dir = 0;
+        } else if (str_type == "xy_integrated") {
+            fd.m_slice_dir = 2;
         } else {
             amrex::Abort("Unknown diagnostics type: must be xyz, xz or yz.");
         }
@@ -62,7 +64,7 @@ Diagnostic::Diagnostic (int nlev)
 
         amrex::Array<int,3> diag_coarsen_arr{1,1,1};
         queryWithParserAlt(pp, "coarsening", diag_coarsen_arr, ppd);
-        if(fd.m_slice_dir == 0 || fd.m_slice_dir == 1) {
+        if(fd.m_slice_dir == 0 || fd.m_slice_dir == 1 || fd.m_slice_dir == 2) {
             diag_coarsen_arr[fd.m_slice_dir] = 1;
         }
         fd.m_diag_coarsen = amrex::IntVect(diag_coarsen_arr);
@@ -286,7 +288,9 @@ Diagnostic::TrimIOBox (int slice_dir, amrex::Box& domain_3d, amrex::RealBox& rbo
         // Flatten the box down to 1 cell in the approprate direction.
         domain_3d.setSmall(slice_dir, 0);
         domain_3d.setBig  (slice_dir, 0);
-        rbox_3d.setLo(slice_dir, mid - half_cell_size);
-        rbox_3d.setHi(slice_dir, mid + half_cell_size);
+        if (slice_dir < 2) {
+            rbox_3d.setLo(slice_dir, mid - half_cell_size);
+            rbox_3d.setHi(slice_dir, mid + half_cell_size);
+        }
     }
 }

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -148,11 +148,12 @@ public:
      * \param[in] ncomp number of components to copy
      * \param[in] do_laser if to copy the laser
      * \param[in] multi_laser MultiLaser object
+     * \param[in] slice_dir slicing direction
      */
      void Copy (const int lev, const int i_slice, const amrex::Geometry& diag_geom,
                 amrex::FArrayBox& diag_fab, amrex::Box diag_box, const amrex::Geometry& calc_geom,
                 const amrex::Gpu::DeviceVector<int>& diag_comps_vect, const int ncomp,
-                bool do_laser, MultiLaser& multi_laser);
+                bool do_laser, MultiLaser& multi_laser, const int slice_dir);
 
      /** \brief Initialize all required fields to zero and interpolate from lev-1 to lev if needed
      *


### PR DESCRIPTION
This diagnostic type integrates 3d field data along z into one xy slice.
```
diagnostic.diag_type = xy_integrated
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
