### PR TITLE
Laser FFT solver for AMD

### DIFF
--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -223,8 +223,6 @@ private:
     /** Geometry of the laser file, 'rt' or 'xyt' */
     std::string m_file_geometry = "";
 
-    /** Nb fields in 3D array: new_real, new_imag, old_real, old_imag */
-    int m_nfields_3d {4};
     /** Array of N slices required to compute current slice */
     amrex::MultiFab m_slices;
     amrex::Real m_MG_tolerance_rel = 1.e-4;

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -42,9 +42,6 @@ MultiLaser::ReadParameters ()
     m_use_laser = m_names[0] != "no_laser";
 
     if (!m_use_laser) return;
-#if defined(AMREX_USE_HIP)
-    amrex::Abort("Laser solver not implemented with HIP");
-#endif
 
     m_laser_from_file = queryWithParser(pp, "input_file", m_input_file_path);
 


### PR DESCRIPTION
This PR enables the use of the FFT laser solver on AMD hardware using rocfft.

It was tested using the `laser_evolution.SI.2Rank` CI test on LUMI


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
