### PR TITLE
Beam external field from parser

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -477,25 +477,17 @@ which are valid only for certain beam types, are introduced further below under
     ``n_subcycles`` times with a time step of `dt/n_subcycles`. This can be used to improve accuracy
     in highly non-linear focusing fields.
 
-* ``hipace.external_E_uniform`` (3 `float`) optional (default `0. 0. 0.`)
-    Uniform external electric field applied to beam particles.
-    The components represent Ex-c*By, Ey+c*Bx and Ez respectively.
+* ``<beam name> or beams.external_E(x,y,z,t)`` (3 `float`) optional (default `0. 0. 0.`)
+    External electric field applied to beam particles as functions of x, y, z and t.
+    The components represent Ex, Ey and Ez respectively.
+    Note that z refers to the location of the beam particle inside the moving frame of reference
+    (zeta) and t to the physical time of the current timestep.
 
-* ``hipace.external_B_uniform`` (3 `float`) optional (default `0. 0. 0.`)
-    Uniform external magnetic field applied to beam particles.
-    The components represent Bx, By and Bz, respectively.
-
-* ``hipace.external_E_slope`` (3 `float`) optional (default `0. 0. 0.`)
-    Slope of a linear external electric field applied to beam particles.
-    The components represent d(Ex-c*By)/dx, d(Ey+c*Bx)/dy and d(Ez)/dz respectively.
-    For the last component, z actually represents the zeta coordinate zeta = z - c*t.
-
-* ``hipace.external_B_slope`` (3 `float`) optional (default `0. 0. 0.`)
-    Slope of a linear external electric field applied to beam particles.
-    The components represent d(Bx)/dy, d(By)/dx and d(Bz)/dz respectively.
-    Note the order of derivatives for the transverse components!
-    For the last component, z actually represents the zeta coordinate zeta = z - c*t.
-    For instance, ``hipace.external_B_slope = -1. 1. 0.`` creates an axisymmetric focusing lens of strength 1 T/m.
+* ``<beam name> or beams.external_B(x,y,z,t)`` (3 `float`) optional (default `0. 0. 0.`)
+    External magnetic field applied to beam particles as functions of x, y, z and t.
+    The components represent Bx, By and Bz respectively.
+    Note that z refers to the location of the beam particle inside the moving frame of reference
+    (zeta) and t to the physical time of the current timestep.
 
 * ``<beam name>.do_z_push`` (`bool`) optional (default `1`)
     Whether the beam particles are pushed along the z-axis. The momentum is still fully updated.

--- a/examples/beam_in_vacuum/inputs_RR
+++ b/examples/beam_in_vacuum/inputs_RR
@@ -16,7 +16,7 @@ my_constants.sigma_ux = emittance_x / sigma_x
 my_constants.uz = sqrt(gamma0^2 - 1 - sigma_ux^2)
 my_constants.w_beta = K*clight/sqrt(gamma0)
 
-hipace.external_E_slope = 1/2*kp*E0 1/2*kp*E0 0.
+hipace.external_E(x,y,z,t) = 1/2*kp*E0*x 1/2*kp*E0*y 0.
 
 hipace.dt = 30 /w_beta
 hipace.verbose = 1

--- a/examples/beam_in_vacuum/inputs_RR
+++ b/examples/beam_in_vacuum/inputs_RR
@@ -16,7 +16,7 @@ my_constants.sigma_ux = emittance_x / sigma_x
 my_constants.uz = sqrt(gamma0^2 - 1 - sigma_ux^2)
 my_constants.w_beta = K*clight/sqrt(gamma0)
 
-hipace.external_E(x,y,z,t) = 1/2*kp*E0*x 1/2*kp*E0*y 0.
+beams.external_E(x,y,z,t) = 1/2*kp*E0*x 1/2*kp*E0*y 0.
 
 hipace.dt = 30 /w_beta
 hipace.verbose = 1

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -157,21 +157,6 @@ public:
     amrex::Vector<amrex::DistributionMapping> m_slice_dm;
     /** xy slice BoxArray, vector over MR levels. Contains only one box */
     amrex::Vector<amrex::BoxArray> m_slice_ba;
