### PR TITLE
Fix typo in assert

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -149,7 +149,7 @@ Hipace::Hipace () :
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         (((double(m_comms_buffer_max_leading_slices) + m_comms_buffer_max_trailing_slices)
         * amrex::ParallelDescriptor::NProcs()) > m_3D_geom[0].Domain().length(2))
-        || (m_max_step <= amrex::ParallelDescriptor::NProcs()),
+        || (m_max_step < amrex::ParallelDescriptor::NProcs()),
         "comms_buffer_max_leading_slices and comms_buffer_max_trailing_slices must be large enough"
         " to distribute all slices between all ranks if there are more timesteps than ranks");
 


### PR DESCRIPTION
There was a small typo in the assert for m_comms_buffer_max_leading_slices/m_comms_buffer_max_trailing_slices were it was not strict enough.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
