### PR TITLE
Doc: Button to Copy Code Blocks

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@
 # License: BSD-3-Clause-LBNL
 
 sphinx>=5.3
+sphinx-copybutton
 sphinx_rtd_theme>=1.1.1
 recommonmark
 # docutils 0.17 breaks HTML tags & RTD theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,9 @@ release = u'23.11'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['breathe'
+extensions = [
+    "breathe",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Add a copy button to every code block in the docs.

X-ref: https://github.com/ECP-WarpX/WarpX/pull/4004

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [x] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
