### PR TITLE
DepositCurrent: atomicAdd -> lockAdd

### DIFF
--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -301,20 +301,20 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields, const MultiLas
                 amrex::Box srcbx = dstbx;
                 srcbx -= amrex::IntVect(a_itilex_bs, a_itiley_bs, srcbx.smallEnd(2));
                 if (jx_cmp != -1) {
-                    isl_fab.atomicAdd(tmp_dens[ithread], srcbx, dstbx, 0, jx_cmp, 1);
-                    isl_fab.atomicAdd(tmp_dens[ithread], srcbx, dstbx, 1, jy_cmp, 1);
+                    isl_fab.lockAdd(tmp_dens[ithread], srcbx, dstbx, 0, jx_cmp, 1);
+                    isl_fab.lockAdd(tmp_dens[ithread], srcbx, dstbx, 1, jy_cmp, 1);
                 }
                 if (jz_cmp != -1) {
-                    isl_fab.atomicAdd(tmp_dens[ithread], srcbx, dstbx, 2, jz_cmp, 1);
+                    isl_fab.lockAdd(tmp_dens[ithread], srcbx, dstbx, 2, jz_cmp, 1);
                 }
                 if (rho_cmp != -1) {
-                    isl_fab.atomicAdd(tmp_dens[ithread], srcbx, dstbx, 3, rho_cmp, 1);
+                    isl_fab.lockAdd(tmp_dens[ithread], srcbx, dstbx, 3, rho_cmp, 1);
                 }
                 if (chi_cmp != -1) {
-                    isl_fab.atomicAdd(tmp_dens[ithread], srcbx, dstbx, 4, chi_cmp, 1);
+                    isl_fab.lockAdd(tmp_dens[ithread], srcbx, dstbx, 4, chi_cmp, 1);
                 }
                 if (rhomjz_cmp != -1) {
-                    isl_fab.atomicAdd(tmp_dens[ithread], srcbx, dstbx, 5, rhomjz_cmp, 1);
+                    isl_fab.lockAdd(tmp_dens[ithread], srcbx, dstbx, 5, rhomjz_cmp, 1);
                 }
             }
 #endif


### PR DESCRIPTION
The new amrex::BaseFab::lockAdd function is an optimized version of atomicAdd for OpenMP. In my testing on Frontier CPUs, it's up to 10x faster. I did not test the new function using hipace. But I used https://github.com/WeiqunZhang/amrex-devtests/tree/main/fab_atomicAdd for testing.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
