### PR TITLE
Add option to use HPMG to solve Poisson equations

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -237,6 +237,11 @@ The default is to use the explicit solver. **We strongly recommend to use the ex
     Which solver to use.
     Possible values: ``explicit`` and ``predictor-corrector``.
 
+* ``fields.poisson_solver`` (`string`) optional (default `FFTDirichlet`)
+    Which Poisson solver to use for ``Psi``, ``Ez`` and ``Bz``. The ``predictor-corrector`` BxBy
+    solver also uses this poisson solver for ``Bx`` and ``By`` internally. Available solvers are
+    ``FFTDirichlet``, ``FFTPeriodic`` and ``MGDirichlet``.
+
 * ``hipace.use_small_dst`` (`bool`) optional (default `0` or `1`)
     Whether to use a large R2C or a small C2R fft in the dst of the Poisson solver.
     The small dst is quicker for simulations with :math:`\geq 511` transverse grid points.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -723,9 +723,9 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice)
         // cell centered MG solve: no ghost cells, put boundary condition into source term
         // node centered MG solve: one ghost cell, use boundary condition from there
         m_fields.SetBoundaryCondition(m_3D_geom, lev, which_slice, "Bx",
-                                      m_fields.getField(lev, which_slice, "Sy"));
+                                      m_fields.getField(lev, which_slice, "Sy"), 0.5, 8./3.);
         m_fields.SetBoundaryCondition(m_3D_geom, lev, which_slice, "By",
-                                      m_fields.getField(lev, which_slice, "Sx"));
+                                      m_fields.getField(lev, which_slice, "Sx"), 0.5, 8./3.);
     }
 
     // interpolate Bx and By to lev from lev-1 in the ghost cells
@@ -803,7 +803,7 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice)
         if (!m_hpmg[lev]) {
             m_hpmg[lev] = std::make_unique<hpmg::MultiGrid>(m_slice_geom[lev].CellSize(0),
                                                             m_slice_geom[lev].CellSize(1),
-                                                            slicemf.boxArray()[0]);
+                                                            slicemf.boxArray()[0], 1);
         }
         const int max_iters = 200;
         m_hpmg[lev]->solve1(BxBy[0], SySx[0], Mult[0], m_MG_tolerance_rel, m_MG_tolerance_abs,

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -723,9 +723,11 @@ Hipace::ExplicitMGSolveBxBy (const int lev, const int which_slice)
         // cell centered MG solve: no ghost cells, put boundary condition into source term
         // node centered MG solve: one ghost cell, use boundary condition from there
         m_fields.SetBoundaryCondition(m_3D_geom, lev, which_slice, "Bx",
-                                      m_fields.getField(lev, which_slice, "Sy"), 0.5, 8./3.);
+                                      m_fields.getField(lev, which_slice, "Sy"),
+                                      amrex::IntVect{0, 0, 0}, 0.5, 8./3.);
         m_fields.SetBoundaryCondition(m_3D_geom, lev, which_slice, "By",
-                                      m_fields.getField(lev, which_slice, "Sx"), 0.5, 8./3.);
+                                      m_fields.getField(lev, which_slice, "Sx"),
+                                      amrex::IntVect{0, 0, 0}, 0.5, 8./3.);
     }
 
     // interpolate Bx and By to lev from lev-1 in the ghost cells

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -505,7 +505,7 @@ private:
     /** Vector over levels of all required fields to compute current slice */
     amrex::Vector<amrex::MultiFab> m_slices;
     /** Type of poisson solver to use */
-    std::string m_poisson_solver_str = "MGDirichlet";
+    std::string m_poisson_solver_str = "FFTDirichlet";
     /** Class to handle transverse FFT Poisson solver on 1 slice */
     amrex::Vector<std::unique_ptr<FFTPoissonSolver>> m_poisson_solver;
     /** Temporary density arrays. one per OpenMP thread, used when tiling is on. */

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -505,7 +505,7 @@ private:
     /** Vector over levels of all required fields to compute current slice */
     amrex::Vector<amrex::MultiFab> m_slices;
     /** Type of poisson solver to use */
-    std::string m_poisson_solver_str = "FFTDirichlet";
+    std::string m_poisson_solver_str = "MGDirichlet";
     /** Class to handle transverse FFT Poisson solver on 1 slice */
     amrex::Vector<std::unique_ptr<FFTPoissonSolver>> m_poisson_solver;
     /** Temporary density arrays. one per OpenMP thread, used when tiling is on. */

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -99,8 +99,6 @@ public:
         int lev, amrex::Geometry const& geom, const amrex::BoxArray& slice_ba,
         const amrex::DistributionMapping& slice_dm, int bin_size);
 
-    /** Class to handle transverse FFT Poisson solver on 1 slice */
-    amrex::Vector<std::unique_ptr<FFTPoissonSolver>> m_poisson_solver;
     /** get function for the 2D slices */
     amrex::Vector<amrex::MultiFab>& getSlices () {return m_slices; }
     /** get function for the 2D slices
@@ -177,10 +175,13 @@ public:
      * \param[in] which_slice slice of the field
      * \param[in] component which can be Psi, Ez, By, Bx ...
      * \param[in,out] staging_area Target MultiFab where the boundary condition is applied
+     * \param[in] offset shift boundary value by offset number of cells
+     * \param[in] factor multiply the boundary value by this factor
      */
     void SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                                const int which_slice, std::string component,