-    /** Uniform external electric field applied to beam particles.
-        The components represent Ex-c*By, Ey+c*Bx and Ez respectively. */
-    amrex::RealVect m_external_E_uniform {0., 0., 0.};
-    /** Uniform external magnetic field applied to beam particles.
-        The components represent Bx, By and Bz, respectively. */
-    amrex::RealVect m_external_B_uniform {0., 0., 0.};
-    /** Slope of a linear external electric field applied to beam particles.
-        The components represent d(Ex-c*By)/dx, d(Ey+c*Bx)/dy and d(Ez)/dz respectively.
-        For the last component, z represents the zeta coordinate zeta = z - c*t */
-    amrex::RealVect m_external_E_slope {0., 0., 0.};
-    /** Slope of a linear external magnetic field applied to beam particles.
-        The components represent d(Bx)/dy, d(By)/dx and d(Bz)/dz respectively.
-        Note the order of derivatives for the transverse components!
-        For the last component, z represents the zeta coordinate zeta = z - c*t */
-    amrex::RealVect m_external_B_slope {0., 0., 0.};
     /** Pointer to current (and only) instance of class Hipace */
     inline static Hipace* m_instance = nullptr;
     /** Whether to use normalized units */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -103,13 +103,14 @@ Hipace::Hipace () :
     if (amrex::TilingIfNotGPU()) {
         DfltMfiTlng.EnableTiling();
     }
-    DeprecatedInput("hipace", "external_ExmBy_slope", "external_E_slope");
-    DeprecatedInput("hipace", "external_Ez_slope", "external_E_slope");
-    DeprecatedInput("hipace", "external_Ez_uniform", "external_E_uniform");
-    queryWithParser(pph, "external_E_uniform", m_external_E_uniform);
-    queryWithParser(pph, "external_B_uniform", m_external_B_uniform);
-    queryWithParser(pph, "external_E_slope", m_external_E_slope);
-    queryWithParser(pph, "external_B_slope", m_external_B_slope);
+
+    DeprecatedInput("hipace", "external_ExmBy_slope", "beams.external_E(x,y,z,t)", "", true);
+    DeprecatedInput("hipace", "external_Ez_slope", "beams.external_E(x,y,z,t)", "", true);
+    DeprecatedInput("hipace", "external_Ez_uniform", "beams.external_E(x,y,z,t)", "", true);
+    DeprecatedInput("hipace", "external_E_uniform", "beams.external_E(x,y,z,t)", "", true);
+    DeprecatedInput("hipace", "external_B_uniform","beams.external_B(x,y,z,t)", "", true);
+    DeprecatedInput("hipace", "external_E_slope", "beams.external_E(x,y,z,t)", "", true);
+    DeprecatedInput("hipace", "external_B_slope", "beams.external_B(x,y,z,t)", "", true);
 
     queryWithParser(pph, "salame_n_iter", m_salame_n_iter);
     queryWithParser(pph, "salame_do_advance", m_salame_do_advance);
@@ -552,9 +553,7 @@ Hipace::SolveOneSlice (int islice, int step)
     m_adaptive_time_step.GatherMinAccSlice(m_multi_beam, m_3D_geom[0], m_fields);
 
     // Push beam particles
-    m_multi_beam.AdvanceBeamParticlesSlice(m_fields, m_3D_geom, islice, current_N_level,
-                                           m_external_E_uniform, m_external_B_uniform,
-                                           m_external_E_slope, m_external_B_slope);
+    m_multi_beam.AdvanceBeamParticlesSlice(m_fields, m_3D_geom, islice, current_N_level);
 
     m_multi_beam.shiftSlippedParticles(islice, m_3D_geom[0]);
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -208,7 +208,7 @@ public:
     /** How often the insitu beam diagnostics should be computed and written
      * Default is 0, meaning no output */
     int m_insitu_period {0};
-    /** If external fields should be used for this beam */
+    /** Whether external fields should be used for this beam */
     bool m_use_external_fields = false;
     /** External field functions for Ex Ey Ez Bx By Bz */
     amrex::GpuArray<amrex::ParserExecutor<4>, 6> m_external_fields;

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -203,6 +203,12 @@ public:
     /** How often the insitu beam diagnostics should be computed and written
      * Default is 0, meaning no output */
     int m_insitu_period {0};
