### PR TITLE
Initialize fixed weight beam from PDF

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -489,14 +489,14 @@ Option: ``fixed_weight_pdf``
     Number of constant weight particles to generate the beam.
 
 * ``<beam name>.pdf`` (`float`)
-    Probability density function to define the longitudinal profile of the beam.
-    The transverse profile is Gaussian. This is a parser function of z
+    Probability density function to define the longitudinal profile of the beam
+    (the transverse profile is Gaussian). This is a parser function of z
     that should return the total amount of charge present on each transverse beam slice.
     This will also be proportional to the per-slice peak density if ``<beam name>.position_mean`` is constant along z,
     if not the pdf can be calculated from the desired peak density using ``<beam name>.pdf = <peak_density(z)> * <position_std_x(z)> * <position_std_y(z)>``.
     The probability density function is automatically normalized so that all constant pre factors
     can be omitted when specifying the function.
-    Examples (relpace `z_center`, `z_std`, `z_length`, `z_slope`, `z_min` and `z_max`):
+    Examples (replace `z_center`, `z_std`, `z_length`, `z_slope`, `z_min` and `z_max`):
     Gaussian: ``exp(-0.5*((z-z_center)/z_std)^2)``
     Cosine: ``(cos(2*pi*(z-z_center)/z_length)+1)*(2*abs(z-z_center)<z_length)``
     Trapezoidal: ``(z<z_max)*(z>z_min)*(1+z_slope*z)``

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -428,29 +428,16 @@ which are valid only for certain beam types, are introduced further below under
 
 
 * ``<beam name>.injection_type`` (`string`)
-    The injection type for the particle beam. Currently available are ``fixed_ppc``, ``fixed_weight``,
-    and ``from_file``. ``fixed_ppc`` generates a beam with a fixed number of particles per cell and
-    varying weights. It can be either a Gaussian or a flattop beam. ``fixed_weight`` generates a
-    Gaussian beam with a fixed number of particles with a constant weight.
+    The injection type for the particle beam. Currently available are ``fixed_ppc``, ``fixed_weight``, ``fixed_weight_pdf``,
+    and ``from_file``.
+    ``fixed_ppc`` generates a beam with a fixed number of particles per cell and
+    varying weights. It can be either a Gaussian or a flattop beam.
+    ``fixed_weight`` generates a Gaussian beam with a fixed number of particles with a constant weight.
+    ``fixed_weight_pdf`` generates a beam with a fixed number of particles with a constant weight where
+    the transverse profile is Gaussian and the longitudinal profile is arbitrary according to a
+    user-specified probability density function. Although it is more general it is faster and uses
+    less memory than ``fixed_weight``.
     ``from_file`` reads a beam from openPMD files.
-
-* ``<beam name>.position_mean`` (3 `float`)
-    The mean position of the beam in ``x, y, z``, separated by a space. For fixed_weight beams the
-    x and y directions can be functions of ``z``. To generate a tilted beam use
-    ``<beam name>.position_mean = "x_center+(z-z_ center)*dx_per_dzeta" "y_center+(z-z_ center)*dy_per_dzeta" "z_center"``.
-
-* ``<beam name>.position_std`` (3 `float`)
-    The rms size of the of the beam in `x, y, z`, separated by a space.
-
-* ``<beam name>.zmin`` (`float`) (default `-infinity`)
-    Minimum in `z` at which particles are injected.
-
-* ``<beam name>.zmax`` (`float`) (default `infinity`)
-    Maximum in `z` at which particles are injected.
-
-* ``<beam name>.radius`` (`float`)
-    Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
-    injected.
 
 * ``<beam name>.element`` (`string`) optional (default `electron`)
     The Physical Element of the plasma. Sets charge, mass and, if available,
@@ -462,15 +449,6 @@ which are valid only for certain beam types, are introduced further below under
 
 * ``<beam name>.charge`` (`float`) optional (default `-q_e`)
     The charge of a beam particle. Can also be set with ``<beam name>.element``.
-
-* ``<beam name>.profile`` (`string`)
-    Beam profile.
-    When ``<beam name>.injection_type == fixed_ppc``, possible options are ``flattop``
-    (flat-top radially and longitudinally), ``gaussian`` (Gaussian in all directions),
-    or ``parsed`` (arbitrary analytic function provided by the user).
-    When ``parsed``, ``<beam name>.density(x,y,z)`` must be specified.
-    When ``<beam name>.injection_type == fixed_weight``, possible options are ``can``
-    (uniform longitudinally, Gaussian transversally) and ``gaussian`` (Gaussian in all directions).
 
 * ``<beam name>.n_subcycles`` (`int`) optional (default `10`)
     Number of sub-cycles performed in the beam particle pusher. The particles will be pushed
@@ -504,9 +482,77 @@ which are valid only for certain beam types, are introduced further below under
 * ``<beam name> or beams.do_reset_id_init`` (`bool`) optional (default `0`)
     Whether to reset the ID incrementor to 1 before initializing beam particles.
 