-                               amrex::MultiFab&& staging_area);
+                               amrex::MultiFab&& staging_area,
+                               amrex::Real offset, amrex::Real factor);
 
     /** \brief Interpolate values from coarse grid (lev-1) to the boundary of the fine grid (lev).
      * This may include ghost cells.
@@ -503,8 +504,10 @@ public:
 private:
     /** Vector over levels of all required fields to compute current slice */
     amrex::Vector<amrex::MultiFab> m_slices;
-    /** Whether to use Dirichlet BC for the Poisson solver. Otherwise, periodic */
-    bool m_do_dirichlet_poisson = true;
+    /** Type of poisson solver to use */
+    std::string m_poisson_solver_str = "FFTDirichlet";
+    /** Class to handle transverse FFT Poisson solver on 1 slice */
+    amrex::Vector<std::unique_ptr<FFTPoissonSolver>> m_poisson_solver;
     /** Temporary density arrays. one per OpenMP thread, used when tiling is on. */
     amrex::Vector<amrex::FArrayBox> m_tmp_densities;
     /** Stores temporary values for z interpolation in Fields::Copy */

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -175,12 +175,13 @@ public:
      * \param[in] which_slice slice of the field
      * \param[in] component which can be Psi, Ez, By, Bx ...
      * \param[in,out] staging_area Target MultiFab where the boundary condition is applied
+     * \param[in] box_grow relative to the domain, how large is the box of staging_area
      * \param[in] offset shift boundary value by offset number of cells
      * \param[in] factor multiply the boundary value by this factor
      */
     void SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                                const int which_slice, std::string component,
