### PR TITLE
Fix MPI buffer max_leading_slices

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -97,7 +97,7 @@ General parameters
     rank that would run out of memory (out of CPU or GPU memory depending on ``hipace.comms_buffer_on_gpu``).
     If there are more time steps than ranks, these parameters must be chosen such that between all
     ranks there is enough capacity to store every slice to avoid a deadlock, i.e.
-    ``(comms_buffer_max_leading_slices + comms_buffer_max_trailing_slices) * nranks > nslices``.
+    ``comms_buffer_max_trailing_slices * nranks > nslices``.
 
 * ``hipace.do_tiling`` (`bool`) optional (default `true`)
     Whether to use tiling, when running on CPU.

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -147,10 +147,10 @@ Hipace::Hipace () :
     MakeGeometry();
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        (((double(m_comms_buffer_max_leading_slices) + m_comms_buffer_max_trailing_slices)
+        ((double(m_comms_buffer_max_trailing_slices)
         * amrex::ParallelDescriptor::NProcs()) > m_3D_geom[0].Domain().length(2))
         || (m_max_step < amrex::ParallelDescriptor::NProcs()),
-        "comms_buffer_max_leading_slices and comms_buffer_max_trailing_slices must be large enough"
+        "comms_buffer_max_trailing_slices must be large enough"
         " to distribute all slices between all ranks if there are more timesteps than ranks");
 
     m_use_laser = m_multi_laser.m_use_laser;

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -177,8 +177,8 @@ void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice)
     const bool is_blocking_send = is_blocking ||
         (m_nslices + slice - current_slice) % m_nslices > m_max_trailing_slices;
     const bool is_blocking_recv = is_blocking;
-    const bool skip_recv = !is_blocking_recv &&
-        (m_nslices - slice + current_slice) % m_nslices > m_max_leading_slices;
+    const bool skip_recv = !is_blocking_recv && (slice == current_slice ||
+        (m_nslices - slice + current_slice) % m_nslices > m_max_leading_slices);
 
     if (m_is_serial) {
         if (is_blocking) {


### PR DESCRIPTION
As noticed by @huixingjian, the `hipace.comms_buffer_max_leading_slices` option doesn't work sometimes. This is because there was one slice where incoming metadata could be received too early, if the `Isend` of the same slice would happen instantly. Furthermore, I noticed that in some situations (all ranks compute slices faster or at the same speed as the head rank) it is possible to go into a deadlock where none of the leading slices are filled, so I adjusted the assert and documentation to only include the trailing slices.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
