### PR TITLE
Add interpolate_neutralizing_background option

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -106,6 +106,10 @@ General parameters
     Whether the beam contribution to :math:`j_z-c\rho` is calculated and used when solving for Psi (used to caculate the transverse fields Ex-By and Ey+Bx).
     if 0, this term is assumed to be 0 (a good approximation for an ultra-relativistic beam in the z direction with small transverse momentum).
 
+* ``hipace.interpolate_neutralizing_background`` (`bool`) optional (default `0`)
+    Whether the neutralizing background from plasmas should be interpolated from level 0
+    to higher MR levels instead of depositing it on all levels.
+
 * ``hipace.output_input`` (`bool`) optional (default `0`)
     Print all input parameters before running the simulation.
     If a parameter is present multiple times then the last occurrence will be used.

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -222,6 +222,8 @@ public:
     inline static bool m_deposit_rho = false;
     /** Whether to deposit rho for every individual plasma for diagnostics */
     inline static bool m_deposit_rho_individual = false;
+    /** Whether to interpolate the neutralizing background to MR levels 1 and 2 instead of depositing it */
+    inline static bool m_interpolate_neutralizing_background = false;
     /** Whether to use tiling for particle operations */
 #ifdef AMREX_USE_GPU
     inline static bool m_do_tiling = false;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -95,6 +95,8 @@ Hipace::Hipace () :
     queryWithParser(pph, "deposit_rho", m_deposit_rho);
     m_deposit_rho_individual = m_diags.needsRhoIndividual();
     queryWithParser(pph, "deposit_rho_individual", m_deposit_rho_individual);
+    queryWithParser(pph, "interpolate_neutralizing_background",
+        m_interpolate_neutralizing_background);
     queryWithParser(pph, "do_device_synchronize", DO_DEVICE_SYNCHRONIZE);
     bool do_mfi_sync = false;
     queryWithParser(pph, "do_MFIter_synchronize", do_mfi_sync);
@@ -363,18 +365,30 @@ Hipace::Evolve ()
         // Only reset plasma after receiving time step, to use proper density
         m_multi_plasma.InitData(m_slice_ba, m_slice_dm, m_slice_geom, m_3D_geom);
 
-        // deposit neutralizing background on every MR level
-        if (m_N_level > 1) {
-            m_multi_plasma.TagByLevel(m_N_level, m_3D_geom);
-        }
-
-        for (int lev=0; lev<m_N_level; ++lev) {
+        // deposit neutralizing background
+        if (m_interpolate_neutralizing_background) {
             if (m_do_tiling) {
-                m_multi_plasma.TileSort(m_slice_geom[lev].Domain(), m_slice_geom[lev]);
+                m_multi_plasma.TileSort(m_slice_geom[0].Domain(), m_slice_geom[0]);
             }
-            // Store charge density of (immobile) ions into WhichSlice::RhomJzIons
+            // Store charge density of (immobile) ions into WhichSlice::RhomJzIons of level 0
             m_multi_plasma.DepositNeutralizingBackground(
-                m_fields, m_multi_laser, WhichSlice::RhomJzIons, m_3D_geom, lev);
+                m_fields, m_multi_laser, WhichSlice::RhomJzIons, m_3D_geom, 0);
+            // interpolate neutralizing background to other levels
+            for (int lev=1; lev<m_N_level; ++lev) {
+                m_fields.LevelUp(m_3D_geom, lev, WhichSlice::RhomJzIons, "rhomjz");
+            }
+        } else {
+            if (m_N_level > 1) {
+                m_multi_plasma.TagByLevel(m_N_level, m_3D_geom);
+            }
+            for (int lev=0; lev<m_N_level; ++lev) {
+                if (m_do_tiling) {
+                    m_multi_plasma.TileSort(m_slice_geom[lev].Domain(), m_slice_geom[lev]);
+                }
+                // Store charge density of (immobile) ions into WhichSlice::RhomJzIons
+                m_multi_plasma.DepositNeutralizingBackground(
+                    m_fields, m_multi_laser, WhichSlice::RhomJzIons, m_3D_geom, lev);
+            }
         }
 
         // need correct physical time for this


### PR DESCRIPTION
This helps if the electron ppc is less than 1 relative to level 1, the electrons do not enter level 1 and the electron density profile is flat across level 1.

Deposition
![image](https://github.com/Hi-PACE/hipace/assets/64009254/5977ebfd-f2cf-4ed1-b481-860ad0b8a75e)
Interpolation (Note the scaling, very flat)
![image](https://github.com/Hi-PACE/hipace/assets/64009254/d9453d2e-a9cc-4b97-a13e-49403e2a1d5f)



- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