-                               amrex::MultiFab&& staging_area,
+                               amrex::MultiFab&& staging_area, amrex::IntVect box_grow,
                                amrex::Real offset, amrex::Real factor);
 
     /** \brief Interpolate values from coarse grid (lev-1) to the boundary of the fine grid (lev).

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -9,8 +9,10 @@
 #include "Fields.H"
 #include "fft_poisson_solver/FFTPoissonSolverPeriodic.H"
 #include "fft_poisson_solver/FFTPoissonSolverDirichlet.H"
+#include "fft_poisson_solver/MGPoissonSolverDirichlet.H"
 #include "Hipace.H"
 #include "OpenBoundary.H"
+#include "utils/DeprecatedInput.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/Constants.H"
 #include "utils/GPUUtil.H"
@@ -26,7 +28,8 @@ Fields::Fields (const int nlev)
     : m_slices(nlev)
 {
     amrex::ParmParse ppf("fields");
-    queryWithParser(ppf, "do_dirichlet_poisson", m_do_dirichlet_poisson);
+    DeprecatedInput("fields", "do_dirichlet_poisson", "poisson_solver", "");
+    queryWithParser(ppf, "poisson_solver", m_poisson_solver_str);
     queryWithParser(ppf, "extended_solve", m_extended_solve);
     queryWithParser(ppf, "open_boundary", m_open_boundary);
     queryWithParser(ppf, "insitu_period", m_insitu_period);
@@ -172,16 +175,24 @@ Fields::AllocData (
     // The Poisson solver operates on transverse slices only.
     // The constructor takes the BoxArray and the DistributionMap of a slice,
     // so the FFTPlans are built on a slice.
-    if (m_do_dirichlet_poisson){
+    if (m_poisson_solver_str == "FFTDirichlet"){
         m_poisson_solver.push_back(std::unique_ptr<FFTPoissonSolverDirichlet>(
             new FFTPoissonSolverDirichlet(getSlices(lev).boxArray(),
                                           getSlices(lev).DistributionMap(),
                                           geom)) );
-    } else {
+    } else if (m_poisson_solver_str == "FFTPeriodic") {
         m_poisson_solver.push_back(std::unique_ptr<FFTPoissonSolverPeriodic>(
             new FFTPoissonSolverPeriodic(getSlices(lev).boxArray(),
                                          getSlices(lev).DistributionMap(),
                                          geom))  );
+    } else if (m_poisson_solver_str == "MGDirichlet") {
+        m_poisson_solver.push_back(std::unique_ptr<MGPoissonSolverDirichlet>(
+            new MGPoissonSolverDirichlet(getSlices(lev).boxArray(),
+                                         getSlices(lev).DistributionMap(),
+                                         geom))  );
+    } else {
+        amrex::Abort("Unknown poisson solver '" + m_poisson_solver_str +
+            "', must be 'FFTDirichlet', 'FFTPeriodic' or 'MGDirichlet'");
     }
     int num_threads = 1;
 #ifdef AMREX_USE_OMP
@@ -684,7 +695,8 @@ SetDirichletBoundaries (Array2<amrex::Real> RHS, const amrex::Box& solver_size,
 void
 Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const int lev,
                               const int which_slice, std::string component,
-                              amrex::MultiFab&& staging_area)
+                              amrex::MultiFab&& staging_area,
+                              amrex::Real offset, amrex::Real factor)
 {
     HIPACE_PROFILE("Fields::SetBoundaryCondition()");
     if (lev == 0 && m_open_boundary) {
@@ -738,7 +750,7 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
             amrex::get<0>(coeff_tuple) = 0._rt;
         }
 
-        SetDirichletBoundaries(arr_staging_area, staging_box, geom[lev], 1, 1,
+        SetDirichletBoundaries(arr_staging_area, staging_box, geom[lev], offset, factor,
             [=] AMREX_GPU_DEVICE (amrex::Real x, amrex::Real y) noexcept
             {
                 return dxdy_div_4pi*GetFieldMultipole(coeff_tuple, x*scale, y*scale);
@@ -757,16 +769,6 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
             const auto arr_solution_interp = solution_interp.array(mfi);
             const Array2<amrex::Real> arr_staging_area = staging_area.array(mfi);
             const amrex::Box fine_staging_box = getStagingArea(lev)[mfi].box();
-
-            amrex::Real offset = 1;
-            amrex::Real factor = 1;
-            if ((component == "Bx" || component == "By") && Hipace::m_explicit &&
-                (getSlices(lev).box(0).length(0) % 2 == 0)) {
-                // hpmg has the boundary condition at a different place
-                // compared to the fft poisson solver
-                offset = 0.5;
-                factor = 8./3.;
-            }
 
             SetDirichletBoundaries(arr_staging_area, fine_staging_box, geom[lev],
                                    offset, factor, arr_solution_interp);
@@ -896,7 +898,8 @@ Fields::SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geo
         Multiply(m_source_nguard, getStagingArea(lev),
             -1._rt/(phys_const.ep0), getField(lev, WhichSlice::This, "rhomjz"));
 
-        SetBoundaryCondition(geom, lev, WhichSlice::This, "Psi", getStagingArea(lev));
+        SetBoundaryCondition(geom, lev, WhichSlice::This, "Psi", getStagingArea(lev),
+            m_poisson_solver[lev]->BoundaryOffset(), m_poisson_solver[lev]->BoundaryFactor());
 
         m_poisson_solver[lev]->SolvePoissonEquation(lhs_Psi);
 
@@ -907,7 +910,8 @@ Fields::SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geo
             1._rt/(phys_const.ep0*phys_const.c),
             derivative<Direction::y>{getField(lev, WhichSlice::This, "jy"), geom[lev]});
 
-        SetBoundaryCondition(geom, lev, WhichSlice::This, "Ez", getStagingArea(lev));
+        SetBoundaryCondition(geom, lev, WhichSlice::This, "Ez", getStagingArea(lev),
+            m_poisson_solver[lev]->BoundaryOffset(), m_poisson_solver[lev]->BoundaryFactor());
 
         m_poisson_solver[lev]->SolvePoissonEquation(lhs_Ez);
 
@@ -918,7 +922,8 @@ Fields::SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geo
             -phys_const.mu0,
             derivative<Direction::x>{getField(lev, WhichSlice::This, "jy"), geom[lev]});
 
-        SetBoundaryCondition(geom, lev, WhichSlice::This, "Bz", getStagingArea(lev));
+        SetBoundaryCondition(geom, lev, WhichSlice::This, "Bz", getStagingArea(lev),
+            m_poisson_solver[lev]->BoundaryOffset(), m_poisson_solver[lev]->BoundaryFactor());
 
         m_poisson_solver[lev]->SolvePoissonEquation(lhs_Bz);
     }
@@ -997,7 +1002,8 @@ Fields::SolvePoissonEz (amrex::Vector<amrex::Geometry> const& geom,
             1._rt/(phys_const.ep0*phys_const.c),
             derivative<Direction::y>{getField(lev, which_slice, "jy"), geom[lev]});
 
-        SetBoundaryCondition(geom, lev,which_slice, "Ez", getStagingArea(lev));
+        SetBoundaryCondition(geom, lev,which_slice, "Ez", getStagingArea(lev),
+            m_poisson_solver[lev]->BoundaryOffset(), m_poisson_solver[lev]->BoundaryFactor());
 
         m_poisson_solver[lev]->SolvePoissonEquation(lhs_Ez);
     }
@@ -1053,7 +1059,8 @@ Fields::SolvePoissonBxBy (amrex::Vector<amrex::Geometry> const& geom,
                     derivative<Direction::z>{getField(lev, WhichSlice::Previous, "jy"),
                     getField(lev, WhichSlice::Next, "jy"), geom[lev]});
 
-        SetBoundaryCondition(geom, lev, which_slice, "Bx", getStagingArea(lev));
+        SetBoundaryCondition(geom, lev, which_slice, "Bx", getStagingArea(lev),
+            m_poisson_solver[lev]->BoundaryOffset(), m_poisson_solver[lev]->BoundaryFactor());
 
         m_poisson_solver[lev]->SolvePoissonEquation(lhs_Bx);
 
@@ -1065,7 +1072,8 @@ Fields::SolvePoissonBxBy (amrex::Vector<amrex::Geometry> const& geom,
                    derivative<Direction::z>{getField(lev, WhichSlice::Previous, "jx"),
                    getField(lev, WhichSlice::Next, "jx"), geom[lev]});
 
-        SetBoundaryCondition(geom, lev, which_slice, "By", getStagingArea(lev));
+        SetBoundaryCondition(geom, lev, which_slice, "By", getStagingArea(lev),
+            m_poisson_solver[lev]->BoundaryOffset(), m_poisson_solver[lev]->BoundaryFactor());
 
         m_poisson_solver[lev]->SolvePoissonEquation(lhs_By);
     }

--- a/src/fields/fft_poisson_solver/CMakeLists.txt
+++ b/src/fields/fft_poisson_solver/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(HiPACE
     FFTPoissonSolver.cpp
     FFTPoissonSolverPeriodic.cpp
     FFTPoissonSolverDirichlet.cpp
+    MGPoissonSolverDirichlet.cpp
 )
 
 add_subdirectory(fft)

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -34,30 +34,19 @@ public:
     virtual ~FFTPoissonSolver () = 0;
 
     /**
-     * \brief Define real space and spectral space boxes and multifabs, multiplier
-     * coefficients inv_k2 to solve Poisson equation and FFT plans.
-     * Currently only works with a single box, i.e., serial FFT.
-     *
-     * \param[in] realspace_ba BoxArray on which the FFT is executed.
-     * \param[in] dm DistributionMapping for the BoxArray.
-     * \param[in] gm Geometry, contains the box dimensions.
-     */
-    virtual void define ( amrex::BoxArray const& realspace_ba,
-                          amrex::DistributionMapping const& dm,
-                          amrex::Geometry const& gm) = 0;
-
-    /**
      * Solve Poisson equation. The source term must be stored in the staging area m_stagingArea prior to this call.
      *
      * \param[in] lhs_mf Destination array, where the result is stored.
      */
     virtual void SolvePoissonEquation (amrex::MultiFab& lhs_mf) = 0;
 
