### PR TITLE
Use amre::GpuComplex in diagnostics

### DIFF
--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -15,19 +15,6 @@
 
 #include <vector>
 
-// 16-byte alignment enables coalesced memory access which is significantly faster
-struct alignas(2*sizeof(amrex::Real)) AlignedComplex {
-    amrex::Real real;
-    amrex::Real imag;
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr
-    AlignedComplex& operator+= (const AlignedComplex& rhs) {
-        real += rhs.real;
-        imag += rhs.imag;
-        return *this;
-    }
-};
-
 
 /** \brief This struct holds data for one field diagnostic on one MR level */
 struct FieldDiagnosticData
@@ -50,7 +37,7 @@ struct FieldDiagnosticData
     amrex::Gpu::DeviceVector<int> m_comps_output_idx;
     /** Vector over levels, all fields */
     amrex::FArrayBox m_F;
-    using complex_type = AlignedComplex;
+    using complex_type = amrex::GpuComplex<amrex::Real>;
     /** FAB for laser */
     amrex::BaseFab<complex_type> m_F_laser;
     amrex::Geometry m_geom_io; /**< Diagnostics geometry */


### PR DESCRIPTION
Now that `amrex::GpuComplex` is aligned to its size, we don't have to use our own complex type with the extra alignment any more. 

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