+    /** If external fields should be used for this beam */
+    bool m_use_external_fields = false;
+    /** External field functions for Ex Ey Ez Bx By Bz */
+    amrex::GpuArray<amrex::ParserExecutor<4>, 6> m_external_fields;
+    /** Owns data for m_external_fields */
+    amrex::Array<amrex::Parser, 6> m_external_fields_parser;
 private:
     std::string m_name; /**< name of the species */
     /** injection type, fixed_width or fixed_ppc */

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -65,6 +65,23 @@ BeamParticleContainer::ReadParameters ()
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_n_subcycles >= 1, "n_subcycles must be >= 1");
     queryWithParserAlt(pp, "do_reset_id_init", m_do_reset_id_init, pp_alt);
     queryWithParser(pp, "do_salame", m_do_salame);
+    amrex::Array<std::string, 3> field_str = {"0", "0", "0"};
+    m_use_external_fields = queryWithParserAlt(pp, "external_E(x,y,z,t)", field_str, pp_alt);
+    m_external_fields[0] = makeFunctionWithParser<4>(field_str[0], m_external_fields_parser[0],
+        {"x", "y", "z", "t"});
+    m_external_fields[1] = makeFunctionWithParser<4>(field_str[1], m_external_fields_parser[1],
+        {"x", "y", "z", "t"});
+    m_external_fields[2] = makeFunctionWithParser<4>(field_str[2], m_external_fields_parser[2],
+        {"x", "y", "z", "t"});
+    field_str = {"0", "0", "0"};
+    m_use_external_fields = queryWithParserAlt(pp, "external_B(x,y,z,t)", field_str, pp_alt)
+        || m_use_external_fields;
+    m_external_fields[3] = makeFunctionWithParser<4>(field_str[0], m_external_fields_parser[3],
+        {"x", "y", "z", "t"});
+    m_external_fields[4] = makeFunctionWithParser<4>(field_str[1], m_external_fields_parser[4],
+        {"x", "y", "z", "t"});
+    m_external_fields[5] = makeFunctionWithParser<4>(field_str[2], m_external_fields_parser[5],
+        {"x", "y", "z", "t"});
     if (m_injection_type == "fixed_ppc" || m_injection_type == "from_file"){
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_duz_per_uz0_dzeta == 0.,
         "Tilted beams and correlated energy spreads are only implemented for fixed weight beams");

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -49,22 +49,10 @@ public:
      * \param[in] gm Geometry object at level lev
      * \param[in] slice longitudinal slice
      * \param[in] current_N_level number of MR levels active on the current slice