-* ``<beam name> or beams.initialize_on_cpu`` (`bool`) optional (default `0`)
-    Whether to initialize the beam on the CPU instead of the GPU.
-    Initializing the beam on the CPU can be much slower but is necessary if the full beam does not fit into GPU memory.
+Option: ``fixed_weight_pdf``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``<beam name>.num_particles`` (`int`)
+    Number of constant weight particles to generate the beam.
+
+* ``<beam name>.pdf`` (`float`)
+    Probability density function to define the longitudinal profile of the beam.
+    The transverse profile will be Gaussian. This is a parser function of z
+    that should return the total amount of charge present on each transverse beam slice.
+    This will also be propartinal to the per-slice peak density if ``<beam name>.position_mean`` is constant along z,
+    if not the pdf can be calculated from the desired peak density using ``<beam name>.pdf = <peak_density(z)> * <position_std_x(z)> * <position_std_y(z)>``.
+    The probability density function is automatically normalized so that all constant pre factors
+    can be omitted when specifying the function.
+    Examples (relpace `z_center`, `z_std`, `z_length`, `z_slope`, `z_min` and `z_max`):
+    Gaussian: ``exp(-0.5*((z-z_center)/z_std)^2)``
+    Cosine: ``(cos(2*pi*(z-z_center)/z_length)+1)*(2*abs(z-z_center)<z_length)``
+    Trapezoidal: ``(z<z_max)*(z>z_min)*(1+z_slope*z)``
+
+* ``<beam name>.total_charge`` (`float`)
+    Total charge of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
+    Only available when running in SI units.
+    The absolute value of this parameter is used when initializing the beam.
+    Note that in contrast to the ``fixed_weight`` injection type, using ``<beam name>.radius`` or
+    a special pdf to emulate `z_min` and `z_max` will result in beam particles being redistributed to
+    other locations and not in them being deleted in the injection, meaning that the resulting beam will
+    have exactly the total charge that is specified here.
+
+* ``<beam name>.density`` (`float`)
+    Peak density of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
+    The absolute value of this parameter is used when initializing the beam.
+    Note that this is the peak density of the analytical profile specified by the `pdf`, `position_mean` and
+    `position_std`, within the limits of the resolution of the numerical evaluation of the pdf. The actual
+    resulting beam profile consists of randomly distributed particles and will likely feature density
+    fluctuations exceeding the specified peak density.
+
+* ``<beam name>.position_mean`` (2 `float`)
+    The mean position of the beam in ``x, y``, separated by a space. Both values can be a function of z.
+    To generate a tilted beam use
+    ``<beam name>.position_mean = "x_center+(z-z_ center)*dx_per_dzeta" "y_center+(z-z_ center)*dy_per_dzeta"``.
+
+* ``<beam name>.position_std`` (2 `float`)
+    The rms size of the of the beam in ``x, y``, separated by a space. Both values can be a function of z.
+
+* ``<beam name>.u_mean`` (3 `float`)
+    The mean normalized momentum of the beam in ``x, y, z``, separated by a space. All values can be a function of z.
+    Normalized momentum is equal to :math:`= \gamma \beta = \frac{p}{m c}`. An electron beam with a momentum of 1 GeV/c
+    has a u_mean of ``0 0 1956.951198`` while a proton beam with the same momentum has a u_mean of ``0 0 1.065788933``.
+
+* ``<beam name>.u_std`` (3 `float`)
+    The rms normalized momentum of the beam in ``x, y, z``, separated by a space. All values can be a function of z.
+
+* ``<beam name>.do_symmetrize`` (`bool`) optional (default `0`)
+    Symmetrizes the beam in the transverse phase space. For each particle with (`x`, `y`, `ux`,
+    `uy`), three further particles are generated with (`-x`, `y`, `-ux`, `uy`), (`x`, `-y`, `ux`,
+    `-uy`), and (`-x`, `-y`, `-ux`, `-uy`). The total number of particles will still be
+    ``beam_name.num_particles``, therefore this option requires that the beam particle number must be
+    divisible by 4.
+
+* ``<beam name>.z_foc`` (`float`) optional (default `0.`)
+    Distance at which the beam will be focused, calculated from the position at which the beam is initialized.
+    The beam is assumed to propagate ballistically in-between.
+
+* ``<beam name>.radius`` (`float`) optional (default `infinity`)
+    Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+    injected. If ``<beam name>.density`` is specified, beam particles outside of the radius get
+    deleted. If ``<beam name>.total_charge`` is specified, beam particles outside of the radius get
+    new random transverse positions to conserve the total charge.
+
+* ``<beam name>.pdf_ref_ratio`` (`int`) optional (default `4`)
+    Into how many segments the pdf is divided per zeta slice for its first-order numerical evaluation.
 
 Option: ``fixed_weight``
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -514,14 +560,35 @@ Option: ``fixed_weight``
 * ``<beam name>.num_particles`` (`int`)
     Number of constant weight particles to generate the beam.
 
+* ``<beam name>.profile`` (`string`) optional (default `gaussian`)
+    Beam profile.
+    Possible options are ``can`` (uniform longitudinally, Gaussian transversally)
+    and ``gaussian`` (Gaussian in all directions).
+
 * ``<beam name>.total_charge`` (`float`)
     Total charge of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
     The absolute value of this parameter is used when initializing the beam.
-    Note that ``<beam name>.zmin`` and ``<beam name>.zmax`` can reduce the total charge.
+    Note that ``<beam name>.zmin``, ``<beam name>.zmax`` and ``<beam name>.radius`` can reduce the total charge.
 
 * ``<beam name>.density`` (`float`)
     Peak density of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
     The absolute value of this parameter is used when initializing the beam.
+
+* ``<beam name>.position_mean`` (3 `float`)
+    The mean position of the beam in ``x, y, z``, separated by a space.
+    The x and y directions can be functions of ``z``. To generate a tilted beam use
+    ``<beam name>.position_mean = "x_center+(z-z_ center)*dx_per_dzeta" "y_center+(z-z_ center)*dy_per_dzeta" "z_center"``.
+
+* ``<beam name>.position_std`` (3 `float`)
+    The rms size of the of the beam in ``x, y, z``, separated by a space.
+
+* ``<beam name>.u_mean`` (3 `float`)
+    The mean normalized momentum of the beam in ``x, y, z``, separated by a space.
+    Normalized momentum is equal to :math:`= \gamma \beta = \frac{p}{m c}`. An electron beam with a momentum of 1 GeV/c
+    has a u_mean of ``0 0 1956.951198`` while a proton beam with the same momentum has a u_mean of ``0 0 1.065788933``.
+
+* ``<beam name>.u_std`` (3 `float`)
+    The rms normalized momentum of the beam in ``x, y, z``, separated by a space.
 
 * ``<beam name>.duz_per_uz0_dzeta`` (`float`) optional (default `0.`)
     Relative correlated energy spread per :math:`\zeta`.