+    /** Position and relative factor used to apply inhomogeneous Dirichlet boundary conditions */
+    virtual amrex::Real BoundaryOffset() = 0;
+    virtual amrex::Real BoundaryFactor() = 0;
+
     /** Get reference to the taging area */
     amrex::MultiFab& StagingArea ();
 protected:
-    /** BoxArray for the spectral fields */
-    amrex::BoxArray m_spectralspace_ba;
     /** Staging area, contains (real) field in real space.
      * This is where the source term is stored before calling the Poisson solver */
     amrex::MultiFab m_stagingArea;

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.H
@@ -43,9 +43,9 @@ public:
      * \param[in] dm DistributionMapping for the BoxArray.
      * \param[in] gm Geometry, contains the box dimensions.
      */
-    virtual void define ( amrex::BoxArray const& realspace_ba,
-                          amrex::DistributionMapping const& dm,
-                          amrex::Geometry const& gm) override final;
+    void define ( amrex::BoxArray const& realspace_ba,
+                  amrex::DistributionMapping const& dm,
+                  amrex::Geometry const& gm);
 
     /**
      * Solve Poisson equation. The source term must be stored in the staging area m_stagingArea prior to this call.
@@ -53,6 +53,10 @@ public:
      * \param[in] lhs_mf Destination array, where the result is stored.
      */
     virtual void SolvePoissonEquation (amrex::MultiFab& lhs_mf) override final;
