### PR TITLE
Add HiPACE_CCACHE Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,15 @@ set_cxx17_superbuild()
 # this is an optional tool that stores compiled object files; allows fast
 # re-builds even with "make clean" in between. Mainly used to store AMReX
 # objects
-set_ccache()
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    set(HiPACE_CCACHE_DEFAULT ON)
+else()
+    set(HiPACE_CCACHE_DEFAULT OFF)  # we are a subproject in a superbuild
+endif()
+option(HiPACE_CCACHE "Enable ccache for faster rebuilds" ${HiPACE_CCACHE_DEFAULT})
+if(HiPACE_CCACHE)
+    set_ccache()
+endif()
 
 
 # Output Directories ##########################################################


### PR DESCRIPTION
Cleaner way to disable CCache in package managers.

See https://github.com/ECP-WarpX/WarpX/pull/4637

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