@@ -540,11 +607,32 @@ Option: ``fixed_weight``
     Distance at which the beam will be focused, calculated from the position at which the beam is initialized.
     The beam is assumed to propagate ballistically in-between.
 
+* ``<beam name>.zmin`` (`float`) (default `-infinity`)
+    Minimum in `z` at which particles are injected.
+
+* ``<beam name>.zmax`` (`float`) (default `infinity`)
+    Maximum in `z` at which particles are injected.
+
+* ``<beam name>.radius`` (`float`) (default `infinity`)
+    Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+    injected.
+
+* ``<beam name> or beams.initialize_on_cpu`` (`bool`) optional (default `0`)
+    Whether to initialize the beam on the CPU instead of the GPU.
+    Initializing the beam on the CPU can be much slower but is necessary if the full beam does not fit into GPU memory.
+
 Option: ``fixed_ppc``
 ^^^^^^^^^^^^^^^^^^^^^
 
 * ``<beam name>.ppc`` (3 `int`) (default `1 1 1`)
     Number of particles per cell in `x`-, `y`-, and `z`-direction to generate the beam.
+
+* ``<beam name>.profile`` (`string`)
+    Beam profile.
+    Possible options are ``flattop`` (flat-top radially and longitudinally),
+    ``gaussian`` (Gaussian in all directions),
+    or ``parsed`` (arbitrary analytic function provided by the user).
+    When ``parsed``, ``<beam name>.density(x,y,z)`` must be specified.
 
 * ``<beam name>.density`` (`float`)
     Peak density of the beam.
@@ -553,14 +641,37 @@ Option: ``fixed_ppc``
 * ``<beam name>.density(x,y,z)`` (`float`)
     The density profile of the beam, as a function of spatial dimensions `x`, `y` and `z`.
     This function uses the parser, see above.
-    Only used when ``<beam name>.profile == parsed``.
 
 * ``<beam name>.min_density`` (`float`) optional (default `0`)
     Minimum density. Particles with a lower density are not injected.
     The absolute value of this parameter is used when initializing the beam.
 
+* ``<beam name>.position_mean`` (3 `float`)
+    The mean position of the beam in ``x, y, z``, separated by a space.
+
+* ``<beam name>.position_std`` (3 `float`)
+    The rms size of the of the beam in ``x, y, z``, separated by a space.
+
+* ``<beam name>.u_mean`` (3 `float`)
+    The mean normalized momentum of the beam in ``x, y, z``, separated by a space.
+    Normalized momentum is equal to :math:`= \gamma \beta = \frac{p}{m c}`. An electron beam with a momentum of 1 GeV/c
+    has a u_mean of ``0 0 1956.951198`` while a proton beam with the same momentum has a u_mean of ``0 0 1.065788933``.
+
+* ``<beam name>.u_std`` (3 `float`)
+    The rms normalized momentum of the beam in ``x, y, z``, separated by a space.
+
 * ``<beam name>.random_ppc`` (3 `bool`) optional (default `0 0 0`)
     Whether the position in `(x y z)` of the particles is randomized within the cell.
+
+* ``<beam name>.zmin`` (`float`) (default `-infinity`)
+    Minimum in `z` at which particles are injected.
+
+* ``<beam name>.zmax`` (`float`) (default `infinity`)
+    Maximum in `z` at which particles are injected.
+
+* ``<beam name>.radius`` (`float`) (default `infinity`)
+    Maximum radius ``<beam name>.radius`` :math:`= \sqrt{x^2 + y^2}` within that particles are
+    injected.
 
 Option: ``from_file``
 ^^^^^^^^^^^^^^^^^^^^^
@@ -578,6 +689,10 @@ Option: ``from_file``
 * ``<beam name>.openPMD_species_name`` (`string`) optional (default `<beam name>`)
     Name of the beam to be read in. If an openPMD file contains multiple beams, the name of the beam
     needs to be specified.
+
+* ``<beam name> or beams.initialize_on_cpu`` (`bool`) optional (default `0`)
+    Whether to initialize the beam on the CPU instead of the GPU.
+    Initializing the beam on the CPU can be much slower but is necessary if the full beam does not fit into GPU memory.
 
 SALAME algorithm
 ^^^^^^^^^^^^^^^^

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -428,15 +428,15 @@ which are valid only for certain beam types, are introduced further below under
 
 
 * ``<beam name>.injection_type`` (`string`)
-    The injection type for the particle beam. Currently available are ``fixed_ppc``, ``fixed_weight``, ``fixed_weight_pdf``,
+    The injection type for the particle beam. Currently available are ``fixed_weight_pdf``, ``fixed_weight``, ``fixed_ppc``,
     and ``from_file``.
-    ``fixed_ppc`` generates a beam with a fixed number of particles per cell and
-    varying weights. It can be either a Gaussian or a flattop beam.
-    ``fixed_weight`` generates a Gaussian beam with a fixed number of particles with a constant weight.
     ``fixed_weight_pdf`` generates a beam with a fixed number of particles with a constant weight where
     the transverse profile is Gaussian and the longitudinal profile is arbitrary according to a
-    user-specified probability density function. Although it is more general it is faster and uses
-    less memory than ``fixed_weight``,
+    user-specified probability density function. It is more general and faster, and uses
+    less memory than ``fixed_weight``.
+    ``fixed_weight`` generates a Gaussian beam with a fixed number of particles with a constant weight.
+    ``fixed_ppc`` generates a beam with a fixed number of particles per cell and
+    varying weights. It can be either a Gaussian or a flattop beam.
     ``from_file`` reads a beam from openPMD files.
 
 * ``<beam name>.element`` (`string`) optional (default `electron`)