-     * \param[in] extEu uniform external electric field applied to beam particles.
-                  The components represent Ex-c*By, Ey+c*Bx and Ez respectively.
-     * \param[in] extBu Uniform external magnetic field applied to beam particles.
-                  The components represent Bx, By and Bz, respectively.
-     * \param[in] extEs Slope of a linear external electric field applied to beam particles.
-                  The components represent d(Ex-c*By)/dx, d(Ey+c*Bx)/dy and d(Ez)/dz respectively.
-                  For the last component, z represents the zeta coordinate zeta = z - c*t.
-     * \param[in] extBs Slope of a linear external magnetic field applied to beam particles.
-                  The components represent d(Bx)/dy, d(By)/dx and d(Bz)/dz respectively.
-                  Note the order of derivatives for the transverse components!
-                  For the last component, z represents the zeta coordinate zeta = z - c*t
      */
     void AdvanceBeamParticlesSlice (
         const Fields& fields, amrex::Vector<amrex::Geometry> const& gm, const int slice,
-        int const current_N_level, const amrex::RealVect& extEu, const amrex::RealVect& extBu,
-        const amrex::RealVect& extEs, const amrex::RealVect& extBs);
+        int const current_N_level);
 
     /** Compute reduced beam diagnostics of current slice, store in member variable.
      * \param[in] step time step of simulation

--- a/src/particles/beam/MultiBeam.cpp
+++ b/src/particles/beam/MultiBeam.cpp
@@ -69,12 +69,10 @@ MultiBeam::shiftSlippedParticles (const int slice, amrex::Geometry const& geom)
 void
 MultiBeam::AdvanceBeamParticlesSlice (
     const Fields& fields, amrex::Vector<amrex::Geometry> const& gm, const int slice,
-    int const current_N_level, const amrex::RealVect& extEu, const amrex::RealVect& extBu,
-    const amrex::RealVect& extEs, const amrex::RealVect& extBs)
+    int const current_N_level)
 {
     for (int i=0; i<m_nbeams; i++) {
-        ::AdvanceBeamParticlesSlice(m_all_beams[i], fields, gm, slice, current_N_level,
-                                    extEu, extBu, extEs, extBs);
+        ::AdvanceBeamParticlesSlice(m_all_beams[i], fields, gm, slice, current_N_level);
     }
 }
 

--- a/src/particles/pusher/BeamParticleAdvance.H
+++ b/src/particles/pusher/BeamParticleAdvance.H
@@ -18,22 +18,10 @@
  * \param[in] gm Geometry of the simulation, to get the cell size etc.
  * \param[in] slice longitudinal slice
  * \param[in] current_N_level number of MR levels active on the current slice
- * \param[in] extEu uniform external electric field applied to beam particles.
-              The components represent Ex-c*By, Ey+c*Bx and Ez respectively.
- * \param[in] extBu Uniform external magnetic field applied to beam particles.
-              The components represent Bx, By and Bz, respectively.
- * \param[in] extEs Slope of a linear external electric field applied to beam particles.
-              The components represent d(Ex-c*By)/dx, d(Ey+c*Bx)/dy and d(Ez)/dz respectively.
-              For the last component, z represents the zeta coordinate zeta = z - c*t.
- * \param[in] extBs Slope of a linear external magnetic field applied to beam particles.
-              The components represent d(Bx)/dy, d(By)/dx and d(Bz)/dz respectively.
-              Note the order of derivatives for the transverse components!
-              For the last component, z represents the zeta coordinate zeta = z - c*t
  */
 void
 AdvanceBeamParticlesSlice (
     BeamParticleContainer& beam, const Fields& fields, amrex::Vector<amrex::Geometry> const& gm,
-    const int slice, int const current_N_level, const amrex::RealVect& extEu,
-    const amrex::RealVect& extBu, const amrex::RealVect& extEs, const amrex::RealVect& extBs);
+    const int slice, int const current_N_level);
 
 #endif //  BEAMPARTICLEADVANCE_H_

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -18,8 +18,7 @@
 void
 AdvanceBeamParticlesSlice (
     BeamParticleContainer& beam, const Fields& fields, amrex::Vector<amrex::Geometry> const& gm,
-    const int slice, int const current_N_level, const amrex::RealVect& extEu,
-    const amrex::RealVect& extBu, const amrex::RealVect& extEs, const amrex::RealVect& extBs)
+    const int slice, int const current_N_level)
 {
     HIPACE_PROFILE("AdvanceBeamParticlesSlice()");
     using namespace amrex::literals;
@@ -29,6 +28,7 @@ AdvanceBeamParticlesSlice (
     const bool do_z_push = beam.m_do_z_push;
     const int n_subcycles = beam.m_n_subcycles;
     const bool radiation_reaction = beam.m_do_radiation_reaction;
+    const amrex::Real time = Hipace::GetInstance().m_physical_time;
     const amrex::Real dt = Hipace::GetInstance().m_dt / n_subcycles;
     const amrex::Real background_density_SI = Hipace::m_background_density_SI;
     const bool normalized_units = Hipace::m_normalized_units;
@@ -101,10 +101,8 @@ AdvanceBeamParticlesSlice (
     const amrex::Real inv_c2 = 1.0_rt/(phys_const.c*phys_const.c);
     const amrex::Real charge_mass_ratio = beam.m_charge / beam.m_mass;
     const amrex::Real min_z = gm[0].ProbLo(2) + (slice-gm[0].Domain().smallEnd(2))*gm[0].CellSize(2);
-    const amrex::RealVect external_E_uniform = extEu;
-    const amrex::RealVect external_B_uniform = extBu;
-    const amrex::RealVect external_E_slope = extEs;
-    const amrex::RealVect external_B_slope = extBs;
+    bool use_external_fields = beam.m_use_external_fields;
+    auto external_fields = beam.m_external_fields;
 
     // Radiation reaction constant
     const amrex::ParticleReal q_over_mc = normalized_units ?
@@ -189,8 +187,10 @@ AdvanceBeamParticlesSlice (
                     slice_arr, psi_comp, ez_comp, bx_comp, by_comp, bz_comp,
                     dx_inv, dy_inv, x_pos_offset, y_pos_offset);
 
-                ApplyExternalField(xp, yp, zp, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
-                    external_E_uniform, external_B_uniform, external_E_slope, external_B_slope);
+                if (use_external_fields) {
+                    ApplyExternalField(xp, yp, zp, time, clight, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
+                        external_fields);
+                }
 
                 // use intermediate fields to calculate next (n+1) transverse momenta
                 amrex::ParticleReal ux_next = ux + dt * charge_mass_ratio

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -119,10 +119,15 @@ AdvanceBeamParticlesSlice (
                            PhysConstSI::m_e * PhysConstSI::c / wp_inv / PhysConstSI::q_e : 1;
 
     amrex::ParallelFor(
-        amrex::TypeList<amrex::CompileTimeOptions<0, 1, 2, 3>>{},
-        {Hipace::m_depos_order_xy},
+        amrex::TypeList<
+            amrex::CompileTimeOptions<0, 1, 2, 3>,
+            amrex::CompileTimeOptions<false, true>
+        >{}, {
+            Hipace::m_depos_order_xy,
+            use_external_fields
+        },
         beam.getNumParticlesIncludingSlipped(WhichBeamSlice::This),
-        [=] AMREX_GPU_DEVICE (int ip, auto depos_order) {
+        [=] AMREX_GPU_DEVICE (int ip, auto depos_order, auto c_use_external_fields) {
 
             if (ptd.id(ip) < 0) return;
 
@@ -187,7 +192,7 @@ AdvanceBeamParticlesSlice (
                     slice_arr, psi_comp, ez_comp, bx_comp, by_comp, bz_comp,
                     dx_inv, dy_inv, x_pos_offset, y_pos_offset);
 
-                if (use_external_fields) {
+                if (c_use_external_fields.value) {
                     ApplyExternalField(xp, yp, zp, time, clight, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
                         external_fields);
                 }

--- a/src/particles/pusher/ExternalFields.H
+++ b/src/particles/pusher/ExternalFields.H
@@ -15,47 +15,44 @@
  * \param[in] xp particle position x
  * \param[in] yp particle position y
  * \param[in] zp particle position x
+ * \param[in] time time of the current step
+ * \param[in] clight speed of light
  * \param[in,out] ExmByp Ex-By Field on particle
  * \param[in,out] EypBxp Ey+Bx Field on particle
  * \param[in,out] Ezp Electric field on particle, z component
  * \param[in,out] Bxp Magnetic field on particle, x component
  * \param[in,out] Byp Magnetic field on particle, y component
  * \param[in,out] Bzp Magnetic field on particle, z component
- * \param[in] ext_E_uniform Uniform electric field Ex-c*By, Ey+c*Bx, Ez to be applied
- * \param[in] ext_B_uniform Uniform magnetic field Bx, B, Bz to be applied
- * \param[in] ext_E_slope strength of external electric field d(Ex-c*By)/dx, d(Ey+c*Bx)/dy, d(Ez)/dz
- * \param[in] ext_B_slope strength of external magnetic field d(Bx)/dy, d(By)/dx, d(Bz)/dz
+ * \param[in] external_fields External field functions for Ex Ey Ez Bx By Bz
  */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void ApplyExternalField(
     const amrex::ParticleReal xp,
     const amrex::ParticleReal yp,
     const amrex::ParticleReal zp,
+    const amrex::ParticleReal time,
+    const amrex::ParticleReal clight,
     amrex::ParticleReal& ExmByp,
     amrex::ParticleReal& EypBxp,
     amrex::ParticleReal& Ezp,
     amrex::ParticleReal& Bxp,
     amrex::ParticleReal& Byp,
     amrex::ParticleReal& Bzp,
-    const amrex::RealVect& ext_E_uniform,
-    const amrex::RealVect& ext_B_uniform,
-    const amrex::RealVect& ext_E_slope,
-    const amrex::RealVect& ext_B_slope)
+    amrex::GpuArray<amrex::ParserExecutor<4>, 6> external_fields)
 {
+    const amrex::Real Ex = external_fields[0](xp, yp, zp, time);
+    const amrex::Real Ey = external_fields[1](xp, yp, zp, time);
+    const amrex::Real Ez = external_fields[2](xp, yp, zp, time);
+    const amrex::Real Bx = external_fields[3](xp, yp, zp, time);
+    const amrex::Real By = external_fields[4](xp, yp, zp, time);
+    const amrex::Real Bz = external_fields[5](xp, yp, zp, time);
 
-    if ((ext_E_uniform == amrex::RealVect(0.,0.,0.)) &&
-        (ext_B_uniform == amrex::RealVect(0.,0.,0.)) &&
-        (ext_E_slope == amrex::RealVect(0.,0.,0.)) &&
-        (ext_B_slope == amrex::RealVect(0.,0.,0.)) ) return;
-
-    ExmByp += ext_E_uniform[0] + ext_E_slope[0] * xp;
-    EypBxp += ext_E_uniform[1] + ext_E_slope[1] * yp;
-    Ezp    += ext_E_uniform[2] + ext_E_slope[2] * zp;
-    Bxp    += ext_B_uniform[0] + ext_B_slope[0] * yp;
-    Byp    += ext_B_uniform[1] + ext_B_slope[1] * xp;
-    Bzp    += ext_B_uniform[2] + ext_B_slope[2] * zp;
-
-    return;
+    ExmByp += Ex - clight * By;
+    EypBxp += Ey + clight * Bx;
+    Ezp    += Ez;
+    Bxp    += Bx;
+    Byp    += By;
+    Bzp    += Bz;
 }
 
 #endif // EXTERNALFIELDS_H_

--- a/tests/adaptive_time_step.1Rank.sh
+++ b/tests/adaptive_time_step.1Rank.sh
@@ -44,7 +44,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.radius = 1. \
         beam.n_subcycles = 4 \
         beam.ppc = 4 4 1 \
-        'hipace.external_E(x,y,z,t) = 0. 0. -.5*z' \
+        'beams.external_E(x,y,z,t) = 0. 0. -.5*z' \
         hipace.verbose=1\
         hipace.dt=adaptive\
         plasmas.adaptive_density=1 \
@@ -63,7 +63,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.radius = 1. \
         beam.n_subcycles = 4 \
         beam.ppc = 4 4 1 \
-        'hipace.external_E(x,y,z,t) = 0. 0. .5*z' \
+        'beams.external_E(x,y,z,t) = 0. 0. .5*z' \
         hipace.verbose=1\
         hipace.dt = adaptive\
         plasmas.adaptive_density=1 \

--- a/tests/adaptive_time_step.1Rank.sh
+++ b/tests/adaptive_time_step.1Rank.sh
@@ -44,7 +44,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.radius = 1. \
         beam.n_subcycles = 4 \
         beam.ppc = 4 4 1 \
-        hipace.external_E_slope = 0. 0. -.5 \
+        'hipace.external_E(x,y,z,t) = 0. 0. -.5*z' \
         hipace.verbose=1\
         hipace.dt=adaptive\
         plasmas.adaptive_density=1 \
@@ -63,7 +63,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.radius = 1. \
         beam.n_subcycles = 4 \
         beam.ppc = 4 4 1 \
-        hipace.external_E_slope = 0. 0. .5 \
+        'hipace.external_E(x,y,z,t) = 0. 0. .5*z' \
         hipace.verbose=1\
         hipace.dt = adaptive\
         plasmas.adaptive_density=1 \

--- a/tests/beam_evolution.1Rank.sh
+++ b/tests/beam_evolution.1Rank.sh
@@ -40,7 +40,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.density = 1.e-8 \
         beam.radius = 1. \
         beam.ppc = 4 4 1 \
-        hipace.external_E_slope = .5 .5 0. \
+        'hipace.external_E(x,y,z,t) = .5*x .5*y 0.' \
         hipace.file_prefix = $TEST_NAME
 
 # Compare the result with theory

--- a/tests/beam_evolution.1Rank.sh
+++ b/tests/beam_evolution.1Rank.sh
@@ -40,7 +40,7 @@ mpiexec -n 1 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         beam.density = 1.e-8 \
         beam.radius = 1. \
         beam.ppc = 4 4 1 \
-        'hipace.external_E(x,y,z,t) = .5*x .5*y 0.' \
+        'beams.external_E(x,y,z,t) = .5*x .5*y 0.' \
         hipace.file_prefix = $TEST_NAME
 
 # Compare the result with theory


### PR DESCRIPTION
This PR generalizes to external fields for beams to parser functions of x,y,z and t.

Performance test: external field negligible compared to gather.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
