### PR TITLE
Try fix MacOS CI by unlinking Python

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,12 +58,6 @@ jobs:
         brew --cache
         set +e
 
-        brew install --overwrite python
-        brew link --force --overwrite python
-
-        brew install --overwrite python@3.12
-        brew link --force --overwrite python@3.12
-
         brew install fftw --only-dependencies --force
         brew install fftw
         brew link fftw
@@ -89,9 +83,6 @@ jobs:
         brew install openpmd-api
         brew link openpmd-api
 
-        python3 -m pip install matplotlib
-        python3 -m pip install numpy
-        python3 -m pip install scipy
     - name: build HiPACE++
       run: |
         cmake -S . -B build_sp          \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -62,6 +62,16 @@ jobs:
         rm -rf /usr/local/bin/2to3
         rm -rf /usr/local/bin/2to3-3.11
         rm -rf /usr/local/bin/2to3-3.12
+        rm -rf /usr/local/bin/idle3
+        rm -rf /usr/local/bin/idle3.12
+        rm -rf /usr/local/bin/pydoc3
+        rm -rf /usr/local/bin/pydoc3.12
+        rm -rf /usr/local/bin/python3
+        rm -rf /usr/local/bin/python3-config
+        rm -rf /usr/local/bin/python3.12
+        rm -rf /usr/local/bin/python3.12-config
+
+        brew uninstall python
 
         brew install fftw --only-dependencies --force
         brew install fftw
@@ -84,7 +94,7 @@ jobs:
         set -e
 
         brew tap openpmd/openpmd
-        brew install openpmd-api --only-dependencies --force --overwrite
+        brew install openpmd-api --only-dependencies --force
         brew install openpmd-api
         brew link openpmd-api
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,20 +58,7 @@ jobs:
         brew --cache
         set +e
 
-        ls /usr/local/bin
-        rm -rf /usr/local/bin/2to3
-        rm -rf /usr/local/bin/2to3-3.11
-        rm -rf /usr/local/bin/2to3-3.12
-        rm -rf /usr/local/bin/idle3
-        rm -rf /usr/local/bin/idle3.12
-        rm -rf /usr/local/bin/pydoc3
-        rm -rf /usr/local/bin/pydoc3.12
-        rm -rf /usr/local/bin/python3
-        rm -rf /usr/local/bin/python3-config
-        rm -rf /usr/local/bin/python3.12
-        rm -rf /usr/local/bin/python3.12-config
-
-        brew uninstall python
+        brew uninstall --ignore-dependencies homebrew/core/python
 
         brew install fftw --only-dependencies --force
         brew install fftw

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,9 @@ jobs:
         brew --cache
         set +e
 
+        ls /usr/local/bin
+        rm -rf /usr/local/bin/2to3
+
         brew install fftw --only-dependencies --force
         brew install fftw
         brew link fftw

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -84,7 +84,7 @@ jobs:
         set -e
 
         brew tap openpmd/openpmd
-        brew install openpmd-api --only-dependencies --force
+        brew install openpmd-api --only-dependencies --force --overwrite
         brew install openpmd-api
         brew link openpmd-api
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,6 +60,8 @@ jobs:
 
         ls /usr/local/bin
         rm -rf /usr/local/bin/2to3
+        rm -rf /usr/local/bin/2to3-3.11
+        rm -rf /usr/local/bin/2to3-3.12
 
         brew install fftw --only-dependencies --force
         brew install fftw

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,7 +58,10 @@ jobs:
         brew --cache
         set +e
 
-        brew uninstall --ignore-dependencies homebrew/core/python
+        rm -rf /usr/local/bin/2to3*
+        rm -rf /usr/local/bin/idle3*
+        rm -rf /usr/local/bin/pydoc3*
+        rm -rf /usr/local/bin/python3*
 
         brew install fftw --only-dependencies --force
         brew install fftw


### PR DESCRIPTION
When installing Python as a dependency of openPMD, it fails because it won’t replace the existing python links, so we remove them. Note that the CI test doesn't need python.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
