### PR TITLE
MacOS CI explicitly install python@3.12

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,9 @@ jobs:
         brew --cache
         set +e
 
+        brew install --overwrite python@3.12
+        brew link python@3.12 --force --overwrite
+
         brew install fftw --only-dependencies --force --overwrite
         brew install fftw
         brew link fftw
@@ -82,8 +85,6 @@ jobs:
         brew install openpmd-api --only-dependencies --force --overwrite
         brew install openpmd-api
         brew link openpmd-api
-
-        brew install --overwrite python
 
         python3 -m pip install matplotlib
         python3 -m pip install numpy

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,8 +58,9 @@ jobs:
         brew --cache
         set +e
 
-        brew install --overwrite python@3.y
-        brew link python@3.y --force --overwrite
+        brew install --overwrite python
+        brew upgrade --force python
+        brew link python --force --overwrite
 
         brew install fftw --only-dependencies --force --overwrite
         brew install fftw

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -57,7 +57,6 @@ jobs:
       run: |
         brew --cache
         set +e
-        brew install --overwrite python
 
         brew install fftw --only-dependencies --force --overwrite
         brew install fftw
@@ -83,6 +82,8 @@ jobs:
         brew install openpmd-api --only-dependencies --force --overwrite
         brew install openpmd-api
         brew link openpmd-api
+
+        brew install --overwrite python
 
         python3 -m pip install matplotlib
         python3 -m pip install numpy

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ jobs:
         set +e
         brew unlink gcc
         brew update
-        brew install ccache --only-dependencies --force
+        brew install ccache --only-dependencies --force --overwrite
         brew install ccache
         brew link ccache
     - name: CCache Cache
@@ -59,19 +59,19 @@ jobs:
         set +e
         brew install --overwrite python
 
-        brew install fftw --only-dependencies --force
+        brew install fftw --only-dependencies --force --overwrite
         brew install fftw
         brew link fftw
 
-        brew install libomp --only-dependencies --force
+        brew install libomp --only-dependencies --force --overwrite
         brew install libomp
         brew link --force libomp
 
-        brew install ninja --only-dependencies --force
+        brew install ninja --only-dependencies --force --overwrite
         brew install ninja
         brew link ninja
 
-        brew install open-mpi --only-dependencies --force
+        brew install open-mpi --only-dependencies --force --overwrite
         brew install open-mpi
         brew link open-mpi
 
@@ -80,7 +80,7 @@ jobs:
         set -e
 
         brew tap openpmd/openpmd
-        brew install openpmd-api --only-dependencies --force
+        brew install openpmd-api --only-dependencies --force --overwrite
         brew install openpmd-api
         brew link openpmd-api
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ jobs:
         set +e
         brew unlink gcc
         brew update
-        brew install ccache --only-dependencies --force --overwrite
+        brew install ccache --only-dependencies --force
         brew install ccache
         brew link ccache
     - name: CCache Cache
@@ -59,22 +59,24 @@ jobs:
         set +e
 
         brew install --overwrite python
-        brew upgrade --force python
-        brew link python --force --overwrite
+        brew link --force --overwrite python
 
-        brew install fftw --only-dependencies --force --overwrite
+        brew install --overwrite python@3.12
+        brew link --force --overwrite python@3.12
+
+        brew install fftw --only-dependencies --force
         brew install fftw
         brew link fftw
 
-        brew install libomp --only-dependencies --force --overwrite
+        brew install libomp --only-dependencies --force
         brew install libomp
         brew link --force libomp
 
-        brew install ninja --only-dependencies --force --overwrite
+        brew install ninja --only-dependencies --force
         brew install ninja
         brew link ninja
 
-        brew install open-mpi --only-dependencies --force --overwrite
+        brew install open-mpi --only-dependencies --force
         brew install open-mpi
         brew link open-mpi
 
@@ -83,7 +85,7 @@ jobs:
         set -e
 
         brew tap openpmd/openpmd
-        brew install openpmd-api --only-dependencies --force --overwrite
+        brew install openpmd-api --only-dependencies --force
         brew install openpmd-api
         brew link openpmd-api
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,8 +58,8 @@ jobs:
         brew --cache
         set +e
 
-        brew install --overwrite python@3.12
-        brew link python@3.12 --force --overwrite
+        brew install --overwrite python@3.y
+        brew link python@3.y --force --overwrite
 
         brew install fftw --only-dependencies --force --overwrite
         brew install fftw


### PR DESCRIPTION
There seems to be a particular MacOS CI runner environment where python 3.11 is installed with brew and 3.12 using something else, so when brew later installs python 3.12 as a dependency of openpmd-api it fails to create the links for 3.12.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