+
+    /** Position and relative factor used to apply inhomogeneous Dirichlet boundary conditions */
+    virtual amrex::Real BoundaryOffset() override final { return 1.; }
+    virtual amrex::Real BoundaryFactor() override final { return 1.; }
 
 private:
     /** Spectral fields, contains (real) field in Fourier space */

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
@@ -32,8 +32,6 @@ FFTPoissonSolverDirichlet::define (amrex::BoxArray const& a_realspace_ba,
     // If we are going to support parallel FFT, the constructor needs to take a communicator.
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(a_realspace_ba.size() == 1, "Parallel FFT not supported yet");
 
-    m_spectralspace_ba = a_realspace_ba;
-
     // Allocate temporary arrays - in real space and spectral space
     // These arrays will store the data just before/after the FFT
     // The stagingArea is also created from 0 to nx, because the real space array may have
@@ -84,7 +82,7 @@ FFTPoissonSolverDirichlet::define (amrex::BoxArray const& a_realspace_ba,
     }
 
     // Allocate and initialize the FFT plans
-    m_plan = AnyDST::DSTplans(m_spectralspace_ba, dm);
+    m_plan = AnyDST::DSTplans(a_realspace_ba, dm);
     // Loop over boxes and allocate the corresponding plan
     // for each box owned by the local MPI proc
     for ( amrex::MFIter mfi(m_stagingArea, DfltMfi); mfi.isValid(); ++mfi ){

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
@@ -47,9 +47,9 @@ public:
      * \param[in] dm DistributionMapping for the BoxArray.
      * \param[in] gm Geometry, contains the box dimensions.
      */
-    virtual void define ( amrex::BoxArray const& realspace_ba,
-                          amrex::DistributionMapping const& dm,
-                          amrex::Geometry const& gm) override final;
+    void define ( amrex::BoxArray const& realspace_ba,
+                  amrex::DistributionMapping const& dm,
+                  amrex::Geometry const& gm);
 
     /**
      * Solve Poisson equation. The source term must be stored in the staging area m_stagingArea prior to this call.
@@ -57,6 +57,16 @@ public:
      * \param[in] lhs_mf Destination array, where the result is stored.
      */
     virtual void SolvePoissonEquation (amrex::MultiFab& lhs_mf) override final;
+
+    /** Position and relative factor used to apply inhomogeneous Dirichlet boundary conditions */
+    virtual amrex::Real BoundaryOffset() override final {
+        amrex::Abort("Cannot set boundary condition with periodic FFT solver");
+        return 1.;
+    }
+    virtual amrex::Real BoundaryFactor() override final {
+        amrex::Abort("Cannot set boundary condition with periodic FFT solver");
+        return 1.;
+    }
 
 private:
     /** Spectral fields, contains (complex) field in Fourier space */

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.H
@@ -58,15 +58,11 @@ public:
      */
     virtual void SolvePoissonEquation (amrex::MultiFab& lhs_mf) override final;
 
-    /** Position and relative factor used to apply inhomogeneous Dirichlet boundary conditions */
-    virtual amrex::Real BoundaryOffset() override final {
-        amrex::Abort("Cannot set boundary condition with periodic FFT solver");
-        return 1.;
-    }
-    virtual amrex::Real BoundaryFactor() override final {
-        amrex::Abort("Cannot set boundary condition with periodic FFT solver");
-        return 1.;
-    }
+    /** Position and relative factor used to apply inhomogeneous Dirichlet boundary conditions
+     * Note: inhomogeneous Dirichlet boundary conditions do not work with this solver
+     */
+    virtual amrex::Real BoundaryOffset() override final { return 1.; }
+    virtual amrex::Real BoundaryFactor() override final { return 1.; }
 
 private:
     /** Spectral fields, contains (complex) field in Fourier space */

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
@@ -54,12 +54,13 @@ FFTPoissonSolverPeriodic::define ( amrex::BoxArray const& realspace_ba,
                           spectral_bx_size - amrex::IntVect::TheUnitVector() );
         spectral_bl.push_back( spectral_bx );
     }
-    m_spectralspace_ba.define( std::move(spectral_bl) );
+    amrex::BoxArray spectralspace_ba{};
+    spectralspace_ba.define( std::move(spectral_bl) );
 
     // Allocate temporary arrays - in real space and spectral space
     // These arrays will store the data just before/after the FFT
     m_stagingArea = amrex::MultiFab(realspace_ba, dm, 1, Fields::m_poisson_nguards);
-    m_tmpSpectralField = SpectralField(m_spectralspace_ba, dm, 1, 0);
+    m_tmpSpectralField = SpectralField(spectralspace_ba, dm, 1, 0);
 
     // This must be true even for parallel FFT.
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stagingArea.local_size() == 1,
@@ -70,7 +71,7 @@ FFTPoissonSolverPeriodic::define ( amrex::BoxArray const& realspace_ba,
     // Calculate the array of inv_k2
     amrex::Real dkx = 2*MathConst::pi/gm.ProbLength(0);
     amrex::Real dky = 2*MathConst::pi/gm.ProbLength(1);
-    m_inv_k2 = amrex::MultiFab(m_spectralspace_ba, dm, 1, 0);
+    m_inv_k2 = amrex::MultiFab(spectralspace_ba, dm, 1, 0);
     // Loop over boxes and calculate inv_k2 in each box
     for (amrex::MFIter mfi(m_inv_k2, DfltMfi); mfi.isValid(); ++mfi ){
         Array2<amrex::Real> inv_k2_arr = m_inv_k2.array(mfi);
@@ -93,8 +94,8 @@ FFTPoissonSolverPeriodic::define ( amrex::BoxArray const& realspace_ba,
     }
 
     // Allocate and initialize the FFT plans
-    m_forward_plan = AnyFFT::FFTplans(m_spectralspace_ba, dm);
-    m_backward_plan = AnyFFT::FFTplans(m_spectralspace_ba, dm);
+    m_forward_plan = AnyFFT::FFTplans(spectralspace_ba, dm);
+    m_backward_plan = AnyFFT::FFTplans(spectralspace_ba, dm);
     // Loop over boxes and allocate the corresponding plan
     // for each box owned by the local MPI proc
     for ( amrex::MFIter mfi(m_stagingArea, DfltMfi); mfi.isValid(); ++mfi ){

--- a/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.H
+++ b/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.H
@@ -1,0 +1,55 @@
+/* Copyright 2024
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: AlexanderSinn
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef MG_POISSON_SOLVER_DIRICHLET_H_
+#define MG_POISSON_SOLVER_DIRICHLET_H_
+
+#include "FFTPoissonSolver.H"
+#include "mg_solver/HpMultiGrid.H"
+
+#include <AMReX_MultiFab.H>
+
+/**
+ * \brief This class handles functions and data to perform transverse multigrid-based Poisson solves.
+ *
+ * For a given source S, it solves equation Laplacian(F) = S and returns F.
+ * Once an instance is created, a typical use consists in:
+ * 1. Compute S directly in FFTPoissonSolver::m_stagingArea
+ * 2. Call FFTPoissonSolver::SolvePoissonEquation(mf), which will solve Poisson equation with RHS
+ *    in the staging area and return the LHS in mf.
+ */
+class MGPoissonSolverDirichlet final : public FFTPoissonSolver
+{
+public:
+    /** Constructor */
+    MGPoissonSolverDirichlet ( amrex::BoxArray const& a_realspace_ba,
+                               amrex::DistributionMapping const& dm,
+                               amrex::Geometry const& gm);
+
+    /** virtual destructor */
+    virtual ~MGPoissonSolverDirichlet () override final {}
+
+    /**
+     * Solve Poisson equation. The source term must be stored in the staging area m_stagingArea prior to this call.
+     *
+     * \param[in] lhs_mf Destination array, where the result is stored.
+     */
+    virtual void SolvePoissonEquation (amrex::MultiFab& lhs_mf) override final;
+
+    /** Position and relative factor used to apply inhomogeneous Dirichlet boundary conditions */
+    virtual amrex::Real BoundaryOffset() override final { return m_mg->m_boundary_condition_offset; }
+    virtual amrex::Real BoundaryFactor() override final { return m_mg->m_boundary_condition_factor; }
+
+private:
+    amrex::Real m_MG_tolerance_rel = 1.e-4;
+    amrex::Real m_MG_tolerance_abs = 0.;
+    int m_MG_verbose = 0;
+    /** hpmg solver for the poisson solver */
+    std::unique_ptr<hpmg::MultiGrid> m_mg;
+};
+
+#endif

--- a/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
@@ -10,6 +10,7 @@
 #include "fields/Fields.H"
 #include "utils/GPUUtil.H"
 #include "utils/HipaceProfilerWrapper.H"
+#include "utils/Parser.H"
 
 MGPoissonSolverDirichlet::MGPoissonSolverDirichlet (
     amrex::BoxArray const& ba,
@@ -20,6 +21,11 @@ MGPoissonSolverDirichlet::MGPoissonSolverDirichlet (
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ba.size() == 1, "Parallel MG not supported");
     amrex::Box solve_box = ba[0].grow(Fields::m_poisson_nguards);
     m_mg = std::make_unique<hpmg::MultiGrid>(gm.CellSize(0), gm.CellSize(1), solve_box, 3);
+
+    amrex::ParmParse pp("MGDirichlet");
+    queryWithParser(pp, "MG_tolerance_rel", m_MG_tolerance_rel);
+    queryWithParser(pp, "MG_tolerance_abs", m_MG_tolerance_abs);
+    queryWithParser(pp, "MG_verbose", m_MG_verbose);
 }
 
 void

--- a/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
@@ -1,0 +1,35 @@
+/* Copyright 2024
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: AlexanderSinn
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "MGPoissonSolverDirichlet.H"
+#include "fields/Fields.H"
+#include "utils/GPUUtil.H"
+#include "utils/HipaceProfilerWrapper.H"
+
+MGPoissonSolverDirichlet::MGPoissonSolverDirichlet (
+    amrex::BoxArray const& ba,
+    amrex::DistributionMapping const& dm,
+    amrex::Geometry const& gm )
+{
+    m_stagingArea = amrex::MultiFab(ba, dm, 1, Fields::m_poisson_nguards);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ba.size() == 1, "Parallel MG not supported");
+    amrex::Box solve_box = ba[0].grow(Fields::m_poisson_nguards);
+    m_mg = std::make_unique<hpmg::MultiGrid>(gm.CellSize(0), gm.CellSize(1), solve_box, 3);
+}
+
+void
+MGPoissonSolverDirichlet::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
+{
+    HIPACE_PROFILE("MGPoissonSolverDirichlet::SolvePoissonEquation()");
+
+    for ( amrex::MFIter mfi(m_stagingArea, DfltMfi); mfi.isValid(); ++mfi ){
+        const int max_iters = 200;
+        m_mg->solve3(lhs_mf[mfi], m_stagingArea[mfi], m_MG_tolerance_rel, m_MG_tolerance_abs,
+                     max_iters, m_MG_verbose);
+    }
+}

--- a/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
@@ -17,7 +17,8 @@ MGPoissonSolverDirichlet::MGPoissonSolverDirichlet (
     amrex::DistributionMapping const& dm,
     amrex::Geometry const& gm )
 {
-    m_stagingArea = amrex::MultiFab(ba, dm, 1, Fields::m_poisson_nguards);
+    // need extra ghost cell for 2^n-1 HPMG
+    m_stagingArea = amrex::MultiFab(ba, dm, 1, Fields::m_poisson_nguards + amrex::IntVect{1, 1, 0});
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ba.size() == 1, "Parallel MG not supported");
     amrex::Box solve_box = ba[0].grow(Fields::m_poisson_nguards);
     m_mg = std::make_unique<hpmg::MultiGrid>(gm.CellSize(0), gm.CellSize(1), solve_box, 3);

--- a/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
@@ -17,6 +17,8 @@ MGPoissonSolverDirichlet::MGPoissonSolverDirichlet (
     amrex::DistributionMapping const& dm,
     amrex::Geometry const& gm )
 {
+    HIPACE_PROFILE("MGPoissonSolverDirichlet::define()");
+
     // need extra ghost cell for 2^n-1 HPMG
     m_stagingArea = amrex::MultiFab(ba, dm, 1, Fields::m_poisson_nguards + amrex::IntVect{1, 1, 0});
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ba.size() == 1, "Parallel MG not supported");

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -712,7 +712,7 @@ MultiLaser::AdvanceSliceMG (const Fields& fields, amrex::Real dt, int step)
     if (!m_mg) {
         m_mg = std::make_unique<hpmg::MultiGrid>(m_laser_geom_3D.CellSize(0),
                                                  m_laser_geom_3D.CellSize(1),
-                                                 m_slices.boxArray()[0]);
+                                                 m_slices.boxArray()[0], 2);
     }
 
     const int max_iters = 200;

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -19,7 +19,7 @@ namespace hpmg {
 /** \brief Multigrid solver
  *
  * This solves `-acoef * sol + Lap(sol) = rhs` with homogeneous Dirichlet BC
- * on a 2D slice.  It can solve two types of linear systems.
+ * on a 2D slice.  It can solve three types of linear systems.
  *
  * (1) sol and rhs have two components, whereas acoef has only one
  *     component.  For Type I, call solve1(...).
@@ -29,6 +29,9 @@ namespace hpmg {
  *       -acoef_imag * sol_real - acoef_real * sol_imag + Lap(sol_imag) = rhs_imag
  *     For Type II, call solve2(...).  Here, acoef_real and acoef_imag can be
  *     either a scalar constant or FArrayBox.
+ *
+ * (3) sol and rhs have one components, whereas acoef zero everywhere.
+ *     For Type III, call solve3(...).
  */
 class MultiGrid
 {
@@ -39,8 +42,9 @@ public:
      * \param[in] dx Cell spacing in x direction
      * \param[in] dy Cell spacing in y direction
      * \param[in] a_domain Box describing a 2D slice
+     * \param[in] a_system_type which system type should be solved
      */
-    explicit MultiGrid (amrex::Real dx, amrex::Real dy, amrex::Box a_domain);
+    explicit MultiGrid (amrex::Real dx, amrex::Real dy, amrex::Box a_domain, int a_system_type);
 
     /** \brief Dtor */
     ~MultiGrid ();
@@ -128,6 +132,19 @@ public:
                 amrex::Real const tol_rel, amrex::Real const tol_abs,
                 int const nummaxiter, int const verbose);
 
+    /** \brief Solve the Type III equation given the initial guess and right hand side.
+     *
+     * \param[in,out] sol the initial guess and final solution
+     * \param[in] rhs right hand side
+     * \param[in] tol_rel relative tolerance
+     * \param[in] tol_abs absolute tolerance
+     * \param[in] nummaxiter maximum number of iterations
+     * \param[in] verbose verbosity level
+     */
+    void solve3 (amrex::FArrayBox& sol, amrex::FArrayBox const& rhs,
+                 amrex::Real const tol_rel, amrex::Real const tol_abs, int const nummaxiter,
+                 int const verbose);
+
     /** \brief Average down the coefficient.  Ideally, this function is not
      * supposed to be a public function.  It's made public due to a CUDA
      * limitation. */
@@ -155,6 +172,11 @@ public:
         AMREX_ALWAYS_ASSERT(out_box.contains(domain));
         return out_box;
     }
+
+    /** When applying Dirichlet boundary conditions, shift boundary value by offset number of cells */
+    amrex::Real m_boundary_condition_offset = 0.;
+    /** When applying Dirichlet boundary conditions, multiply the boundary value by this factor */
+    amrex::Real m_boundary_condition_factor = 0.;
 
 private:
 

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -173,6 +173,32 @@ public:
         return out_box;
     }
 
+    /** \brief Return the number of components used for a given system type
+     *
+     * \param[in] system_type which system type to use
+     */
+    static constexpr int get_num_comps (int system_type) {
+        switch (system_type) {
+            case 1: return 2;
+            case 2: return 2;
+            case 3: return 1;
+        }
+        return 0;
+    }
+
+    /** \brief Return the number of acf components used for a given system type
+     *
+     * \param[in] system_type which system type to use
+     */
+    static constexpr int get_num_comps_acf (int system_type) {
+        switch (system_type) {
+            case 1: return 1;
+            case 2: return 2;
+            case 3: return 0;
+        }
+        return 0;
+    }
+
     /** When applying Dirichlet boundary conditions, shift boundary value by offset number of cells */
     amrex::Real m_boundary_condition_offset = 0.;
     /** When applying Dirichlet boundary conditions, multiply the boundary value by this factor */

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -30,7 +30,7 @@ namespace hpmg {
  *     For Type II, call solve2(...).  Here, acoef_real and acoef_imag can be
  *     either a scalar constant or FArrayBox.
  *
- * (3) sol and rhs have one components, whereas acoef zero everywhere.
+ * (3) sol and rhs have one component, whereas acoef is zero everywhere.
  *     For Type III, call solve3(...).
  */
 class MultiGrid

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -158,8 +158,10 @@ public:
 
 private:
 
-    static constexpr int m_num_system_types = 2;
+    static constexpr int m_num_system_types = 3;
     int m_system_type = 0;
+    int m_num_comps = 0;
+    int m_num_comps_acf = 0;
 
     /** 2D slice domain */
     amrex::Vector<amrex::Box> m_domain;
@@ -204,14 +206,14 @@ private:
 
 #if defined(AMREX_USE_CUDA)
     /** CUDA graphs for average-down */
-    bool m_cuda_graph_acf_created[m_num_system_types] = {false,false};
-    cudaGraph_t m_cuda_graph_acf[m_num_system_types] = {NULL,NULL};
-    cudaGraphExec_t m_cuda_graph_exe_acf[m_num_system_types] = {NULL,NULL};
+    bool m_cuda_graph_acf_created = false;
+    cudaGraph_t m_cuda_graph_acf = NULL;
+    cudaGraphExec_t m_cuda_graph_exe_acf = NULL;
 
     /** CUDA graphs for the V-cycle*/
-    bool m_cuda_graph_vcycle_created[m_num_system_types] = {false,false};
-    cudaGraph_t m_cuda_graph_vcycle[m_num_system_types] = {NULL,NULL};
-    cudaGraphExec_t m_cuda_graph_exe_vcycle[m_num_system_types] = {NULL,NULL};
+    bool m_cuda_graph_vcycle_created = false;
+    cudaGraph_t m_cuda_graph_vcycle = NULL;
+    cudaGraphExec_t m_cuda_graph_exe_vcycle = NULL;
 #endif
 };
 


### PR DESCRIPTION
This PR enables the use of HPMG as a Poisson solver for Psi, Ez and Bz using the new HPMG system type 3. Additionally, gsrb_shared was expanded to system types 2 and 3 which makes the laser MG solver about 2x faster.
```
fields.poisson_solver = MGDirichlet # or FFTDirichlet, FFTPeriodic
```
Note that the fastest Poisson solve is still achieved with the FFT solver and a resolution of `2^n-1`.


Performance with `amr.n_cell = 1023 8191 2000` on A100:
```
TinyProfiler total time across processes [min...avg...max]: 93.89 ... 93.89 ... 93.89

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve3()                            6000      31.73      31.73      31.73  33.79%
hpmg::MultiGrid::solve1()                            2000       16.6       16.6       16.6  17.68%
hpmg::MultiGrid::solve2()                            2000      16.22      16.22      16.22  17.27%
ExplicitDeposition()                                 2000      7.393      7.393      7.393   7.87%
```
Dev:
```
TinyProfiler total time across processes [min...avg...max]: 93.83 ... 93.83 ... 93.83

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve2()                            2000       34.7       34.7       34.7  36.99%
hpmg::MultiGrid::solve1()                            2000      16.73      16.73      16.73  17.83%
AnyDST::Execute()                                   12000         11         11         11  11.72%
ExplicitDeposition()                                 2000      7.394      7.394      7.394   7.88%
```
Performance with `amr.n_cell = 1024 8192 2000` on A100:
```
TinyProfiler total time across processes [min...avg...max]: 95.76 ... 95.76 ... 95.76

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve3()                            6000       33.4       33.4       33.4  34.88%
hpmg::MultiGrid::solve2()                            2000      17.08      17.08      17.08  17.83%
hpmg::MultiGrid::solve1()                            2000      16.61      16.61      16.61  17.34%
ExplicitDeposition()                                 2000      6.911      6.911      6.911   7.22%
```
Dev:
```
TinyProfiler total time across processes [min...avg...max]: 111.9 ... 111.9 ... 111.9

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve2()                            2000      34.66      34.66      34.66  30.97%
AnyDST::Execute()                                   12000      28.93      28.93      28.93  25.85%
hpmg::MultiGrid::solve1()                            2000       17.2       17.2       17.2  15.37%
ExplicitDeposition()                                 2000      6.897      6.897      6.897   6.16%
```

Register usage of gsrb_shared PR:
```
--- 64 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)2, (bool)0, (bool)0, (bool)1>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 64 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)2, (bool)1, (bool)1, (bool)0>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 64 registers, 8 bytes stack frame, 16 bytes spill stores, 16 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)2, (bool)1, (bool)1, (bool)1>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 64 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)1, (bool)1, (bool)1, (bool)1>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 60 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)1, (bool)0, (bool)0, (bool)1>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 56 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)2, (bool)0, (bool)0, (bool)0>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 55 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)1, (bool)1, (bool)1, (bool)0>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 52 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)1, (bool)0, (bool)0, (bool)0>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 49 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)3, (bool)1, (bool)1, (bool)1>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 40 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)3, (bool)1, (bool)1, (bool)0>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 39 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)3, (bool)0, (bool)0, (bool)1>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
--- 37 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<(int)3, (bool)0, (bool)0, (bool)0>(const amrex::Box &, const amrex::Array4<double> &, const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &, double, double)::[lambda() (instance 1)]>(int, CUstream_st *, T2 &&)::[lambda() (instance 1)]>(T2)
```
Register usage of bottomsolve_gpu PR (unchanged/slight improvement):
```
--- 64 registers, 8 bytes stack frame, 16 bytes spill stores, 16 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void hpmg::<unnamed>::bottomsolve_gpu<(int)16, (int)2, hpmg::MultiGrid::bottomsolve()::[lambda(int, int, int, int, int, int, const amrex::Array4<double> &, const amrex::Array4<double> &, const amrex::Array4<double> &, double, double) (instance 2)], hpmg::MultiGrid::bottomsolve()::[lambda(int, int, const amrex::Array4<double> &, int, int, int, int, const amrex::Array4<double> &, const amrex::Array4<double> &, const amrex::Array4<double> &, double, double) (instance 2)]>(double, double, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, int, int, T3 &&, T4 &&)::[lambda() (instance 1)]>(T2)
--- 64 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void hpmg::<unnamed>::bottomsolve_gpu<(int)16, (int)1, hpmg::MultiGrid::bottomsolve()::[lambda(int, int, int, int, int, int, const amrex::Array4<double> &, const amrex::Array4<double> &, const amrex::Array4<double> &, double, double) (instance 1)], hpmg::MultiGrid::bottomsolve()::[lambda(int, int, const amrex::Array4<double> &, int, int, int, int, const amrex::Array4<double> &, const amrex::Array4<double> &, const amrex::Array4<double> &, double, double) (instance 1)]>(double, double, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, int, int, T3 &&, T4 &&)::[lambda() (instance 1)]>(T2)
--- 63 registers, 0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void hpmg::<unnamed>::bottomsolve_gpu<(int)16, (int)3, hpmg::MultiGrid::bottomsolve()::[lambda(int, int, int, int, int, int, const amrex::Array4<double> &, const amrex::Array4<double> &, const amrex::Array4<double> &, double, double) (instance 3)], hpmg::MultiGrid::bottomsolve()::[lambda(int, int, const amrex::Array4<double> &, int, int, int, int, const amrex::Array4<double> &, const amrex::Array4<double> &, const amrex::Array4<double> &, double, double) (instance 3)]>(double, double, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, int, int, T3 &&, T4 &&)::[lambda() (instance 1)]>(T2)
```
Register usage of bottomsolve_gpu dev:
```
--- 64 registers, 8 bytes stack frame, 16 bytes spill stores, 16 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void hpmg::<unnamed>::bottomsolve_gpu<(int)16, hpmg::MultiGrid::bottomsolve()::[lambda(int, int, int, int, int, int, const amrex::Array4<double> &, double, double, const amrex::Array4<double> &, double, double) (instance 2)], hpmg::MultiGrid::bottomsolve()::[lambda(int, int, double &, double &, int, int, int, int, const amrex::Array4<double> &, double, double, const amrex::Array4<double> &, double, double) (instance 2)]>(double, double, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, int, int, T2 &&, T3 &&)::[lambda() (instance 1)]>(T2)
--- 64 registers, 8 bytes stack frame, 8 bytes spill stores, 8 bytes spill loads, function name:
void amrex::launch_global<(int)1024, void hpmg::<unnamed>::bottomsolve_gpu<(int)16, hpmg::MultiGrid::bottomsolve()::[lambda(int, int, int, int, int, int, const amrex::Array4<double> &, double, double, const amrex::Array4<double> &, double, double) (instance 1)], hpmg::MultiGrid::bottomsolve()::[lambda(int, int, double &, double &, int, int, int, int, const amrex::Array4<double> &, double, double, const amrex::Array4<double> &, double, double) (instance 1)]>(double, double, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, const amrex::Array4<double> *, int, int, T2 &&, T3 &&)::[lambda() (instance 1)]>(T2)
```