@@ -489,31 +489,31 @@ Option: ``fixed_weight_pdf``
     Number of constant weight particles to generate the beam.
 
 * ``<beam name>.pdf`` (`float`)
-    Probability density function to define the longitudinal profile of the beam
-    (the transverse profile is Gaussian). This is a parser function of z
-    that should return the total amount of charge present on each transverse beam slice.
-    This will also be proportional to the per-slice peak density if ``<beam name>.position_mean`` is constant along z,
-    if not the pdf can be calculated from the desired peak density using ``<beam name>.pdf = <peak_density(z)> * <position_std_x(z)> * <position_std_y(z)>``.
-    The probability density function is automatically normalized so that all constant pre factors
-    can be omitted when specifying the function.
-    Examples (replace `z_center`, `z_std`, `z_length`, `z_slope`, `z_min` and `z_max`):
-    Gaussian: ``exp(-0.5*((z-z_center)/z_std)^2)``
-    Cosine: ``(cos(2*pi*(z-z_center)/z_length)+1)*(2*abs(z-z_center)<z_length)``
-    Trapezoidal: ``(z<z_max)*(z>z_min)*(1+z_slope*z)``
+    Longitudinal density profile of the beam, given as a probability density function
+    (the transverse profile is Gaussian). This is a parser function of z, giving the charge density
+    integrated in both transverse directions `x` and `y` (this is proportional to the beam current
+    profile in the limit :math:`v_z \simeq c`). The probability density function is automatically
+    normalized, and combined with ``<beam name>.total_charge`` or ``<beam name>.density`` within
+    the code to generate the absolute beam profile.
+    Examples (assuming ``z_center``, ``z_std``, ``z_length``, ``z_slope``, ``z_min`` and ``z_max``
+    are defined with ``my_constants``):
+    - Gaussian: ``exp(-0.5*((z-z_center)/z_std)^2)``
+    - Cosine: ``(cos(2*pi*(z-z_center)/z_length)+1)*(2*abs(z-z_center)<z_length)``
+    - Trapezoidal: ``(z<z_max)*(z>z_min)*(1+z_slope*z)``
 
 * ``<beam name>.total_charge`` (`float`)
-    Total charge of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
+    Total charge of the beam (either ``total_charge`` or ``density`` must be specified).
     Only available when running in SI units.
     The absolute value of this parameter is used when initializing the beam.
     Note that in contrast to the ``fixed_weight`` injection type, using ``<beam name>.radius`` or
-    a special pdf to emulate `z_min` and `z_max` will result in beam particles being redistributed to
-    other locations and not in them being deleted in the injection, meaning that the resulting beam will
-    have exactly the total charge that is specified here.
+    a special pdf to emulate ``z_min`` and ``z_max`` will result in beam particles being redistributed to
+    other locations rather than being deleted. Therefore, the resulting beam will have exactly the
+    specified total charge, but cutting a significant fraction of the charge is not recommended.
 
 * ``<beam name>.density`` (`float`)
-    Peak density of the beam. Note: Either ``total_charge`` or ``density`` must be specified.
+    Peak density of the beam (either ``total_charge`` or ``density`` must be specified).
     The absolute value of this parameter is used when initializing the beam.
-    Note that this is the peak density of the analytical profile specified by the `pdf`, `position_mean` and
+    Note that this is the peak density of the analytical profile specified by `pdf`, `position_mean` and
     `position_std`, within the limits of the resolution of the numerical evaluation of the pdf. The actual
     resulting beam profile consists of randomly distributed particles and will likely feature density
     fluctuations exceeding the specified peak density.
@@ -521,7 +521,7 @@ Option: ``fixed_weight_pdf``
 * ``<beam name>.position_mean`` (2 `float`)
     The mean position of the beam in ``x, y``, separated by a space. Both values can be a function of z.
     To generate a tilted beam use
-    ``<beam name>.position_mean = "x_center+(z-z_ center)*dx_per_dzeta" "y_center+(z-z_ center)*dy_per_dzeta"``.
+    ``<beam name>.position_mean = "x_center+(z-z_center)*dx_per_dzeta" "y_center+(z-z_center)*dy_per_dzeta"``.
 
 * ``<beam name>.position_std`` (2 `float`)
     The rms size of the of the beam in ``x, y``, separated by a space. Both values can be a function of z.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -436,7 +436,7 @@ which are valid only for certain beam types, are introduced further below under
     ``fixed_weight_pdf`` generates a beam with a fixed number of particles with a constant weight where
     the transverse profile is Gaussian and the longitudinal profile is arbitrary according to a
     user-specified probability density function. Although it is more general it is faster and uses
-    less memory than ``fixed_weight``.
+    less memory than ``fixed_weight``,
     ``from_file`` reads a beam from openPMD files.
 
 * ``<beam name>.element`` (`string`) optional (default `electron`)
@@ -490,9 +490,9 @@ Option: ``fixed_weight_pdf``
 
 * ``<beam name>.pdf`` (`float`)
     Probability density function to define the longitudinal profile of the beam.
-    The transverse profile will be Gaussian. This is a parser function of z
+    The transverse profile is Gaussian. This is a parser function of z
     that should return the total amount of charge present on each transverse beam slice.
-    This will also be propartinal to the per-slice peak density if ``<beam name>.position_mean`` is constant along z,
+    This will also be proportional to the per-slice peak density if ``<beam name>.position_mean`` is constant along z,
     if not the pdf can be calculated from the desired peak density using ``<beam name>.pdf = <peak_density(z)> * <position_std_x(z)> * <position_std_y(z)>``.
     The probability density function is automatically normalized so that all constant pre factors
     can be omitted when specifying the function.

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -85,15 +85,16 @@ public:
      */
     amrex::Real InitData (const amrex::Geometry& geom);
 
