### PR TITLE
Update version numbers before release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # Preamble ####################################################################
 #
 cmake_minimum_required(VERSION 3.18.0)
-project(HiPACE VERSION 23.10)
+project(HiPACE VERSION 23.11)
 
 # helper functions
 include(${HiPACE_SOURCE_DIR}/cmake/HiPACEFunctions.cmake)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -143,7 +143,7 @@ macro(find_amrex)
     else()
         message(STATUS "Searching for pre-installed AMReX ...")
         set(COMPONENT_PRECISION ${HiPACE_PRECISION} P${HiPACE_PRECISION})
-        find_package(AMReX 23.10 CONFIG REQUIRED COMPONENTS 3D ${COMPONENT_PRECISION} PARTICLES)
+        find_package(AMReX 23.11 CONFIG REQUIRED COMPONENTS 3D ${COMPONENT_PRECISION} PARTICLES)
         # note: TINYP skipped because user-configured and optional
 
         # AMReX CMake helper scripts
@@ -162,7 +162,7 @@ set(HiPACE_amrex_src ""
 set(HiPACE_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(HiPACE_amrex_internal)")
-set(HiPACE_amrex_branch "23.10"
+set(HiPACE_amrex_branch "23.11"
     CACHE STRING
     "Repository branch for HiPACE_amrex_repo if(HiPACE_amrex_internal)")
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,8 +26,8 @@ sys.path.insert(0, os.path.abspath('../../src/'))
 project = 'HiPACE++'
 copyright = '2021, Severin Diederichs, Axel Huebl, Remi Lehe, Andrew Myers, Alexander Sinn, Maxence Thevenet, Weiqun Zhang'
 author = 'Severin Diederichs, Axel Huebl, Remi Lehe, Andrew Myers, Alexander Sinn, Maxence Thevenet, Weiqun Zhang'
-version = u'23.10'
-release = u'23.10'
+version = u'23.11'
+release = u'23.11'
 
 # -- General configuration ---------------------------------------------------
 

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-HiPACE++ v23.10 Copyright (c) 2021-2023, The Regents of the University of California,
+HiPACE++ v23.11 Copyright (c) 2021-2023, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of
 any required approvals from the U.S. Dept. of Energy) and Deutsches
 Elektronen-Synchrotron (DESY). All rights reserved.


### PR DESCRIPTION
We have been building all month on amrex `23.10`, not `development`. So we have not tested anything included in amrex `23.11`, but the `23.11` release of hipace should build on amrex `23.11` to do as usual. Let's see if CI passes, then it's probably fine, but if we encounter issues we know where to look.