### PR TITLE
[mini] build on latest openpmd-api 0.15.2

### DIFF
--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -13,7 +13,7 @@ function(find_openpmd)
     if(HiPACE_openpmd_internal OR HiPACE_openpmd_src)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-        # see https://openpmd-api.readthedocs.io/en/0.15.1/dev/buildoptions.html
+        # see https://openpmd-api.readthedocs.io/en/0.15.2/dev/buildoptions.html
         set(openPMD_USE_MPI         ${HiPACE_openpmd_mpi} CACHE INTERNAL "")
         set(openPMD_USE_PYTHON      OFF                   CACHE INTERNAL "")
         set(openPMD_BUILD_CLI_TOOLS OFF                   CACHE INTERNAL "")
@@ -68,7 +68,7 @@ function(find_openpmd)
         else()
             set(COMPONENT_WMPI NOMPI)
         endif()
-        find_package(openPMD 0.15.1 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
+        find_package(openPMD 0.15.2 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
         message(STATUS "openPMD-api: Found version '${openPMD_VERSION}'")
     endif()
 endfunction()
@@ -84,7 +84,7 @@ if(HiPACE_OPENPMD)
     set(HiPACE_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(HiPACE_openpmd_internal)")
-    set(HiPACE_openpmd_branch "0.15.1"
+    set(HiPACE_openpmd_branch "0.15.2"
         CACHE STRING
         "Repository branch for HiPACE_openpmd_repo if(HiPACE_openpmd_internal)")
 

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -208,7 +208,7 @@ CMake Option                 Default & Values                                   
 ``HiPACE_openpmd_mpi``       ON/OFF (default is set to value of ``HiPACE_MPI``)  Build openPMD with MPI support, although I/O is always serial
 ``HiPACE_openpmd_src``       *None*                                              Path to openPMD-api source directory (preferred if set)
 ``HiPACE_openpmd_repo``      ``https://github.com/openPMD/openPMD-api.git``      Repository URI to pull and build openPMD-api from
-``HiPACE_openpmd_branch``    ``0.15.1``                                          Repository branch for ``HiPACE_openpmd_repo``
+``HiPACE_openpmd_branch``    ``0.15.2``                                          Repository branch for ``HiPACE_openpmd_repo``
 ``HiPACE_openpmd_internal``  **ON**/OFF                                          Needs a pre-installed openPMD-api library if set to ``OFF``
 ``AMReX_LINEAR_SOLVERS``     ON/**OFF**                                          Compile AMReX multigrid solver.
 ===========================  ==================================================  =============================================================


### PR DESCRIPTION
Is there a reason for building on openPMD-api 0.15.1 instead of 0.15.1? This PR proposes to try out 0.15.2.