-    /** Initialize a beam with a fix number of particles per cell */
+    /** Initialize a beam with a fixed number of particles per cell */
     void InitBeamFixedPPC3D ();
     void InitBeamFixedPPCSlice (const int islice, const int which_beam_slice);
 
-    /** Initialize a beam with a fix number of particles, and fixed weight */
+    /** Initialize a beam with a fixed number of particles, and fixed weight */
     void InitBeamFixedWeight3D ();
     void InitBeamFixedWeightSlice (const int islice, const int which_beam_slice);
 
-    /** Initialize a beam with a fix number of particles, and fixed weight using a pdf */
+    /** Initialize a beam with a fixed number of particles,
+     * and fixed weight using a probability density function (PDF) */
     void InitBeamFixedWeightPDF3D ();
     void InitBeamFixedWeightPDFSlice (int slice, int which_slice);
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -93,6 +93,9 @@ public:
     void InitBeamFixedWeight3D ();
     void InitBeamFixedWeightSlice (const int islice, const int which_beam_slice);
 
+    void InitBeamFixedWeightPDF3D ();
+    void InitBeamFixedWeightPDFSlice (int slice, int which_slice);
+
 #ifdef HIPACE_USE_OPENPMD
     /** Checks the input file first to determine its Datatype
      * \return physical time at which the simulation will start
@@ -251,6 +254,19 @@ private:
     bool m_do_symmetrize {0}; /**< Option to symmetrize the beam */
     /** Array for the z position of all beam particles */
     amrex::PODVector<amrex::Real, amrex::PolymorphicArenaAllocator<amrex::Real>> m_z_array {};
+
+    // fixed_weight_pdf:
+
+    bool m_peak_density_is_specified = false;
+    int m_pdf_ref_ratio = 4;
+    amrex::Real m_total_weight = 0;
+    amrex::ParserExecutor<1> m_pdf_func;
+    amrex::Vector<unsigned int> m_num_particles_slice;
+
+    amrex::Array<amrex::ParserExecutor<1>, 4> m_pdf_pos_func;
+    amrex::Array<amrex::ParserExecutor<1>, 6> m_pdf_u_func;
+
+    amrex::Vector<amrex::Parser> m_pdf_parsers;
 
     // from_file:
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -93,6 +93,7 @@ public:
     void InitBeamFixedWeight3D ();
     void InitBeamFixedWeightSlice (const int islice, const int which_beam_slice);
 
+    /** Initialize a beam with a fix number of particles, and fixed weight using a pdf */
     void InitBeamFixedWeightPDF3D ();
     void InitBeamFixedWeightPDFSlice (int slice, int which_slice);
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -257,15 +257,17 @@ private:
 
     // fixed_weight_pdf:
 
-    bool m_peak_density_is_specified = false;
-    int m_pdf_ref_ratio = 4;
-    amrex::Real m_total_weight = 0;
-    amrex::ParserExecutor<1> m_pdf_func;
+    bool m_peak_density_is_specified = false; /**< if the peak density is specified */
+    int m_pdf_ref_ratio = 4; /**< number of subcycles per slice for the pdf evaluation */
+    amrex::Real m_total_weight = 0; /**< sum of the weights of all particles */
+    amrex::ParserExecutor<1> m_pdf_func; /**< probability density function */
+    /** number of particles that need to be initialized per slice */
     amrex::Vector<unsigned int> m_num_particles_slice;
-
+    /** functions for x_mean, y_mean, x_std, y_std */
     amrex::Array<amrex::ParserExecutor<1>, 4> m_pdf_pos_func;
+    /** functions for ux_mean, uy_mean, uz_mean, ux_std, uy_std, uz_std */
     amrex::Array<amrex::ParserExecutor<1>, 6> m_pdf_u_func;
