### PR TITLE
Beam particle sorting

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -491,6 +491,18 @@ which are valid only for certain beam types, are introduced further below under
 * ``<beam name> or beams.do_reset_id_init`` (`bool`) optional (default `0`)
     Whether to reset the ID incrementor to 1 before initializing beam particles.
 
+* ``<beam name> or beams.reorder_period`` (`int`) optional (default `0`)
+    Reorder particles periodically to speed-up current deposition and particle push on GPU.
+    A good starting point is a period of 1 to reorder beam particles on every timestep.
+    To disable reordering set this to 0. For very narrow beams the sorting may take longer than
+    the time saved in the beam push and deposition.
+
+* ``<beam name> or beams.reorder_idx_type`` (2 `int`) optional (default `0 0` or `1 1`)
+    Change if beam particles are binned to cells (0), nodes (1) or both (2)
+    for both x and y direction as part of the reordering.
+    The ideal index type is different for beam push and beam deposition so some experimentation
+    may be required to find the overall fastest setting for a specific simulation.
+
 Option: ``fixed_weight_pdf``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -449,6 +449,7 @@ Hipace::SolveOneSlice (int islice, int step)
 
     if (islice == m_3D_geom[0].Domain().bigEnd(2)) {
         m_multi_buffer.get_data(islice, m_multi_beam, m_multi_laser, WhichBeamSlice::This);
+        m_multi_beam.ReorderParticles( WhichBeamSlice::This, step, m_slice_geom[0]);
     }
 
     m_multi_plasma.InSituComputeDiags(step, islice, m_max_step, m_physical_time, m_max_time);
@@ -505,6 +506,7 @@ Hipace::SolveOneSlice (int islice, int step)
 
     if (islice-1 >= m_3D_geom[0].Domain().smallEnd(2)) {
         m_multi_buffer.get_data(islice-1, m_multi_beam, m_multi_laser, WhichBeamSlice::Next);
+        m_multi_beam.ReorderParticles( WhichBeamSlice::Next, step, m_slice_geom[0]);
     }
 
     if (m_N_level > 1) {

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -145,6 +145,11 @@ public:
     void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D,
                      const int which_slice);
 
+    /** \brief Reorder beam particles to speed-up push and current deposition
+     * \param[in] beam_slice beam slice to reorder, WhichBeamSlice::This WhichBeamSlice::Next
+     * \param[in] step current time step
+     * \param[in] slice_geom Geometry object for one xy slice
+     */
     void ReorderParticles (int beam_slice, int step, amrex::Geometry& slice_geom);
 
     /** Returns elementary charge q_e (or -q_e for electrons). */

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -145,6 +145,8 @@ public:
     void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D,
                      const int which_slice);
 
+    void ReorderParticles (int beam_slice, int step, amrex::Geometry& slice_geom);
+
     /** Returns elementary charge q_e (or -q_e for electrons). */
     amrex::Real GetCharge () const {return m_charge;}
 
@@ -221,6 +223,10 @@ private:
     /** radius of the beam insitu diagnostics */
     amrex::Real m_insitu_radius {std::numeric_limits<amrex::Real>::infinity()};
     GetInitialMomentum m_get_momentum {}; /**< momentum profile of the beam */
+    /** After how many slices the particles are reordered. 0: off */
+    int m_reorder_period = 0;
+    /** 2D reordering index type. 0: cell, 1: node, 2: both */
+    amrex::IntVect m_reorder_idx_type = {0, 0, 0};
 
     // fixed_ppc:
 

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -115,6 +115,8 @@ public:
     void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D,
                      const int which_slice);
 
+    void ReorderParticles (int beam_slice, int step, amrex::Geometry& slice_geom);
+
     /** \brief returns if the SALAME algorithm should be used on this slice
      * \param[in] step time step of simulation
      */

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -103,6 +103,11 @@ public:
     void TagByLevel (const int current_N_level, amrex::Vector<amrex::Geometry> const& geom3D,
                      const int which_slice);
 
+    /** \brief Reorder beam particles to speed-up push and current deposition
+     * \param[in] beam_slice beam slice to reorder, WhichBeamSlice::This WhichBeamSlice::Next
+     * \param[in] step current time step
+     * \param[in] slice_geom Geometry object for one xy slice
+     */
     void ReorderParticles (int beam_slice, int step, amrex::Geometry& slice_geom);
 
     /** \brief returns if the SALAME algorithm should be used on this slice

--- a/src/particles/beam/MultiBeam.cpp
+++ b/src/particles/beam/MultiBeam.cpp
@@ -110,6 +110,14 @@ MultiBeam::InSituWriteToFile (int step, amrex::Real time, const amrex::Geometry&
     }
 }
 
+void
+MultiBeam::ReorderParticles (int beam_slice, int step, amrex::Geometry& slice_geom)
+{
+    for (auto& beam : m_all_beams) {
+        beam.ReorderParticles(beam_slice, step, slice_geom);
+    }
+}
+
 bool MultiBeam::AnySpeciesSalame () {
     for (int i = 0; i < m_nbeams; ++i) {
         if (m_all_beams[i].m_do_salame) {


### PR DESCRIPTION
Sorting beam particles can improve the performance of beam current deposition and beam push by about 2x, however for beams that are very narrow and only cover a few cells transversely the sorting itself may take a significant amount of time.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
