### PR TITLE
Use 64 bit idcpu

### DIFF
--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -99,7 +99,6 @@ private:
     /** vector of length nbeams with the numbers of particles already written to file */
     amrex::Vector<uint64_t> m_offset;
 
-    std::vector<std::vector<std::shared_ptr<int>>> m_int_beam_data {};
     std::vector<std::vector<std::shared_ptr<uint64_t>>> m_uint64_beam_data {};
     std::vector<std::vector<std::shared_ptr<amrex::ParticleReal>>> m_real_beam_data {};
 

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -236,7 +236,8 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
             uint64_t * const uint64_data = m_uint64_beam_data[ibeam][idx].get();
 
             for (uint64_t i=0; i<np_total; ++i) {
-                uint64_data[i] = amrex::ConstParticleIDWrapper(uint64_data[i]);
+                amrex::Long id = amrex::ConstParticleIDWrapper(uint64_data[i]);
+                uint64_data[i] = id;
             }
 
             // handle scalar and non-scalar records by name

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -166,7 +166,6 @@ OpenPMDWriter::InitBeamData (MultiBeam& beams, const amrex::Vector< std::string 
 
     const int nbeams = beams.get_nbeams();
     m_offset.resize(nbeams);
-    m_int_beam_data.resize(nbeams);
     m_uint64_beam_data.resize(nbeams);
     m_real_beam_data.resize(nbeams);
     for (int ibeam = 0; ibeam < nbeams; ibeam++) {
@@ -177,27 +176,15 @@ OpenPMDWriter::InitBeamData (MultiBeam& beams, const amrex::Vector< std::string 
         // initialize beam IO on first slice
         const uint64_t np_total = beams.getBeam(ibeam).getTotalNumParticles();
 
-        m_int_beam_data[ibeam].resize(m_int_names.size());
-
-        for (std::size_t idx=0; idx<m_int_beam_data[ibeam].size(); idx++) {
-            m_int_beam_data[ibeam][idx].reset(
-                reinterpret_cast<int*>(
-                    amrex::The_Pinned_Arena()->alloc(sizeof(int)*np_total)
-                ),
-                [](int *p){
-                    amrex::The_Pinned_Arena()->free(reinterpret_cast<void*>(p));
-                });
-        }
-
         m_uint64_beam_data[ibeam].resize(m_int_names.size());
 
         for (std::size_t idx=0; idx<m_uint64_beam_data[ibeam].size(); idx++) {
             m_uint64_beam_data[ibeam][idx].reset(
                 reinterpret_cast<uint64_t*>(
-                    amrex::The_Cpu_Arena()->alloc(sizeof(uint64_t)*np_total)
+                    amrex::The_Pinned_Arena()->alloc(sizeof(uint64_t)*np_total)
                 ),
                 [](uint64_t *p){
-                    amrex::The_Cpu_Arena()->free(reinterpret_cast<void*>(p));
+                    amrex::The_Pinned_Arena()->free(reinterpret_cast<void*>(p));
                 });
         }
 
@@ -245,12 +232,11 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
         SetupPos(beam_species, beam, np_total, geom);
         SetupRealProperties(beam_species, m_real_names, np_total);
 
-        for (std::size_t idx=0; idx<m_int_beam_data[ibeam].size(); idx++) {
-            const int * const int_data = m_int_beam_data[ibeam][idx].get();
+        for (std::size_t idx=0; idx<m_uint64_beam_data[ibeam].size(); idx++) {
             uint64_t * const uint64_data = m_uint64_beam_data[ibeam][idx].get();
 
             for (uint64_t i=0; i<np_total; ++i) {
-                uint64_data[i] = static_cast<uint64_t>(int_data[i]);
+                uint64_data[i] = amrex::ConstParticleIDWrapper(uint64_data[i]);
             }
 
             // handle scalar and non-scalar records by name
@@ -291,11 +277,11 @@ OpenPMDWriter::CopyBeams (MultiBeam& beams, const amrex::Vector< std::string > b
             // copy data from GPU to IO buffer
             auto& soa = beam.getBeamSlice(WhichBeamSlice::This).GetStructOfArrays();
 
-            for (std::size_t idx=0; idx<m_int_beam_data[ibeam].size(); idx++) {
+            for (std::size_t idx=0; idx<m_uint64_beam_data[ibeam].size(); idx++) {
                 amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost,
-                    soa.GetIntData(idx).begin(),
-                    soa.GetIntData(idx).begin() + np,
-                    m_int_beam_data[ibeam][idx].get() + m_offset[ibeam]);
+                    soa.GetIdCPUData().begin(),
+                    soa.GetIdCPUData().begin() + np,
+                    m_uint64_beam_data[ibeam][idx].get() + m_offset[ibeam]);
             }
 
             for (std::size_t idx=0; idx<m_real_beam_data[ibeam].size(); idx++) {
@@ -421,7 +407,6 @@ OpenPMDWriter::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
 void OpenPMDWriter::flush ()
 {
     amrex::Gpu::streamSynchronize();
-    m_int_beam_data.resize(0);
     m_uint64_beam_data.resize(0);
     m_real_beam_data.resize(0);
     if (m_outputSeries) {

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -30,7 +30,7 @@ struct BeamIdx
         real_nattribs=real_nattribs_in_buffer
     };
     enum {
-        id=0,        // id
+        id=0,        // id TODO: remove this
         int_nattribs_in_buffer,
         // cpu is not stored or communicated in MultiBuffer, only used temporarily per slice
         cpu=int_nattribs_in_buffer,

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -30,13 +30,11 @@ struct BeamIdx
         real_nattribs=real_nattribs_in_buffer
     };
     enum {
-        id=0,        // id TODO: remove this
+        // no extra components stored in MultiBuffer, besides 64bit idcpu
         int_nattribs_in_buffer,
-        // cpu is not stored or communicated in MultiBuffer, only used temporarily per slice
-        cpu=int_nattribs_in_buffer,
         // nsubcycles: by how many subcycles was this particle pushed already
         // nsubcycles is not stored or communicated in MultiBuffer
-        nsubcycles,
+        nsubcycles=int_nattribs_in_buffer,
         int_nattribs
     };
 };

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -93,6 +93,8 @@ BeamParticleContainer::ReadParameters ()
     }
     queryWithParserAlt(pp, "initialize_on_cpu", m_initialize_on_cpu, pp_alt);
     auto& soa = getBeamInitSlice().GetStructOfArrays();
+    soa.GetIdCPUData().setArena(
+        m_initialize_on_cpu ? amrex::The_Pinned_Arena() : amrex::The_Arena());
     for (int rcomp = 0; rcomp < BeamIdx::real_nattribs_in_buffer; ++rcomp) {
         soa.GetRealData()[rcomp].setArena(
             m_initialize_on_cpu ? amrex::The_Pinned_Arena() : amrex::The_Arena());

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -304,7 +304,7 @@ void BeamParticleContainer::TagByLevel (const int current_N_level,
     auto& soa = getBeamSlice(which_slice).GetStructOfArrays();
     const amrex::Real * const pos_x = soa.GetRealData(BeamIdx::x).data();
     const amrex::Real * const pos_y = soa.GetRealData(BeamIdx::y).data();
-    int * const cpup = soa.GetIntData(BeamIdx::cpu).data();
+    auto * const idcpup = soa.GetIdCPUData().data();
 
     const int lev1_idx = std::min(1, current_N_level-1);
     const int lev2_idx = std::min(2, current_N_level-1);
@@ -330,15 +330,15 @@ void BeamParticleContainer::TagByLevel (const int current_N_level,
                 lo_x_lev2 < xp && xp < hi_x_lev2 &&
                 lo_y_lev2 < yp && yp < hi_y_lev2) {
                 // level 2
-                cpup[ip] = 2;
+                amrex::ParticleCPUWrapper{idcpup[ip]} = 2;
             } else if (current_N_level > 1 &&
                 lo_x_lev1 < xp && xp < hi_x_lev1 &&
                 lo_y_lev1 < yp && yp < hi_y_lev1) {
                 // level 1
-                cpup[ip] = 1;
+                amrex::ParticleCPUWrapper{idcpup[ip]} = 1;
             } else {
                 // level 0
-                cpup[ip] = 0;
+                amrex::ParticleCPUWrapper{idcpup[ip]} = 0;
             }
         }
     );
@@ -376,8 +376,8 @@ BeamParticleContainer::intializeSlice (int slice, int which_slice) {
                 ptd.rdata(BeamIdx::uy)[ip] = ptd_init.rdata(BeamIdx::uy)[idx_src];
                 ptd.rdata(BeamIdx::uz)[ip] = ptd_init.rdata(BeamIdx::uz)[idx_src];
 
-                ptd.idata(BeamIdx::id)[ip] = ptd_init.idata(BeamIdx::id)[idx_src];
-                ptd.idata(BeamIdx::cpu)[ip] = 0;
+                ptd.id(ip) = ptd_init.id(idx_src);
+                ptd.cpu(ip) = 0;
                 ptd.idata(BeamIdx::nsubcycles)[ip] = 0;
             }
         );
@@ -461,7 +461,7 @@ BeamParticleContainer::InSituComputeDiags (int islice)
     const auto uxp = soa.GetRealData(BeamIdx::ux).data();
     const auto uyp = soa.GetRealData(BeamIdx::uy).data();
     const auto uzp = soa.GetRealData(BeamIdx::uz).data();
-    auto idp = soa.GetIntData(BeamIdx::id).data();
+    auto idcpup = soa.GetIdCPUData().data();
 
     // Tuple contains:
     //      0,   1,     2,   3,     4,   5,     6,    7,      8,    9,     10,   11,     12,
@@ -486,7 +486,7 @@ BeamParticleContainer::InSituComputeDiags (int islice)
         getNumParticles(WhichBeamSlice::This), reduce_data,
         [=] AMREX_GPU_DEVICE (int ip) -> ReduceTuple
         {
-            if (idp[ip] < 0 ||
+            if (amrex::ConstParticleIDWrapper(idcpup[ip]) < 0 ||
                 pos_x[ip]*pos_x[ip] + pos_y[ip]*pos_y[ip] > insitu_radius*insitu_radius) {
                 return{0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt,
                     0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0._rt, 0};

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -25,8 +25,7 @@ namespace
 {
     /** \brief Adds a single beam particle
      *
-     * \param[in,out] rarrdata real array with SoA beam data
-     * \param[in,out] iarrdata int array with SoA beam data
+     * \param[in,out] ptd real and int beam data
      * \param[in] x position in x
      * \param[in] y position in y
      * \param[in] z position in z
@@ -40,27 +39,25 @@ namespace
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void AddOneBeamParticle (
-        amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs_in_buffer> rarrdata,
-        amrex::GpuArray<int*, BeamIdx::int_nattribs_in_buffer> iarrdata, const amrex::Real& x,
+        const BeamTileInit::ParticleTileDataType& ptd, const amrex::Real& x,
         const amrex::Real& y, const amrex::Real& z, const amrex::Real& ux, const amrex::Real& uy,
         const amrex::Real& uz, const amrex::Real& weight, const int& pid,
         const int& ip, const amrex::Real& speed_of_light) noexcept
     {
-        rarrdata[BeamIdx::x  ][ip] = x;
-        rarrdata[BeamIdx::y  ][ip] = y;
-        rarrdata[BeamIdx::z  ][ip] = z;
-        rarrdata[BeamIdx::ux ][ip] = ux * speed_of_light;
-        rarrdata[BeamIdx::uy ][ip] = uy * speed_of_light;
-        rarrdata[BeamIdx::uz ][ip] = uz * speed_of_light;
-        rarrdata[BeamIdx::w  ][ip] = std::abs(weight);
+        ptd.rdata(BeamIdx::x  )[ip] = x;
+        ptd.rdata(BeamIdx::y  )[ip] = y;
+        ptd.rdata(BeamIdx::z  )[ip] = z;
+        ptd.rdata(BeamIdx::ux )[ip] = ux * speed_of_light;
+        ptd.rdata(BeamIdx::uy )[ip] = uy * speed_of_light;
+        ptd.rdata(BeamIdx::uz )[ip] = uz * speed_of_light;
+        ptd.rdata(BeamIdx::w  )[ip] = std::abs(weight);
 
-        iarrdata[BeamIdx::id ][ip] = pid > 0 ? pid + ip : pid;
+        ptd.id(ip) = pid > 0 ? pid + ip : pid;
     }
 
     /** \brief Adds a single beam particle into the per-slice BeamTile
      *
-     * \param[in,out] rarrdata real array with SoA beam data
-     * \param[in,out] iarrdata int array with SoA beam data
+     * \param[in,out] ptd real and int beam data
      * \param[in] x position in x
      * \param[in] y position in y
      * \param[in] z position in z
@@ -75,19 +72,18 @@ namespace
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void AddOneBeamParticleSlice (
-        amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs> rarrdata,
-        amrex::GpuArray<int*, BeamIdx::int_nattribs> iarrdata,const amrex::Real x,
+        const BeamTile::ParticleTileDataType& ptd, const amrex::Real x,
         const amrex::Real y, const amrex::Real z, const amrex::Real ux, const amrex::Real uy,
         const amrex::Real uz, const amrex::Real weight, const amrex::Long pid,
         const amrex::Long ip, const amrex::Real speed_of_light, const bool is_valid=true) noexcept
     {
-        rarrdata[BeamIdx::x  ][ip] = x;
-        rarrdata[BeamIdx::y  ][ip] = y;
-        rarrdata[BeamIdx::z  ][ip] = z;
-        rarrdata[BeamIdx::ux ][ip] = ux * speed_of_light;
-        rarrdata[BeamIdx::uy ][ip] = uy * speed_of_light;
-        rarrdata[BeamIdx::uz ][ip] = uz * speed_of_light;
-        rarrdata[BeamIdx::w  ][ip] = std::abs(weight);
+        ptd.rdata(BeamIdx::x  )[ip] = x;
+        ptd.rdata(BeamIdx::y  )[ip] = y;
+        ptd.rdata(BeamIdx::z  )[ip] = z;
+        ptd.rdata(BeamIdx::ux )[ip] = ux * speed_of_light;
+        ptd.rdata(BeamIdx::uy )[ip] = uy * speed_of_light;
+        ptd.rdata(BeamIdx::uz )[ip] = uz * speed_of_light;
+        ptd.rdata(BeamIdx::w  )[ip] = std::abs(weight);
 
         // ensure id is always valid
         // it will repeat if there are more than 2^31-1 particles
@@ -95,9 +91,9 @@ namespace
         if (id == 0) id = 1;
         if (!is_valid) id = -1;
 
-        iarrdata[BeamIdx::id ][ip] = id;
-        iarrdata[BeamIdx::cpu][ip] = 0;
-        iarrdata[BeamIdx::nsubcycles][ip] = 0;
+        ptd.id(ip) = id;
+        ptd.cpu(ip) = 0;
+        ptd.idata(BeamIdx::nsubcycles)[ip] = 0;
     }
 }
 
@@ -271,11 +267,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
     if (num_to_add == 0) return;
     auto& particle_tile = getBeamSlice(which_beam_slice);
 
-    amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs> rarrdata =
-        particle_tile.GetStructOfArrays().realarray();
-
-    amrex::GpuArray<int*, BeamIdx::int_nattribs> iarrdata =
-        particle_tile.GetStructOfArrays().intarray();
+    const auto ptd = particle_tile.getParticleTileData();
 
     const uint64_t pid = m_id64;
     m_id64 += num_to_add;
@@ -324,7 +316,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
 
                 const amrex::Real weight = density * scale_fac;
 
-                AddOneBeamParticleSlice(rarrdata, iarrdata, x, y, z, u[0], u[1], u[2], weight,
+                AddOneBeamParticleSlice(ptd, x, y, z, u[0], u[1], u[2], weight,
                                         pid, pidx, speed_of_light, true);
 
                 ++pidx;
@@ -389,10 +381,7 @@ InitBeamFixedWeightSlice (int slice, int which_slice)
     auto& particle_tile = getBeamSlice(which_slice);
 
     // Access particles' SoA
-    amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs> rarrdata =
-        particle_tile.GetStructOfArrays().realarray();
-    amrex::GpuArray<int*, BeamIdx::int_nattribs> iarrdata =
-        particle_tile.GetStructOfArrays().intarray();
+    const auto ptd = particle_tile.getParticleTileData();
 
     const amrex::Long slice_offset = m_init_sorter.m_box_offsets_cpu[slice];
     const auto permutations = m_init_sorter.m_box_permutations.dataPtr();
@@ -440,21 +429,21 @@ InitBeamFixedWeightSlice (int slice, int which_slice)
 
             if (!do_symmetrize)
             {
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
+                AddOneBeamParticleSlice(ptd, cental_x_pos+x, cental_y_pos+y,
                                         z_central, u[0], u[1], u[2], weight,
                                         pid, i, clight, is_valid);
 
             } else {
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos+y,
+                AddOneBeamParticleSlice(ptd, cental_x_pos+x, cental_y_pos+y,
                                         z_central, u[0], u[1], u[2], weight,
                                         pid, 4*i, clight, is_valid);
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos+y,
+                AddOneBeamParticleSlice(ptd, cental_x_pos-x, cental_y_pos+y,
                                         z_central, -u[0], u[1], u[2], weight,
                                         pid, 4*i+1, clight, is_valid);
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos+x, cental_y_pos-y,
+                AddOneBeamParticleSlice(ptd, cental_x_pos+x, cental_y_pos-y,
                                         z_central, u[0], -u[1], u[2], weight,
                                         pid, 4*i+2, clight, is_valid);
-                AddOneBeamParticleSlice(rarrdata, iarrdata, cental_x_pos-x, cental_y_pos-y,
+                AddOneBeamParticleSlice(ptd, cental_x_pos-x, cental_y_pos-y,
                                         z_central, -u[0], -u[1], u[2], weight,
                                         pid, 4*i+3, clight, is_valid);
             }
@@ -594,10 +583,7 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
 
         auto& particle_tile = getBeamSlice(which_slice);
         // Access particles' SoA
-        amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs> rarrdata =
-            particle_tile.GetStructOfArrays().realarray();
-        amrex::GpuArray<int*, BeamIdx::int_nattribs> iarrdata =
-            particle_tile.GetStructOfArrays().intarray();
+        const auto ptd = particle_tile.getParticleTileData();
 
         const uint64_t pid = m_id64;
         m_id64 += num_to_add;
@@ -666,17 +652,17 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
 
                 if (!do_symmetrize)
                 {
-                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean+x, y_mean+y,
+                    AddOneBeamParticleSlice(ptd, x_mean+x, y_mean+y,
                                             z, ux, uy, uz, weight, pid, i, clight, is_valid);
 
                 } else {
-                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean+x, y_mean+y,
+                    AddOneBeamParticleSlice(ptd, x_mean+x, y_mean+y,
                                             z, ux, uy, uz, weight, pid, 4*i, clight, is_valid);
-                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean-x, y_mean+y,
+                    AddOneBeamParticleSlice(ptd, x_mean-x, y_mean+y,
                                             z, -ux, uy, uz, weight, pid, 4*i+1, clight, is_valid);
-                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean+x, y_mean-y,
+                    AddOneBeamParticleSlice(ptd, x_mean+x, y_mean-y,
                                             z, ux, -uy, uz, weight, pid, 4*i+2, clight, is_valid);
-                    AddOneBeamParticleSlice(rarrdata, iarrdata, x_mean-x, y_mean-y,
+                    AddOneBeamParticleSlice(ptd, x_mean-x, y_mean-y,
                                             z, -ux, -uy, uz, weight, pid, 4*i+3, clight, is_valid);
                 }
             });
@@ -1043,10 +1029,7 @@ InitBeamFromFile (const std::string input_file,
     auto old_size = particle_tile.size();
     auto new_size = old_size + num_to_add;
     particle_tile.resize(new_size);
-    amrex::GpuArray<amrex::ParticleReal*, BeamIdx::real_nattribs_in_buffer> rarrdata =
-        particle_tile.GetStructOfArrays().realarray();
-    amrex::GpuArray<int*, BeamIdx::int_nattribs_in_buffer> iarrdata =
-        particle_tile.GetStructOfArrays().intarray();
+    const auto ptd = particle_tile.getParticleTileData();
     const int pid = BeamTileInit::ParticleType::NextID();
     BeamTileInit::ParticleType::NextID(pid + num_to_add);
 
@@ -1060,7 +1043,7 @@ InitBeamFromFile (const std::string input_file,
 
     amrex::ParallelFor(int(num_to_add),
         [=] AMREX_GPU_DEVICE (const int i) {
-            AddOneBeamParticle(rarrdata, iarrdata,
+            AddOneBeamParticle(ptd,
                 static_cast<amrex::Real>(r_x_ptr[i] * unit_rx),
                 static_cast<amrex::Real>(r_y_ptr[i] * unit_ry),
                 static_cast<amrex::Real>(r_z_ptr[i] * unit_rz),

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -40,7 +40,6 @@ struct PlasmaIdx
         real_nattribs
     };
     enum {
-        id=0, cpu,          // cpu used for MR level TODO: remove this
         ion_lev,            // ionization level
         int_nattribs
     };

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -40,7 +40,7 @@ struct PlasmaIdx
         real_nattribs
     };
     enum {
-        id=0, cpu,          // cpu used for MR level
+        id=0, cpu,          // cpu used for MR level TODO: remove this
         ion_lev,            // ionization level
         int_nattribs
     };

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -224,7 +224,7 @@ PlasmaParticleContainer::TagByLevel (const int current_N_level,
             soa.GetRealData(PlasmaIdx::x_prev).data() : soa.GetRealData(PlasmaIdx::x).data();
         const amrex::Real * const AMREX_RESTRICT pos_y = to_prev ?
             soa.GetRealData(PlasmaIdx::y_prev).data() : soa.GetRealData(PlasmaIdx::y).data();
-        int * const AMREX_RESTRICT cpup = soa.GetIntData(PlasmaIdx::cpu).data();
+        auto * AMREX_RESTRICT idcpup = soa.GetIdCPUData().data();
 
         const int lev1_idx = std::min(1, current_N_level-1);
         const int lev2_idx = std::min(2, current_N_level-1);
@@ -250,15 +250,15 @@ PlasmaParticleContainer::TagByLevel (const int current_N_level,
                     lo_x_lev2 < xp && xp < hi_x_lev2 &&
                     lo_y_lev2 < yp && yp < hi_y_lev2) {
                     // level 2
-                    cpup[ip] = 2;
+                    amrex::ParticleCPUWrapper{idcpup[ip]} = 2;
                 } else if (current_N_level > 1 &&
                     lo_x_lev1 < xp && xp < hi_x_lev1 &&
                     lo_y_lev1 < yp && yp < hi_y_lev1) {
                     // level 1
-                    cpup[ip] = 1;
+                    amrex::ParticleCPUWrapper{idcpup[ip]} = 1;
                 } else {
                     // level 0
-                    cpup[ip] = 0;
+                    amrex::ParticleCPUWrapper{idcpup[ip]} = 0;
                 }
             }
         );
@@ -324,8 +324,7 @@ IonizationModule (const int lev,
         const amrex::Real * const uxp = soa_ion.GetRealData(PlasmaIdx::ux_half_step).data();
         const amrex::Real * const uyp = soa_ion.GetRealData(PlasmaIdx::uy_half_step).data();
         const amrex::Real * const psip =soa_ion.GetRealData(PlasmaIdx::psi_half_step).data();
-        const int * const idp = soa_ion.GetIntData(PlasmaIdx::id).data();
-        const int * const cpup = soa_ion.GetIntData(PlasmaIdx::cpu).data();
+        const auto * idcpup = soa_ion.GetIdCPUData().data();
 
         // Make Ion Mask and load ADK prefactors
         // Ion Mask is necessary to only resize electron particle tile once
@@ -342,7 +341,8 @@ IonizationModule (const int lev,
         amrex::ParallelForRNG(num_ions,
             [=] AMREX_GPU_DEVICE (long ip, const amrex::RandomEngine& engine) {
 
-            if (idp[ip] < 0 || cpup[ip] != lev) return;
+            if (amrex::ConstParticleIDWrapper(idcpup[ip]) < 0 ||
+                amrex::ConstParticleCPUWrapper(idcpup[ip]) != lev) return;
 
             // avoid temp slice
             const amrex::Real xp = x_prev[ip];
@@ -402,6 +402,7 @@ IonizationModule (const int lev,
         auto arrdata_ion = ptile_ion.GetStructOfArrays().realarray();
         auto arrdata_elec = ptile_elec.GetStructOfArrays().realarray();
         auto int_arrdata_elec = ptile_elec.GetStructOfArrays().intarray();
+        auto idcpu_elec = ptile_elec.GetStructOfArrays().GetIdCPUData().data();
 
         const int init_ion_lev = m_product_pc->m_init_ion_lev;
 
@@ -416,8 +417,8 @@ IonizationModule (const int lev,
                 const long pidx = pid + old_size;
 
                 // Copy ion data to new electron
-                int_arrdata_elec[PlasmaIdx::id ][pidx] = pid_start + pid;
-                int_arrdata_elec[PlasmaIdx::cpu][pidx] = lev; // current level
+                amrex::ParticleIDWrapper{idcpu_elec[pidx]} = pid_start + pid;
+                amrex::ParticleCPUWrapper{idcpu_elec[pidx]} = lev; // current level
                 arrdata_elec[PlasmaIdx::x      ][pidx] = arrdata_ion[PlasmaIdx::x     ][ip];
                 arrdata_elec[PlasmaIdx::y      ][pidx] = arrdata_ion[PlasmaIdx::y     ][ip];
 
@@ -461,7 +462,6 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
     const amrex::Real insitu_radius = m_insitu_radius;
     const PhysConst phys_const = get_phys_const();
     const amrex::Real clight_inv = 1.0_rt/phys_const.c;
-    const amrex::Real clightsq_inv = 1.0_rt/(phys_const.c*phys_const.c);
 
     // Loop over particle boxes
     for (PlasmaParticleIterator pti(*this); pti.isValid(); ++pti)

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -185,8 +185,7 @@ InitParticles (const amrex::RealVect& a_u_std,
         const int pid = ParticleType::NextID();
         ParticleType::NextID(pid + total_num_particles);
 
-        auto arrdata = particle_tile.GetStructOfArrays().realarray();
-        auto int_arrdata = particle_tile.GetStructOfArrays().intarray();
+        auto ptd = particle_tile.getParticleTileData();
         const int init_ion_lev = m_init_ion_lev;
 
         // The loop over particles is outside the loop over cells
@@ -302,35 +301,35 @@ InitParticles (const amrex::RealVect& a_u_std,
                 amrex::Real u[3] = {0.,0.,0.};
                 ParticleUtil::get_gaussian_random_momentum(u, a_u_mean, a_u_std, engine);
 
-                int_arrdata[PlasmaIdx::id ][pidx] = pid + int(pidx);
-                int_arrdata[PlasmaIdx::cpu][pidx] = 0; // level 0
-                arrdata[PlasmaIdx::x      ][pidx] = x;
-                arrdata[PlasmaIdx::y      ][pidx] = y;
+                ptd.id(pidx) = pid + int(pidx);
+                ptd.cpu(pidx) = 0; // level 0
+                ptd.rdata(PlasmaIdx::x)[pidx] = x;
+                ptd.rdata(PlasmaIdx::y)[pidx] = y;
 
                 if (use_fine_patch) {
-                    arrdata[PlasmaIdx::w      ][pidx] = density_func(x, y, c_t) *
+                    ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) *
                         (arr_fine(i, j, comp_a) == 0 ? scale_fac_coarse : scale_fac_fine);
                 } else {
-                    arrdata[PlasmaIdx::w      ][pidx] = density_func(x, y, c_t) * scale_fac_coarse;
+                    ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * scale_fac_coarse;
                 }
 
-                arrdata[PlasmaIdx::ux     ][pidx] = u[0] * c_light;
-                arrdata[PlasmaIdx::uy     ][pidx] = u[1] * c_light;
-                arrdata[PlasmaIdx::psi][pidx] = std::sqrt(1._rt+u[0]*u[0]+u[1]*u[1]+u[2]*u[2])-u[2];
-                arrdata[PlasmaIdx::x_prev ][pidx] = x;
-                arrdata[PlasmaIdx::y_prev ][pidx] = y;
-                arrdata[PlasmaIdx::ux_half_step ][pidx] = u[0] * c_light;
-                arrdata[PlasmaIdx::uy_half_step ][pidx] = u[1] * c_light;
-                arrdata[PlasmaIdx::psi_half_step][pidx] = arrdata[PlasmaIdx::psi][pidx];
+                ptd.rdata(PlasmaIdx::ux)[pidx] = u[0] * c_light;
+                ptd.rdata(PlasmaIdx::uy)[pidx] = u[1] * c_light;
+                ptd.rdata(PlasmaIdx::psi)[pidx] = std::sqrt(1._rt+u[0]*u[0]+u[1]*u[1]+u[2]*u[2])-u[2];
+                ptd.rdata(PlasmaIdx::x_prev)[pidx] = x;
+                ptd.rdata(PlasmaIdx::y_prev)[pidx] = y;
+                ptd.rdata(PlasmaIdx::ux_half_step)[pidx] = u[0] * c_light;
+                ptd.rdata(PlasmaIdx::uy_half_step)[pidx] = u[1] * c_light;
+                ptd.rdata(PlasmaIdx::psi_half_step)[pidx] = ptd.rdata(PlasmaIdx::psi)[pidx];
 #ifdef HIPACE_USE_AB5_PUSH
 #ifdef AMREX_USE_GPU
 #pragma unroll
 #endif
                 for (int iforce = PlasmaIdx::Fx1; iforce <= PlasmaIdx::Fpsi5; ++iforce) {
-                    arrdata[iforce][pidx] = 0._rt;
+                    ptd.rdata(iforce)[pidx] = 0._rt;
                 }
 #endif
-                int_arrdata[PlasmaIdx::ion_lev][pidx] = init_ion_lev;
+                ptd.idata(PlasmaIdx::ion_lev)[pidx] = init_ion_lev;
             });
 
             old_size += num_to_add;
@@ -343,8 +342,8 @@ InitParticles (const amrex::RealVect& a_u_std,
             amrex::ParallelFor(mirror_offset,
             [=] AMREX_GPU_DEVICE (amrex::Long pidx) noexcept
             {
-                const amrex::Real x = arrdata[PlasmaIdx::x][pidx];
-                const amrex::Real y = arrdata[PlasmaIdx::y][pidx];
+                const amrex::Real x = ptd.rdata(PlasmaIdx::x)[pidx];
+                const amrex::Real y = ptd.rdata(PlasmaIdx::y)[pidx];
                 const amrex::Real x_mirror = x_mid2 - x;
                 const amrex::Real y_mirror = y_mid2 - y;
 
@@ -359,32 +358,32 @@ InitParticles (const amrex::RealVect& a_u_std,
                 for (int imirror=0; imirror<3; ++imirror) {
                     const amrex::Long midx = (imirror+1)*mirror_offset +pidx;
 
-                    int_arrdata[PlasmaIdx::id][midx] = pid + int(midx);
-                    int_arrdata[PlasmaIdx::cpu][midx] = 0; // level 0
-                    arrdata[PlasmaIdx::x][midx] = x_arr[imirror];
-                    arrdata[PlasmaIdx::y][midx] = y_arr[imirror];
+                    ptd.id(midx) = pid + int(midx);
+                    ptd.cpu(midx) = 0; // level 0
+                    ptd.rdata(PlasmaIdx::x)[midx] = x_arr[imirror];
+                    ptd.rdata(PlasmaIdx::y)[midx] = y_arr[imirror];
 
-                    arrdata[PlasmaIdx::w][midx] = arrdata[PlasmaIdx::w][pidx];
-                    arrdata[PlasmaIdx::ux][midx] = arrdata[PlasmaIdx::ux][pidx] * ux_arr[imirror];
-                    arrdata[PlasmaIdx::uy][midx] = arrdata[PlasmaIdx::uy][pidx] * uy_arr[imirror];
-                    arrdata[PlasmaIdx::psi][midx] = arrdata[PlasmaIdx::psi][pidx];
-                    arrdata[PlasmaIdx::x_prev][midx] = x_arr[imirror];
-                    arrdata[PlasmaIdx::y_prev][midx] = y_arr[imirror];
-                    arrdata[PlasmaIdx::ux_half_step][midx] =
-                        arrdata[PlasmaIdx::ux_half_step][pidx] * ux_arr[imirror];
-                    arrdata[PlasmaIdx::uy_half_step][midx] =
-                        arrdata[PlasmaIdx::uy_half_step][pidx] * uy_arr[imirror];
-                    arrdata[PlasmaIdx::psi_half_step][midx] =
-                        arrdata[PlasmaIdx::psi_half_step][pidx];
+                    ptd.rdata(PlasmaIdx::w)[midx] = ptd.rdata(PlasmaIdx::w)[pidx];
+                    ptd.rdata(PlasmaIdx::ux)[midx] = ptd.rdata(PlasmaIdx::ux)[pidx] * ux_arr[imirror];
+                    ptd.rdata(PlasmaIdx::uy)[midx] = ptd.rdata(PlasmaIdx::uy)[pidx] * uy_arr[imirror];
+                    ptd.rdata(PlasmaIdx::psi)[midx] = ptd.rdata(PlasmaIdx::psi)[pidx];
+                    ptd.rdata(PlasmaIdx::x_prev)[midx] = x_arr[imirror];
+                    ptd.rdata(PlasmaIdx::y_prev)[midx] = y_arr[imirror];
+                    ptd.rdata(PlasmaIdx::ux_half_step)[midx] =
+                        ptd.rdata(PlasmaIdx::ux_half_step)[pidx] * ux_arr[imirror];
+                    ptd.rdata(PlasmaIdx::uy_half_step)[midx] =
+                        ptd.rdata(PlasmaIdx::uy_half_step)[pidx] * uy_arr[imirror];
+                    ptd.rdata(PlasmaIdx::psi_half_step)[midx] =
+                        ptd.rdata(PlasmaIdx::psi_half_step)[pidx];
 #ifdef HIPACE_USE_AB5_PUSH
 #ifdef AMREX_USE_GPU
 #pragma unroll
 #endif
                     for (int iforce = PlasmaIdx::Fx1; iforce <= PlasmaIdx::Fpsi5; ++iforce) {
-                        arrdata[iforce][midx] = 0._rt;
+                        ptd.rdata(iforce)[midx] = 0._rt;
                     }
 #endif
-                    int_arrdata[PlasmaIdx::ion_lev][midx] = int_arrdata[PlasmaIdx::ion_lev][pidx];
+                    ptd.idata(PlasmaIdx::ion_lev)[midx] = ptd.idata(PlasmaIdx::ion_lev)[pidx];
 
         }
     });

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -385,9 +385,9 @@ InitParticles (const amrex::RealVect& a_u_std,
 #endif
                     ptd.idata(PlasmaIdx::ion_lev)[midx] = ptd.idata(PlasmaIdx::ion_lev)[pidx];
 
+                }
+            });
         }
-    });
-}
     }
 }
 

--- a/src/particles/sorting/SliceSort.cpp
+++ b/src/particles/sorting/SliceSort.cpp
@@ -78,6 +78,7 @@ shiftSlippedParticles (BeamParticleContainer& beam, const int slice, amrex::Geom
         [=] AMREX_GPU_DEVICE (const int ip, const int s)
         {
             if (ptd.id(ip) >= 0 && ptd.pos(2, ip) >= min_z) {
+                ptd_tmp.idcpu(s) = ptd.idcpu(ip);
                 for (int j=0; j<ptd_tmp.NAR; ++j) {
                     ptd_tmp.rdata(j)[s] = ptd.rdata(j)[ip];
                 }
@@ -101,6 +102,7 @@ shiftSlippedParticles (BeamParticleContainer& beam, const int slice, amrex::Geom
         [=] AMREX_GPU_DEVICE (const int ip, const int s)
         {
             if (ptd.id(ip) >= 0 && ptd.pos(2, ip) < min_z) {
+                ptd_next.idcpu(s+next_size) = ptd.idcpu(ip);
                 for (int j=0; j<ptd_next.NAR; ++j) {
                     ptd_next.rdata(j)[s+next_size] = ptd.rdata(j)[ip];
                 }

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -408,17 +408,18 @@ SalameMultiplyBeamWeight (const amrex::Real W, Hipace* hipace)
         // For id and weights
         auto& soa = beam.getBeamSlice(WhichBeamSlice::This).GetStructOfArrays();
         amrex::Real * const wp = soa.GetRealData(BeamIdx::w).data();
-        int * const idp = soa.GetIntData(BeamIdx::id).data();
+        auto * const idcpup = soa.GetIdCPUData().data();
 
         amrex::ParallelFor(
             beam.getNumParticles(WhichBeamSlice::This),
             [=] AMREX_GPU_DEVICE (long ip) {
                 // Skip invalid particles and ghost particles not in the last slice
-                if (idp[ip] < 0) return;
+                auto id = amrex::ParticleIDWrapper(idcpup[ip]);
+                if (id < 0) return;
 
                 // invalidate particles with a weight of zero
                 if (W == 0) {
-                    idp[ip] = -idp[ip];
+                    id = -id;
                     return;
                 }
 

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -112,7 +112,7 @@ AdaptiveTimeStep::GatherMinUzSlice (MultiBeam& beams, const bool initial)
         unsigned long long num_particles = 0;
         const amrex::Real * uzp = nullptr;
         const amrex::Real * wp = nullptr;
-        const int * idp = nullptr;
+        const std::uint64_t * idcpup = nullptr;
 
         // Extract particle properties
         // For momenta and weights
@@ -121,13 +121,13 @@ AdaptiveTimeStep::GatherMinUzSlice (MultiBeam& beams, const bool initial)
             num_particles = beam.getBeamInitSlice().size();
             uzp = soa.GetRealData(BeamIdx::uz).data();
             wp = soa.GetRealData(BeamIdx::w).data();
-            idp = soa.GetIntData(BeamIdx::id).data();
+            idcpup = soa.GetIdCPUData().data();
         } else {
             const auto& soa = beam.getBeamSlice(WhichBeamSlice::This).GetStructOfArrays();
             num_particles = beam.getNumParticles(WhichBeamSlice::This);
             uzp = soa.GetRealData(BeamIdx::uz).data();
             wp = soa.GetRealData(BeamIdx::w).data();
-            idp = soa.GetIntData(BeamIdx::id).data();
+            idcpup = soa.GetIdCPUData().data();
         }
 
         amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum,
@@ -139,7 +139,7 @@ AdaptiveTimeStep::GatherMinUzSlice (MultiBeam& beams, const bool initial)
         reduce_op.eval(num_particles, reduce_data,
             [=] AMREX_GPU_DEVICE (unsigned long long ip) noexcept -> ReduceTuple
             {
-                if (idp[ip] < 0) return {
+                if (amrex::ConstParticleIDWrapper(idcpup[ip]) < 0) return {
                     0._rt, 0._rt, 0._rt, std::numeric_limits<amrex::Real>::infinity()
                 };
                 return {
@@ -292,12 +292,12 @@ AdaptiveTimeStep::GatherMinAccSlice (MultiBeam& beams, const amrex::Geometry& ge
         auto const& soa = beam.getBeamSlice(WhichBeamSlice::This).GetStructOfArrays();
         const auto pos_x = soa.GetRealData(BeamIdx::x).data();
         const auto pos_y = soa.GetRealData(BeamIdx::y).data();
-        const auto idp = soa.GetIntData(BeamIdx::id).data();
+        const auto idcpup = soa.GetIdCPUData().data();
 
         reduce_op.eval(beam.getNumParticles(WhichBeamSlice::This), reduce_data,
             [=] AMREX_GPU_DEVICE (long ip) noexcept -> ReduceTuple
             {
-                if (idp[ip] < 0) return { 0._rt };
+                if (amrex::ConstParticleIDWrapper(idcpup[ip]) < 0) return { 0._rt };
                 const amrex::Real xp = pos_x[ip];
                 const amrex::Real yp = pos_y[ip];
 

--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -131,6 +131,7 @@ private:
     void write_metadata (int slice, MultiBeam& beams, int beam_slice);
 
     // helper functions to get location of individual arrays inside a buffer
+    std::size_t get_buffer_offset_idcpu (int slice, int ibeam);
     std::size_t get_buffer_offset_real (int slice, int ibeam, int rcomp);
     std::size_t get_buffer_offset_int (int slice, int ibeam, int icomp);
     std::size_t get_buffer_offset_laser (int slice, int icomp);


### PR DESCRIPTION
After https://github.com/AMReX-Codes/amrex/pull/3585 there are two different IDs for every particle that are used incorrectly throughout hipace. This PR removes the old ID and replaces it with the new 39bit one. Note that the latest AMReX version is needed for this PR https://github.com/AMReX-Codes/amrex/pull/3671 .

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