-
+    /** Owns data for all 11 Parser functions of fixed_weight_pdf */
     amrex::Vector<amrex::Parser> m_pdf_parsers;
 
     // from_file:

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -534,6 +534,10 @@ InitBeamFixedWeightPDF3D ()
 
     while (num_added != num_to_add) {
 
+        // It is very unlikely that the correct amount of particles will be initialized in the first
+        // iteration. Another iteration is done with remaining particles (or subtracting extra
+        // particles). This converges quickly as the expected deviation is  sqrt(num_to_add_now),
+        // resulting in a time complexity of O(num_slices*log(log(num_to_add)))
         const amrex::Long num_to_add_now = num_to_add - num_added;
 
         for (int slice=domain.length(2)*m_pdf_ref_ratio-1; slice >=0; --slice) {

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -478,26 +478,56 @@ InitBeamFixedWeightPDF3D ()
     const amrex::Geometry geom = Hipace::GetInstance().m_3D_geom[0];
     const amrex::Box domain = geom.Domain();
 
-    m_num_particles_slice.resize(domain.length(2));
+    m_num_particles_slice.resize(domain.length(2) * m_pdf_ref_ratio);
 
     const amrex::Real zoffset = geom.ProbLo(2);
-    const amrex::Real zscale = geom.CellSize(2);
+    const amrex::Real zscale = geom.CellSize(2) / m_pdf_ref_ratio;
 
     amrex::Real integral = 0._rt;
+    amrex::Real max_density = 0._rt;
+    amrex::Real avg_uz = 0._rt;
+    amrex::Real avg_uz_sq = 0._rt;
 
-    for (int slice=domain.bigEnd(2); slice >=domain.smallEnd(2); --slice) {
-        const amrex::Real zmin = zoffset + slice+zscale;
+    for (int slice=domain.length(2)*m_pdf_ref_ratio-1; slice>=0; --slice) {
+        const amrex::Real zmin = zoffset + slice*zscale;
         const amrex::Real zmax = zoffset + (slice+1)*zscale;
+        const amrex::Real zmid = 0.5_rt*(zmin + zmax);
 
         const amrex::Real pdf_zmin = m_pdf_func(zmin);
         const amrex::Real pdf_zmax = m_pdf_func(zmax);
+        const amrex::Real local_weight = 0.5_rt*(pdf_zmin+pdf_zmax);
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_pdf_func(zmin) >= 0._rt &&  m_pdf_func(zmax) >= 0._rt,
-            "PDF must be >= 0");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pdf_zmin >= 0._rt &&  pdf_zmax >= 0._rt,
+            "PDF must be >= 0 everywhere");
 
-        integral += 0.5_rt*(pdf_zmin+pdf_zmax);
+        if (m_peak_density_is_specified) {
+            max_density = std::max(max_density, local_weight
+                / (zscale * m_pdf_pos_func[2](zmid) * m_pdf_pos_func[3](zmid) * 2._rt*MathConst::pi)
+            );
+        }
 
+        // calculate uz and uz_std for AdaptiveTimeStep
+        amrex::Real uz_mean_local = m_pdf_u_func[2](zmid);
+        amrex::Real uz_std_local = m_pdf_u_func[5](zmid);
+        avg_uz += local_weight * uz_mean_local;
+        avg_uz_sq += local_weight * (uz_mean_local*uz_mean_local + uz_std_local*uz_std_local);
+
+        integral += local_weight;
         m_num_particles_slice[slice] = 0;
+    }
+
+    if (m_peak_density_is_specified) {
+        m_total_weight = m_density * integral / max_density;
+    } else {
+        m_total_weight = m_total_charge / m_charge;
+    }
+
+    // calculate uz and uz_std for AdaptiveTimeStep
+    m_get_momentum.m_u_mean[2] = avg_uz/integral;
+    m_get_momentum.m_u_std[2] = std::sqrt(avg_uz_sq/integral - (avg_uz/integral)*(avg_uz/integral));
+
+    if (Hipace::m_normalized_units) {
+        m_total_weight *= geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
     }
 
     amrex::Long num_added = 0;
@@ -506,16 +536,15 @@ InitBeamFixedWeightPDF3D ()
 
         const amrex::Long num_to_add_now = num_to_add - num_added;
 
-        std::cout << "PDF iter num_to_add " << num_to_add << " num_to_add_now " << num_to_add_now << std::endl;
-
-        for (int slice=domain.bigEnd(2); slice >=domain.smallEnd(2); --slice) {
-            const amrex::Real zmin = zoffset + slice+zscale;
+        for (int slice=domain.length(2)*m_pdf_ref_ratio-1; slice >=0; --slice) {
+            const amrex::Real zmin = zoffset + slice*zscale;
             const amrex::Real zmax = zoffset + (slice+1)*zscale;
 
             const amrex::Real pdf_zmin = m_pdf_func(zmin);
             const amrex::Real pdf_zmax = m_pdf_func(zmax);
+            const amrex::Real local_weight = 0.5_rt*(pdf_zmin+pdf_zmax);
 
-            const amrex::Real mean_particles = num_to_add_now*0.5_rt*(pdf_zmin+pdf_zmax)/integral;
+            const amrex::Real mean_particles = num_to_add_now*local_weight/integral;
 
             if (mean_particles >= 0) {
                 const unsigned int n = amrex::RandomPoisson(mean_particles);
@@ -540,102 +569,106 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
 
     if (!Hipace::HeadRank() || m_num_particles == 0) { return; }
 
-    const unsigned int num_to_add = m_num_particles_slice[slice];
+    unsigned int num_to_add_full = 0;
+    for (int r=m_pdf_ref_ratio-1; r>=0; --r) {
+        num_to_add_full += m_num_particles_slice[slice*m_pdf_ref_ratio+r];
+    }
     if (m_do_symmetrize) {
-        resize(which_slice, 4*num_to_add, 0);
+        resize(which_slice, 4*num_to_add_full, 0);
     } else {
-        resize(which_slice, num_to_add, 0);
+        resize(which_slice, num_to_add_full, 0);
     }
 
-    if (num_to_add == 0) return;
+    unsigned int loc_index = 0;
+    for (int r=m_pdf_ref_ratio-1; r>=0; --r) {
+        const unsigned int num_to_add = m_num_particles_slice[slice*m_pdf_ref_ratio+r];
+        if (num_to_add == 0) continue;
 
-    const amrex::Real clight = get_phys_const().c;
+        auto& particle_tile = getBeamSlice(which_slice);
+        // Access particles' SoA
+        amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs> rarrdata =
+            particle_tile.GetStructOfArrays().realarray();
+        amrex::GpuArray<int*, BeamIdx::int_nattribs> iarrdata =
+            particle_tile.GetStructOfArrays().intarray();
 
-    auto& particle_tile = getBeamSlice(which_slice);
+        const uint64_t pid = m_id64;
+        m_id64 += num_to_add;
 
-    // Access particles' SoA
-    amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs> rarrdata =
-        particle_tile.GetStructOfArrays().realarray();
-    amrex::GpuArray<int*, BeamIdx::int_nattribs> iarrdata =
-        particle_tile.GetStructOfArrays().intarray();
+        const amrex::Real clight = get_phys_const().c;
+        const bool do_symmetrize = m_do_symmetrize;
+        const bool peak_density_is_specified = m_peak_density_is_specified;
+        const amrex::Real z_foc = m_z_foc;
+        const amrex::Real radius = m_radius;
+        const amrex::Real weight = m_total_weight / m_num_particles;
+        const auto pos_func = m_pdf_pos_func;
+        const auto u_func = m_pdf_u_func;
+        const amrex::Geometry& geom = Hipace::GetInstance().m_3D_geom[0];
+        const amrex::Real dz = geom.CellSize(2) / m_pdf_ref_ratio;
+        const amrex::Real zmin = geom.ProbLo(2) + (slice*m_pdf_ref_ratio+r)*dz;
+        const amrex::Real zmax = geom.ProbLo(2) + (slice*m_pdf_ref_ratio+r+1)*dz;
+        const amrex::Real lo_weight = m_pdf_func(zmin);
+        const amrex::Real hi_weight = m_pdf_func(zmax);
+        AMREX_ALWAYS_ASSERT(lo_weight + hi_weight > 0._rt);
+        const bool use_taylor = std::min(lo_weight, hi_weight)*1.1 > std::max(lo_weight, hi_weight);
+        const amrex::Real lo_hi_weight_inv = use_taylor ?
+            1._rt/(hi_weight+lo_weight) : 1._rt/(hi_weight-lo_weight);
 
-    const uint64_t pid = m_id64;
-    m_id64 += num_to_add;
-
-    const bool do_symmetrize = m_do_symmetrize;
-    const amrex::Real duz_per_uz0_dzeta = m_duz_per_uz0_dzeta;
-    const amrex::RealVect pos_std = m_position_std;
-    const amrex::Real z_foc = m_z_foc;
-    const amrex::Real radius = m_radius;
-    auto pos_mean_x = m_pos_mean_x_func;
-    auto pos_mean_y = m_pos_mean_y_func;
-    const amrex::Real weight = m_total_charge / (m_num_particles * m_charge);
-    const GetInitialMomentum get_momentum = m_get_momentum;
-    const amrex::Geometry& geom = Hipace::GetInstance().m_3D_geom[0];
-    const amrex::Real dz = geom.CellSize(2);
-    const amrex::Real zmin = geom.ProbLo(2) + slice+dz;
-    const amrex::Real zmax = geom.ProbLo(2) + (slice+1)*dz;
-    const amrex::Real lo_weight = m_pdf_func(zmin);
-    const amrex::Real hi_weight = m_pdf_func(zmax);
-    AMREX_ALWAYS_ASSERT(lo_weight + hi_weight > 0._rt);
-    const bool use_taylor = std::min(lo_weight, hi_weight) * 1.1 > std::max(lo_weight, hi_weight);
-    const amrex::Real lo_hi_weight_inv = use_taylor ?
-        1._rt/(hi_weight-lo_weight) : 1._rt/(lo_weight+hi_weight);
-
-    amrex::ParallelForRNG(
-        num_to_add,
-        [=] AMREX_GPU_DEVICE (amrex::Long i, const amrex::RandomEngine& engine) noexcept
-        {
-            const amrex::Real w = amrex::Random(engine);
-            amrex::Real z_central = zmin;
-            if (use_taylor) {
-                z_central += dz*(w - w*(w-1._rt)*(hi_weight-lo_weight)*lo_hi_weight_inv);
-            } else {
-                z_central += dz*((std::sqrt(lo_weight*lo_weight
-                    +w*(hi_weight*hi_weight-lo_weight*lo_weight))-lo_weight)*lo_hi_weight_inv);
-            }
-
-            amrex::Real x = amrex::RandomNormal(0, pos_std[0], engine);
-            amrex::Real y = amrex::RandomNormal(0, pos_std[1], engine);
-
-            amrex::Real u[3] = {0.,0.,0.};
-            get_momentum(u[0], u[1], u[2], engine, z_central - z_mean, duz_per_uz0_dzeta);
-
-            bool is_valid = true;
-            if (x*x + y*y > radius*radius) {
-                is_valid = false;
-            }
-
-            // Propagate each electron ballistically for z_foc
-            x -= z_foc*u[0]/u[2];
-            y -= z_foc*u[1]/u[2];
-
-            const amrex::Real cental_x_pos = pos_mean_x(z_central);
-            const amrex::Real cental_y_pos = pos_mean_y(z_central);
-
-            if (!do_symmetrize)
+        amrex::ParallelForRNG(
+            num_to_add,
+            [=] AMREX_GPU_DEVICE (unsigned int i, const amrex::RandomEngine& engine) noexcept
             {
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
-                                        z_central, u[0], u[1], u[2], weight,
-                                        pid, i, clight, is_valid);
+                i += loc_index;
 
-            } else {
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
-                                        z_central, u[0], u[1], u[2], weight,
-                                        pid, 4*i, clight, is_valid);
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos+y,
-                                        z_central, -u[0], u[1], u[2], weight,
-                                        pid, 4*i+1, clight, is_valid);
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos-y,
-                                        z_central, u[0], -u[1], u[2], weight,
-                                        pid, 4*i+2, clight, is_valid);
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos-y,
-                                        z_central, -u[0], -u[1], u[2], weight,
-                                        pid, 4*i+3, clight, is_valid);
-            }
-        });
+                const amrex::Real w = amrex::Random(engine);
+                amrex::Real z = zmin;
+                if (use_taylor) {
+                    z += dz*(w - w*(w-1._rt)*(hi_weight-lo_weight)*lo_hi_weight_inv);
+                } else {
+                    z += dz*((std::sqrt(lo_weight*lo_weight
+                        +w*(hi_weight*hi_weight-lo_weight*lo_weight))-lo_weight)*lo_hi_weight_inv);
+                }
 
-    return;
+                const amrex::Real x_mean = pos_func[0](z);
+                const amrex::Real y_mean = pos_func[1](z);
+                const amrex::Real x_std = pos_func[2](z);
+                const amrex::Real y_std = pos_func[3](z);
+
+                amrex::Real x = 0._rt;
+                amrex::Real y = 0._rt;
+                bool is_valid = false;
+                do {
+                    x = amrex::RandomNormal(0, x_std, engine);
+                    y = amrex::RandomNormal(0, y_std, engine);
+                    is_valid = x*x + y*y <= radius*radius;
+                } while (!peak_density_is_specified && !is_valid);
+
+                const amrex::Real ux = amrex::RandomNormal(u_func[0](z), u_func[3](z), engine);
+                const amrex::Real uy = amrex::RandomNormal(u_func[1](z), u_func[4](z), engine);
+                const amrex::Real uz = amrex::RandomNormal(u_func[2](z), u_func[5](z), engine);
+
+                // Propagate each electron ballistically for z_foc
+                x -= z_foc*ux/uz;
+                y -= z_foc*uy/uz;
+
+                if (!do_symmetrize)
+                {
+                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean+x, y_mean+y,
+                                            z, ux, uy, uz, weight, pid, i, clight, is_valid);
+
+                } else {
+                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean+x, y_mean+y,
+                                            z, ux, uy, uz, weight, pid, 4*i, clight, is_valid);
+                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean-x, y_mean+y,
+                                            z, -ux, uy, uz, weight, pid, 4*i+1, clight, is_valid);
+                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean+x, y_mean-y,
+                                            z, ux, -uy, uz, weight, pid, 4*i+2, clight, is_valid);
+                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean-x, y_mean-y,
+                                            z, -ux, -uy, uz, weight, pid, 4*i+3, clight, is_valid);
+                }
+            });
+
+        loc_index += num_to_add;
+    }
 }
 
 #ifdef HIPACE_USE_OPENPMD

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -547,10 +547,14 @@ InitBeamFixedWeightPDF3D ()
             const amrex::Real mean_particles = num_to_add_now*local_weight/integral;
 
             if (mean_particles >= 0) {
+                // use a Poisson distribution to mimic how many independent particles would be
+                // initialized according to the full PDF
                 const unsigned int n = amrex::RandomPoisson(mean_particles);
                 m_num_particles_slice[slice] += n;
                 num_added += n;
             } else {
+                // if there were too many particles initialized in an earlier iteration we need to
+                // remove some but also avoid having less than zero particles per slice
                 const unsigned int n = std::min(amrex::RandomPoisson(-mean_particles),
                                                 m_num_particles_slice[slice]);
                 m_num_particles_slice[slice] -= n;
@@ -609,6 +613,9 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
         const amrex::Real lo_weight = m_pdf_func(zmin);
         const amrex::Real hi_weight = m_pdf_func(zmax);
         AMREX_ALWAYS_ASSERT(lo_weight + hi_weight > 0._rt);
+        // the proper formular is not defined for hi_weight == lo_weight and may
+        // have prcission issues around that point so we use a taylor expansion instead
+        // if the hi_weight and lo_weight are within 10% of each other
         const bool use_taylor = std::min(lo_weight, hi_weight)*1.1 > std::max(lo_weight, hi_weight);
         const amrex::Real lo_hi_weight_inv = use_taylor ?
             1._rt/(hi_weight+lo_weight) : 1._rt/(hi_weight-lo_weight);
@@ -617,6 +624,9 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
             num_to_add,
             [=] AMREX_GPU_DEVICE (unsigned int i, const amrex::RandomEngine& engine) noexcept
             {
+                // if m_pdf_ref_ratio is greater than one, a single slice of beam particles
+                // needs to be initialized by multiple kernels so we need to keep track of the
+                // local index offset for each kernel
                 i += loc_index;
 
                 const amrex::Real w = amrex::Random(engine);

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -536,7 +536,7 @@ InitBeamFixedWeightPDF3D ()
 
         // It is very unlikely that the correct amount of particles will be initialized in the first
         // iteration. Another iteration is done with remaining particles (or subtracting extra
-        // particles). This converges quickly as the expected deviation is  sqrt(num_to_add_now),
+        // particles). This converges quickly as the expected deviation is sqrt(num_to_add_now),
         // resulting in a time complexity of O(num_slices*log(log(num_to_add)))
         const amrex::Long num_to_add_now = num_to_add - num_added;
 

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -617,9 +617,9 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
         const amrex::Real lo_weight = m_pdf_func(zmin);
         const amrex::Real hi_weight = m_pdf_func(zmax);
         AMREX_ALWAYS_ASSERT(lo_weight + hi_weight > 0._rt);
-        // the proper formular is not defined for hi_weight == lo_weight and may
-        // have prcission issues around that point so we use a taylor expansion instead
-        // if the hi_weight and lo_weight are within 10% of each other
+        // the proper formula is not defined for hi_weight == lo_weight and may
+        // have precision issues around that point, so we use a Taylor expansion instead
+        // if the hi_weight and lo_weight are within 10% of each other.
         const bool use_taylor = std::min(lo_weight, hi_weight)*1.1 > std::max(lo_weight, hi_weight);
         const amrex::Real lo_hi_weight_inv = use_taylor ?
             1._rt/(hi_weight+lo_weight) : 1._rt/(hi_weight-lo_weight);


### PR DESCRIPTION
This PR adds the `fixed_weight_pdf` injection type that is a generalization of `fixed_weight` where the longitudinal profile can be arbitrary. It is supplied by the user using a probability density function. Because the pdf is fully evaluated per-slice the array of z positions does not have to be fully precomputed, sorted and stored in memory like with `fixed_weight`, resulting in a performance improvement and a reduction of memory usage. With the right setup it is possible to use one trillion beam particles. 

Example:
```
beam.injection_type = fixed_weight_pdf
beam.pdf = exp(-0.5*(z/4)^2)
beam.position_mean = 0 0
beam.position_std = 2 2
beam.u_mean = 0 0 10000
beam.u_std = 0 0 0
beam.num_particles = 10^9
beam.density = 1
beam.pdf_ref_ratio = 4
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
