### PR TITLE
[mini] Fix typo in laser pulse length to pulse duration conversion

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -797,7 +797,7 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
     The laser pulse length in `z`. Use either the pulse length or the pulse duration ``<laser name>.tau``.
 
 * ``<laser name>.tau`` (`float`) optional (default `0`)
-    The laser pulse duration. The pulse length is set to `laser.tau`:math:`/c_0`.
+    The laser pulse duration. The pulse length is set to `laser.tau`:math:`*c_0`.
     Use either the pulse length or the pulse duration.
 
 * ``<laser name>.focal_distance`` (`float`)

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -25,7 +25,7 @@ Laser::Laser (std::string name, bool laser_from_file)
     bool duration_is_specified = queryWithParser(pp, "tau", m_tau);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( length_is_specified + duration_is_specified == 1,
         "Please specify exlusively either the pulse length L0 or the duration tau of the laser");
-    if (duration_is_specified) m_L0 = m_tau/get_phys_const().c;
+    if (duration_is_specified) m_L0 = m_tau*get_phys_const().c;
     queryWithParser(pp, "focal_distance", m_focal_distance);
 
     queryWithParser(pp, "position_mean", m_position_mean);


### PR DESCRIPTION
I think this is incorrect currently