### PR TITLE
Add option to symmetrize fields

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -247,6 +247,10 @@ The default is to use the explicit solver. **We strongly recommend to use the ex
     ``fields.extended_solve = true`` and ``geometry.is_periodic = false false false``.
     Only available with the predictor-corrector solver.
 
+* ``fields.do_symmetrize`` (`bool`) optional (default `0`)
+    Symmetrizes current and charge densities transversely before the field solve.
+    Each cell at (`x`, `y`) is averaged with cells at (`-x`, `y`), (`x`, `-y`) and (`-x`, `-y`).
+
 Explicit solver parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -729,6 +729,12 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice)
     m_fields.LevelUpBoundary(m_3D_geom, lev, which_slice, "By",
         m_fields.m_slices_nguards, m_fields.m_poisson_nguards);
 
+    if (m_fields.m_do_symmetrize) {
+        m_fields.SymmetrizeFields(Comps[which_slice_chi]["chi"], lev, 1, 1);
+        m_fields.SymmetrizeFields(Comps[which_slice]["Sx"], lev, -1, 1);
+        m_fields.SymmetrizeFields(Comps[which_slice]["Sy"], lev, 1, -1);
+    }
+
 #ifdef AMREX_USE_LINEAR_SOLVERS
     if (m_use_amrex_mlmg) {
         // Copy chi to chi2

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -241,6 +241,15 @@ public:
      */
     void SolvePoissonBxBy (amrex::Vector<amrex::Geometry> const& geom, const int current_N_level,
                            const int which_slice);
+    /** \brief Symmetrize fields by averaging over (x,y), symm_x*(-x,y),
+     * symm_y*(x,-y) and symm_x*symm_y*(-x,-y) where symm_x and symm_y can be 1 or -1.
+     *
+     * \param[in] field_comp component index of the filed
+     * \param[in] lev current level
+     * \param[in] symm_x type of reflection in x direction
+     * \param[in] symm_y type of reflection in y direction
+     */
+    void SymmetrizeFields (int field_comp, const int lev, const int symm_x, const int symm_y);
     /** \brief Sets the initial guess of the B field from the two previous slices
      *
      * This modifies component Bx or By of slice 1 in m_fields.m_slices
@@ -474,6 +483,8 @@ public:
     inline static amrex::IntVect m_poisson_nguards {-1, -1, -1};
     /** If the poisson solver should include the guard cells */
     bool m_extended_solve = false;
+    /** Whether the currents should be symmetrized for the field solve */
+    bool m_do_symmetrize = false;
 
 private:
     /** Vector over levels of all required fields to compute current slice */


### PR DESCRIPTION
Add option to symmetrize the fields (charge and currents before the field solve).


```
fields.do_symmetrize = 0
```
x-y plot with an offset beam:
![image](https://github.com/Hi-PACE/hipace/assets/64009254/6257f658-215a-4627-ac70-95d4e5d9d637)

```
fields.do_symmetrize = 1
```
![image](https://github.com/Hi-PACE/hipace/assets/64009254/50f0d930-033d-4be9-9b87-6bdf3791f82c)


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
