### PR TITLE
Add zyx geometry for laser input

### DIFF
--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -367,8 +367,6 @@ MultiLaser::GetEnvelopeFromFile (const amrex::Geometry& gm) {
         amrex::Real zmin_laser = offset[0] + position[0]*spacing[0];
         amrex::Real ymin_laser = offset[1] + position[1]*spacing[1];
         amrex::Real xmin_laser = offset[2] + position[2]*spacing[2];
-        AMREX_ALWAYS_ASSERT(position[0] == 0 && position[1] == 0 && position[2] == 0);
-
 
         for (int k = kmin; k <= domain.bigEnd(2); ++k) {
             for (int j = jmin; j <= domain.bigEnd(1); ++j) {


### PR DESCRIPTION
Previously only tyx and tr were supported. zyx is need to read previous output from HiPACE++

![image](https://github.com/Hi-PACE/hipace/assets/64009254/0a62dd9e-9663-41f8-a77e-439c40899997)


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
