### PR TITLE
Limit size in GiB of communications buffer

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -98,6 +98,15 @@ General parameters
     This can improve performance in a typical situation where the CPU-GPU link has relatively
     low bandwidth at the cost of some GPU memory and a reduced maximum number of MPI ranks.
 
+* ``comms_buffer.max_size_GiB`` (`float`) optional (default `inf`)
+    How many Gibibytes of beam particles and laser slices can be stored in the communications buffer
+    on each rank. This setting offers an alternative to ``comms_buffer.max_leading_slices``
+    and ``comms_buffer.max_trailing_slices``. Note that the amount specified here may be slightly
+    exeeded in practice. If there are more time steps than ranks, this parameter must be chosen
+    such that between all ranks there is enough capacity to store every beam particle and
+    laser slice to avoid a deadlock, i.e.
+    ``comms_buffer.max_size_GiB * nranks > beam_size + laser_size``.
+
 * ``comms_buffer.max_leading_slices`` (`int`) optional (default `inf`)
     How many slices of beam particles can be received and stored in advance.
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -213,7 +213,7 @@ Hipace::InitData ()
     m_fields.checkInit();
 
     m_multi_buffer.initialize(m_3D_geom[0].Domain().length(2),
-                              m_multi_beam.get_nbeams(),
+                              m_multi_beam,
                               m_use_laser,
                               m_use_laser ? m_multi_laser.getSlices()[0].box() : amrex::Box{});
 

--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -18,7 +18,7 @@ class MultiBuffer
 public:
 
     // initialize MultiBuffer and open initial receive requests
-    void initialize (int nslices, int nbeams, bool use_laser, amrex::Box laser_box);
+    void initialize (int nslices, MultiBeam& beams, bool use_laser, amrex::Box laser_box);
 
     // receive data from previous rank and unpack it into MultiBeam and MultiLaser
     void get_data (int slice, MultiBeam& beams, MultiLaser& laser, int beam_slice);
@@ -120,6 +120,8 @@ private:
     int m_max_leading_slices = std::numeric_limits<int>::max();
     /** How many slices of beam particles can be stored before being sent */
     int m_max_trailing_slices = std::numeric_limits<int>::max();
+    std::size_t m_current_buffer_size = 0;
+    std::size_t m_max_buffer_size = std::numeric_limits<std::size_t>::max();
 
     // parameters to send physical time
     amrex::Real m_time_send_buffer = 0.;

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -36,6 +36,7 @@ void MultiBuffer::allocate_buffer (int slice) {
         ));
         m_datanodes[slice].m_location = memory_location::device;
     }
+    m_current_buffer_size += m_datanodes[slice].m_buffer_size * sizeof(storage_type);
 }
 
 void MultiBuffer::free_buffer (int slice) {
@@ -45,12 +46,13 @@ void MultiBuffer::free_buffer (int slice) {
     } else {
         amrex::The_Device_Arena()->free(m_datanodes[slice].m_buffer);
     }
+    m_current_buffer_size -= m_datanodes[slice].m_buffer_size * sizeof(storage_type);
     m_datanodes[slice].m_location = memory_location::nowhere;
     m_datanodes[slice].m_buffer = nullptr;
     m_datanodes[slice].m_buffer_size = 0;
 }
 
-void MultiBuffer::initialize (int nslices, int nbeams, bool use_laser, amrex::Box laser_box) {
+void MultiBuffer::initialize (int nslices, MultiBeam& beams, bool use_laser, amrex::Box laser_box) {
 
     amrex::ParmParse pp("comms_buffer");
 
@@ -59,7 +61,7 @@ void MultiBuffer::initialize (int nslices, int nbeams, bool use_laser, amrex::Bo
     const int n_ranks = amrex::ParallelDescriptor::NProcs();
 
     m_nslices = nslices;
-    m_nbeams = nbeams;
+    m_nbeams = beams.get_nbeams();
     m_use_laser = use_laser;
     m_laser_slice_box = laser_box;
 
@@ -89,6 +91,49 @@ void MultiBuffer::initialize (int nslices, int nbeams, bool use_laser, amrex::Bo
         || (Hipace::m_max_step < amrex::ParallelDescriptor::NProcs()),
         "comms_buffer.max_trailing_slices must be large enough"
         " to distribute all slices between all ranks if there are more timesteps than ranks");
+
+    double max_size_GiB = -1.;
+    queryWithParser(pp, "max_size_GiB", max_size_GiB);
+    if(max_size_GiB >= 0.) {
+        m_max_buffer_size = static_cast<std::size_t>(max_size_GiB*1024*1024*1024);
+
+        double size_estimate = 0.;
+        for (int b = 0; b < m_nbeams; ++b) {
+            auto& beam = beams.getBeam(b);
+            const double num_particles = static_cast<double>(beam.getTotalNumParticles());
+
+            if (beam.communicateIdCpuComponent()) {
+                size_estimate += num_particles * sizeof(std::uint64_t);
+            }
+
+            for (int rcomp = 0; rcomp < beam.numRealComponents(); ++rcomp) {
+                if (beam.communicateRealComponent(rcomp)) {
+                    size_estimate += num_particles * sizeof(amrex::Real);
+                }
+            }
+
+            for (int icomp = 0; icomp < beam.numIntComponents(); ++icomp) {
+                if (beam.communicateIntComponent(icomp)) {
+                    size_estimate += num_particles * sizeof(int);
+                }
+            }
+        }
+
+        if (m_use_laser) {
+            size_estimate += m_laser_slice_box.d_numPts() * nslices
+                * m_laser_ncomp * sizeof(amrex::Real);
+        }
+
+        size_estimate /= 1024*1024*1024;
+        if (!((1.05*size_estimate < max_size_GiB*n_ranks)
+            || (Hipace::m_max_step < amrex::ParallelDescriptor::NProcs()))) {
+            amrex::Abort("comms_buffer.max_size_GiB must be large enough to fit "
+                         "all the data needed for all beams and the laser "
+                         "between all ranks if there are more timesteps than ranks!\n"
+                         "Data needed: " + std::to_string(1.05*size_estimate) + " GiB\n"
+                         "Space available: " + std::to_string(max_size_GiB*n_ranks) + " GiB\n");
+        }
+    }
 
     for (int p = 0; p < comm_progress::nprogress; ++p) {
         m_async_metadata_slice[p] = m_nslices - 1;
@@ -187,9 +232,13 @@ MultiBuffer::~MultiBuffer() {
 }
 
 void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice) {
-
+    const bool is_first_slice_with_recv_data =
+        m_async_data_slice[comm_progress::receive_started] == slice;
+    const bool is_last_slice_with_send_data =
+        m_async_data_slice[comm_progress::sent] == slice;
     const bool is_blocking_send = is_blocking ||
-        (m_nslices + slice - current_slice) % m_nslices > m_max_trailing_slices;
+        ((m_nslices + slice - current_slice) % m_nslices > m_max_trailing_slices) ||
+        (is_last_slice_with_send_data && (m_current_buffer_size > m_max_buffer_size));
     const bool is_blocking_recv = is_blocking;
     const bool skip_recv = !is_blocking_recv && (slice == current_slice ||
         (m_nslices - slice + current_slice) % m_nslices > m_max_leading_slices);
@@ -300,16 +349,21 @@ void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice)
             // don't receive empty buffer
             m_datanodes[slice].m_progress = comm_progress::received;
         } else {
-            allocate_buffer(slice);
-            MPI_Irecv(
-                m_datanodes[slice].m_buffer,
-                m_datanodes[slice].m_buffer_size,
-                amrex::ParallelDescriptor::Mpi_typemap<storage_type>::type(),
-                m_rank_receive_from,
-                m_tag_buffer_start + slice,
-                m_comm,
-                &(m_datanodes[slice].m_request));
-            m_datanodes[slice].m_progress = comm_progress::receive_started;
+            // enforce that slices are received in order
+            if (is_blocking_recv || (is_first_slice_with_recv_data &&
+                (m_current_buffer_size + m_datanodes[slice].m_buffer_size * sizeof(storage_type)
+                <= m_max_buffer_size))) {
+                allocate_buffer(slice);
+                MPI_Irecv(
+                    m_datanodes[slice].m_buffer,
+                    m_datanodes[slice].m_buffer_size,
+                    amrex::ParallelDescriptor::Mpi_typemap<storage_type>::type(),
+                    m_rank_receive_from,
+                    m_tag_buffer_start + slice,
+                    m_comm,
+                    &(m_datanodes[slice].m_request));
+                m_datanodes[slice].m_progress = comm_progress::receive_started;
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds an easy-to-use alternative to `comms_buffer.max_leading_slices` and `comms_buffer.max_trailing_slices`. The maximum amount of memory that can be used for the communications buffer on each rank can be specified with:
```
comms_buffer.max_size_GiB = 10
```
The unit GiB is used because the memory capacity of GPUs is also given in GiB (e.g. A100 can have 40 GiB of HBM memory).

Test with 4 A100 and `comms_buffer.max_size_GiB = 28`:
```
Initializing AMReX (24.03)...
MPI initialized with 4 MPI processes
MPI initialized with thread support level 0
Initializing CUDA...
Multiple GPUs are visible to each MPI rank, This may lead to incorrect or suboptimal rank-to-GPU mapping.!
CUDA initialized with 4 devices.
AMReX (24.03) initialized
HiPACE++ (24.03-nogit) running in double precision
using CUDA version 11.8.89
using the leapfrog plasma particle pusher
using C2R cuFFT of sizes 1024 and 8192 with 129 MiB of work area
00:00:00 Rank 0 started step 0 at time = 0 with dt = 1.676676018e-13
00:00:00 Rank 1 started step 1 at time = 1.676676018e-13 with dt = 1.676676018e-13
00:00:00 Rank 2 started step 2 at time = 3.353352035e-13 with dt = 1.676676018e-13
00:00:00 Rank 3 started step 3 at time = 5.030028053e-13 with dt = 1.676676018e-13
00:00:15 Rank 0 started step 4 at time = 6.70670407e-13 with dt = 1.676676018e-13
00:00:16 Rank 1 started step 5 at time = 8.383380088e-13 with dt = 1.676676018e-13
00:00:19 Rank 2 started step 6 at time = 1.006005611e-12 with dt = 1.676676018e-13
00:00:23 Rank 3 started step 7 at time = 1.173673212e-12 with dt = 1.676676018e-13
00:00:32 Rank 0 started step 8 at time = 1.341340814e-12 with dt = 1.676676018e-13
00:00:32 Rank 1 started step 9 at time = 1.509008416e-12 with dt = 1.676676018e-13
00:00:35 Rank 2 started step 10 at time = 1.676676018e-12 with dt = 1.676676018e-13
00:00:39 Rank 3 started step 11 at time = 1.844343619e-12 with dt = 1.676676018e-13
00:00:48 Rank 0 started step 12 at time = 2.012011221e-12 with dt = 1.676676018e-13
00:00:48 Rank 1 started step 13 at time = 2.179678823e-12 with dt = 1.676676018e-13
00:00:51 Rank 2 started step 14 at time = 2.347346425e-12 with dt = 1.676676018e-13
00:00:56 Rank 3 started step 15 at time = 2.515014026e-12 with dt = 1.676676018e-13
00:01:04 Rank 0 started step 16 at time = 2.682681628e-12 with dt = 1.676676018e-13
00:01:04 Rank 1 started step 17 at time = 2.85034923e-12 with dt = 1.676676018e-13
00:01:08 Rank 2 started step 18 at time = 3.018016832e-12 with dt = 1.676676018e-13
00:01:12 Rank 3 started step 19 at time = 3.185684433e-12 with dt = 1.676676018e-13
00:01:21 Rank 0 started step 20 at time = 3.353352035e-12 with dt = 1.676676018e-13
00:01:21 Rank 1 started step 21 at time = 3.521019637e-12 with dt = 1.676676018e-13
00:01:24 Rank 2 started step 22 at time = 3.688687239e-12 with dt = 1.676676018e-13
00:01:28 Rank 3 started step 23 at time = 3.85635484e-12 with dt = 1.676676018e-13
00:01:37 Rank 0 started step 24 at time = 4.024022442e-12 with dt = 1.676676018e-13
00:01:37 Rank 1 started step 25 at time = 4.191690044e-12 with dt = 1.676676018e-13
00:01:41 Rank 2 started step 26 at time = 4.359357646e-12 with dt = 1.676676018e-13
00:01:45 Rank 3 started step 27 at time = 4.527025247e-12 with dt = 1.676676018e-13
00:01:53 Rank 0 started step 28 at time = 4.694692849e-12 with dt = 1.676676018e-13
00:01:54 Rank 1 started step 29 at time = 4.862360451e-12 with dt = 1.676676018e-13
00:01:57 Rank 2 started step 30 at time = 5.030028053e-12 with dt = 1.676676018e-13
00:02:01 Rank 3 started step 31 at time = 5.197695654e-12 with dt = 1.676676018e-13
00:02:10 Rank 0 started step 32 at time = 5.365363256e-12 with dt = 1.676676018e-13
00:02:10 Rank 1 started step 33 at time = 5.533030858e-12 with dt = 1.676676018e-13
00:02:14 Rank 2 started step 34 at time = 5.70069846e-12 with dt = 1.676676018e-13
00:02:18 Rank 3 started step 35 at time = 5.868366061e-12 with dt = 1.676676018e-13
00:02:26 Rank 0 started step 36 at time = 6.036033663e-12 with dt = 1.676676018e-13
00:02:27 Rank 1 started step 37 at time = 6.203701265e-12 with dt = 1.676676018e-13
00:02:30 Rank 2 started step 38 at time = 6.371368867e-12 with dt = 1.676676018e-13
00:02:34 Rank 3 started step 39 at time = 6.539036468e-12 with dt = 1.676676018e-13
00:02:43 Rank 0 started step 40 at time = 6.70670407e-12 with dt = 1.676676018e-13
00:02:43 Rank 1 started step 41 at time = 6.874371672e-12 with dt = 1.676676018e-13
00:02:47 Rank 2 started step 42 at time = 7.042039274e-12 with dt = 1.676676018e-13
00:02:51 Rank 3 started step 43 at time = 7.209706875e-12 with dt = 1.676676018e-13
00:02:59 Rank 0 started step 44 at time = 7.377374477e-12 with dt = 1.676676018e-13
00:03:00 Rank 1 started step 45 at time = 7.545042079e-12 with dt = 1.676676018e-13
00:03:03 Rank 2 started step 46 at time = 7.712709681e-12 with dt = 1.676676018e-13
00:03:07 Rank 3 started step 47 at time = 7.880377283e-12 with dt = 1.676676018e-13
00:03:16 Rank 0 started step 48 at time = 8.048044884e-12 with dt = 1.676676018e-13
00:03:16 Rank 1 started step 49 at time = 8.215712486e-12 with dt = 1.676676018e-13
00:03:20 Rank 2 started step 50 at time = 8.383380088e-12 with dt = 1.676676018e-13
00:03:24 Rank 3 started step 51 at time = 8.55104769e-12 with dt = 1.676676018e-13
00:03:32 Rank 0 started step 52 at time = 8.718715291e-12 with dt = 1.676676018e-13
00:03:33 Rank 1 started step 53 at time = 8.886382893e-12 with dt = 1.676676018e-13
00:03:36 Rank 2 started step 54 at time = 9.054050495e-12 with dt = 1.676676018e-13
00:03:40 Rank 3 started step 55 at time = 9.221718097e-12 with dt = 1.676676018e-13
00:03:49 Rank 0 started step 56 at time = 9.389385698e-12 with dt = 1.676676018e-13
00:03:50 Rank 1 started step 57 at time = 9.5570533e-12 with dt = 1.676676018e-13
00:03:53 Rank 2 started step 58 at time = 9.724720902e-12 with dt = 1.676676018e-13
00:03:57 Rank 3 started step 59 at time = 9.892388504e-12 with dt = 1.676676018e-13
00:04:06 Rank 0 started step 60 at time = 1.006005611e-11 with dt = 1.676676018e-13
00:04:06 Rank 1 started step 61 at time = 1.022772371e-11 with dt = 1.676676018e-13
00:04:09 Rank 2 started step 62 at time = 1.039539131e-11 with dt = 1.676676018e-13
00:04:14 Rank 3 started step 63 at time = 1.056305891e-11 with dt = 1.676676018e-13


TinyProfiler total time across processes [min...avg...max]: 262.6 ... 265.6 ... 270.4

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve1()                            6400      63.11      63.35      63.62  23.53%
hpmg::MultiGrid::solve2()                            6400      59.77      59.91         60  22.19%
AnyDST::Execute()                                   38400      35.36      35.46      35.53  13.14%
ExplicitDeposition()                                 6400      23.79      23.86      23.93   8.85%
AdvancePlasmaParticles()                             6400      16.67      16.68      16.69   6.17%
DepositCurrent_PlasmaParticleContainer()             6416      14.32      14.44      14.56   5.38%
MultiLaser::ShiftLaserSlices()                       6400      11.59      11.65      11.71   4.33%
MultiBuffer::put_data()                              6400      2.968      5.015       8.89   3.29%
MultiLaser::AdvanceSliceMG()                         6400      7.938      7.961      7.972   2.95%
FFTPoissonSolverDirichlet::SolvePoissonEquation()   19200      5.138      5.152      5.164   1.91%
Fields::InitializeSlices()                           6400      4.625      4.663      4.703   1.74%
MultiBuffer::get_data()                              6400      2.561      3.565      4.467   1.65%
Fields::ShiftSlices()                                6400      3.589      3.598      3.614   1.34%
Hipace::InitializeSxSyWithBeam()                     6400      2.422      2.427      2.432   0.90%
Fields::LinCombination()                            12800      2.078      2.081      2.085   0.77%
Fields::AddRhoIons()                                 6400      1.986      1.991      1.997   0.74%
Fields::SolvePoissonPsiExmByEypBxEzBz()              6400      1.278      1.284      1.287   0.48%
Fields::Multiply()                                   6400     0.7067     0.7099     0.7132   0.26%
AnyDST::C2Rfft()                                    76800     0.3784     0.3962     0.4165   0.15%
MultiLaser::InitLaserSlice()                          100          0    0.07121     0.2848   0.11%
AnyDST::ToSine()                                    76800     0.2287       0.24     0.2529   0.09%
AnyDST::ToComplex()                                 76800     0.2224     0.2356     0.2481   0.09%
AnyDST::Transpose()                                 76800     0.2169     0.2294     0.2414   0.09%
Hipace::SolveOneSlice()                              6400      0.213     0.2208     0.2288   0.08%
PlasmaParticleContainer::InitParticles                 16    0.09057    0.09106     0.0913   0.03%
AnyDST::CreatePlan()                                    1    0.05394    0.05584    0.05684   0.02%
Hipace::ExplicitMGSolveBxBy()                        6400    0.05109    0.05322    0.05469   0.02%
FabArray::setVal()                                     36    0.03575    0.03603    0.03636   0.01%
DepositCurrentSlice_BeamParticleContainer()         12800    0.03071    0.03175     0.0329   0.01%
BeamParticleContainer::resize()                     19293    0.02662    0.02805    0.02894   0.01%
Fields::SetBoundaryCondition()                      19200    0.02622    0.02724    0.02808   0.01%
AdvanceBeamParticlesSlice()                          6400    0.02282    0.02339    0.02381   0.01%
Hipace::Evolve()                                        1    0.01216    0.01637      0.022   0.01%
main()                                                  1   0.001087    0.01382    0.01915   0.01%
shiftSlippedParticles()                              6400    0.01544    0.01597    0.01646   0.01%
FabArray::FillBoundary()                            25600    0.01089    0.01101    0.01112   0.00%
PlasmaParticleContainer::IonizationModule()          6400   0.009504   0.009721   0.009953   0.00%
GridCurrent::DepositCurrentSlice()                   6400   0.009181   0.009453   0.009744   0.00%
PlasmaParticleContainer::ReorderParticles()          6400   0.008719   0.009096   0.009469   0.00%
BeamParticleContainer::ReorderParticles()            6400   0.008924   0.009243   0.009395   0.00%
FillBoundary_nowait()                               25600   0.007808   0.008008   0.008136   0.00%
FabArrayBase::getFB()                               25600    0.00509   0.005281   0.005371   0.00%
FillBoundary_finish()                               25600   0.003972   0.004091   0.004198   0.00%
Hipace::InitData()                                      1  0.0003267  0.0008781   0.002403   0.00%
MultiBuffer::get_time()                                15  8.908e-05  0.0004919   0.001411   0.00%
BeamParticleContainer::InitBeamFixedWeightSlice()     100          0  0.0003342   0.001337   0.00%
BeamParticleContainer::intializeSlice()               100          0  0.0002985   0.001194   0.00%
MultiLaser::InitSliceEnvelope()                       100          0  0.0002884   0.001154   0.00%
FFTPoissonSolverDirichlet::define()                     1  0.0003198  0.0003226  0.0003247   0.00%
MultiLaser::InitData()                                  1  0.0002978  0.0003012  0.0003058   0.00%
MultiBuffer::put_time()                                15  5.738e-05  8.535e-05  0.0001263   0.00%
MultiPlasma::InitData()                                16  9.914e-05  0.0001091   0.000119   0.00%
sortBeamParticlesByBox()                                0          0  2.816e-05  0.0001126   0.00%
Diagnostic::ResizeFDiagFAB()                           16  6.176e-05  7.799e-05  8.958e-05   0.00%
Hipace::ResetAllQuantities()                           16  4.883e-05  5.051e-05   5.28e-05   0.00%
Fields::AllocData()                                     1  4.227e-05  4.765e-05  4.985e-05   0.00%
ParticleContainer::clearParticles()                    16   4.36e-05  4.437e-05  4.554e-05   0.00%
Hipace::ResetLaser()                                   16  2.932e-05  3.067e-05   3.22e-05   0.00%
FabArrayBase::FB::FB()                                  1  1.344e-05  1.879e-05  2.469e-05   0.00%
BeamParticleContainer::InitBeamFixedWeight3D()          1    1.9e-06  7.392e-06  2.364e-05   0.00%
--------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Incl. Min  Incl. Avg  Incl. Max   Max %
--------------------------------------------------------------------------------------------------
main()                                                  1      262.6      265.6      270.4 100.00%
Hipace::Evolve()                                        1      262.5      265.6      270.3  99.98%
Hipace::SolveOneSlice()                              6400      262.4      265.4      270.2  99.92%
MultiLaser::AdvanceSliceMG()                         6400      67.71      67.87      67.96  25.14%
Hipace::ExplicitMGSolveBxBy()                        6400      63.17       63.4      63.67  23.55%
hpmg::MultiGrid::solve1()                            6400      63.11      63.35      63.62  23.53%
hpmg::MultiGrid::solve2()                            6400      59.77      59.91         60  22.19%
Fields::SolvePoissonPsiExmByEypBxEzBz()              6400      45.79      45.83      45.88  16.97%
FFTPoissonSolverDirichlet::SolvePoissonEquation()   19200      41.67      41.71      41.75  15.44%
AnyDST::Execute()                                   38400      36.51      36.56      36.59  13.53%
ExplicitDeposition()                                 6400      23.79      23.86      23.93   8.85%
AdvancePlasmaParticles()                             6400      16.67      16.68      16.69   6.17%
DepositCurrent_PlasmaParticleContainer()             6416      14.32      14.44      14.56   5.38%
MultiLaser::ShiftLaserSlices()                       6400      11.59      11.65      11.71   4.33%
MultiBuffer::put_data()                              6400      2.978      5.024      8.899   3.29%
Fields::InitializeSlices()                           6400      4.625      4.663      4.703   1.74%
MultiBuffer::get_data()                              6400      2.859      3.646      4.476   1.66%
Fields::ShiftSlices()                                6400      3.589      3.598      3.614   1.34%
Hipace::InitializeSxSyWithBeam()                     6400      2.435       2.44      2.444   0.90%
Fields::LinCombination()                            12800      2.078      2.081      2.085   0.77%
Fields::AddRhoIons()                                 6400      1.986      1.991      1.997   0.74%
Fields::Multiply()                                   6400     0.7067     0.7099     0.7132   0.26%
AnyDST::C2Rfft()                                    76800     0.3784     0.3962     0.4165   0.15%
MultiLaser::InitSliceEnvelope()                       100          0     0.0715      0.286   0.11%
MultiLaser::InitLaserSlice()                          100          0    0.07121     0.2848   0.11%
AnyDST::ToSine()                                    76800     0.2287       0.24     0.2529   0.09%
AnyDST::ToComplex()                                 76800     0.2224     0.2356     0.2481   0.09%
AnyDST::Transpose()                                 76800     0.2169     0.2294     0.2414   0.09%
MultiPlasma::InitData()                                16    0.09071    0.09121    0.09146   0.03%
PlasmaParticleContainer::InitParticles                 16    0.09061     0.0911    0.09134   0.03%
Hipace::InitData()                                      1    0.05912     0.0597    0.06022   0.02%
Fields::AllocData()                                     1    0.05566    0.05756    0.05858   0.02%
FFTPoissonSolverDirichlet::define()                     1    0.05445    0.05635    0.05735   0.02%
AnyDST::CreatePlan()                                    1    0.05394    0.05584    0.05684   0.02%
FabArray::setVal()                                     36    0.03575    0.03603    0.03636   0.01%
Hipace::ResetAllQuantities()                           16    0.03356    0.03383    0.03416   0.01%
DepositCurrentSlice_BeamParticleContainer()         12800    0.03071    0.03175     0.0329   0.01%
BeamParticleContainer::resize()                     19293    0.02662    0.02805    0.02894   0.01%
FabArray::FillBoundary()                            25600    0.02814    0.02841    0.02871   0.01%
Fields::SetBoundaryCondition()                      19200    0.02622    0.02724    0.02808   0.01%
AdvanceBeamParticlesSlice()                          6400    0.02282    0.02339    0.02381   0.01%
shiftSlippedParticles()                              6400    0.01572    0.01625    0.01675   0.01%
Hipace::ResetLaser()                                   16     0.0156    0.01581    0.01601   0.01%
FillBoundary_nowait()                               25600    0.01317    0.01331    0.01348   0.00%
PlasmaParticleContainer::IonizationModule()          6400   0.009504   0.009721   0.009953   0.00%
GridCurrent::DepositCurrentSlice()                   6400   0.009181   0.009453   0.009744   0.00%
PlasmaParticleContainer::ReorderParticles()          6400   0.008719   0.009096   0.009469   0.00%
BeamParticleContainer::ReorderParticles()            6400   0.008924   0.009243   0.009395   0.00%
FabArrayBase::getFB()                               25600   0.005109     0.0053   0.005384   0.00%
FillBoundary_finish()                               25600   0.003972   0.004091   0.004198   0.00%
BeamParticleContainer::intializeSlice()               100          0  0.0007805   0.003122   0.00%
BeamParticleContainer::InitBeamFixedWeightSlice()     100          0   0.000482   0.001928   0.00%
MultiBuffer::get_time()                                15  8.908e-05  0.0004919   0.001411   0.00%
MultiLaser::InitData()                                  1   0.001218   0.001222   0.001226   0.00%
MultiBuffer::put_time()                                15  5.738e-05  8.535e-05  0.0001263   0.00%
sortBeamParticlesByBox()                                0          0  2.816e-05  0.0001126   0.00%
Diagnostic::ResizeFDiagFAB()                           16  6.176e-05  7.799e-05  8.958e-05   0.00%
ParticleContainer::clearParticles()                    16   4.36e-05  4.437e-05  4.554e-05   0.00%
FabArrayBase::FB::FB()                                  1  1.344e-05  1.879e-05  2.469e-05   0.00%
BeamParticleContainer::InitBeamFixedWeight3D()          1    1.9e-06  7.392e-06  2.364e-05   0.00%
--------------------------------------------------------------------------------------------------

Device Memory Usage:
--------------------------------------------------------------------------------------------------------------------------------------
Name                                            Nalloc   Nfree  AvgMem min  AvgMem avg  AvgMem max  MaxMem min  MaxMem avg  MaxMem max
--------------------------------------------------------------------------------------------------------------------------------------
The_Arena::Initialize()                              4       4    9841 KiB    9855 KiB    9870 KiB      29 GiB      29 GiB      29 GiB
MultiBuffer::put_data()                          50372   50372      16 GiB      23 GiB      26 GiB      19 GiB      25 GiB      28 GiB
MultiLaser::InitData()                              16      16    1494 MiB    1511 MiB    1539 MiB    1539 MiB    1539 MiB    1539 MiB
Fields::AllocData()                                  4       4    1371 MiB    1387 MiB    1412 MiB    1412 MiB    1412 MiB    1412 MiB
MultiLaser::AdvanceSliceMG()                     51348   51348     711 MiB     719 MiB     730 MiB     875 MiB     875 MiB     875 MiB
PlasmaParticleContainer::InitParticles            1088    1088     755 MiB     764 MiB     778 MiB     842 MiB     842 MiB     842 MiB
Hipace::ExplicitMGSolveBxBy()                      148     148     580 MiB     586 MiB     596 MiB     598 MiB     598 MiB     598 MiB
MultiBuffer::get_data()                             28      28       0   B     223 KiB     373 KiB       0   B     192 MiB     256 MiB
FFTPoissonSolverDirichlet::define()                 12      12     186 MiB     188 MiB     191 MiB     191 MiB     191 MiB     191 MiB
AnyDST::CreatePlan()                                 8       8     124 MiB     125 MiB     128 MiB     128 MiB     128 MiB     128 MiB
ResizeRandomSeed                                     4       4      40 MiB      40 MiB      40 MiB      40 MiB      40 MiB      40 MiB
hpmg::MultiGrid::solve2()                       100822  100822      52 KiB      52 KiB      52 KiB     432 KiB     432 KiB     432 KiB
hpmg::MultiGrid::solve1()                       109967  109967      54 KiB      54 KiB      54 KiB     432 KiB     432 KiB     432 KiB
BeamParticleContainer::resize()                    252     252     319 KiB     321 KiB     324 KiB     353 KiB     353 KiB     353 KiB
shiftSlippedParticles()                           1557    1557       2   B       2   B       2   B     108 KiB     108 KiB     108 KiB
sortBeamParticlesByBox()                             4       4       0   B      18 KiB      75 KiB       0   B      21 KiB      85 KiB
BeamParticleContainer::InitBeamFixedWeight3D()       1       1       0   B      18 KiB      75 KiB       0   B      19 KiB      78 KiB
main()                                              36      36     637   B     644   B     655   B     656   B     656   B     656   B
Hipace::InitData()                                  12      12     139   B     140   B     143   B     144   B     144   B     144   B
DepositCurrent_PlasmaParticleContainer()         25664   25664       0   B       0   B       0   B      16   B      16   B      16   B
--------------------------------------------------------------------------------------------------------------------------------------

Managed Memory Usage:
----------------------------------------------------------------------------------------------------------------------
Name                             Nalloc  Nfree  AvgMem min  AvgMem avg  AvgMem max  MaxMem min  MaxMem avg  MaxMem max
----------------------------------------------------------------------------------------------------------------------
The_Managed_Arena::Initialize()       4      4       1   B       1   B       3   B    8192 KiB    8192 KiB    8192 KiB
----------------------------------------------------------------------------------------------------------------------

Pinned Memory Usage:
------------------------------------------------------------------------------------------------------------------------------
Name                                    Nalloc   Nfree  AvgMem min  AvgMem avg  AvgMem max  MaxMem min  MaxMem avg  MaxMem max
------------------------------------------------------------------------------------------------------------------------------
The_Pinned_Arena::Initialize()               4       4     102   B     104   B     106   B    8192 KiB    8192 KiB    8192 KiB
Hipace::InitData()                          76      76    6276   B    6349   B    6462   B    6496   B    6496   B    6496   B
main()                                     216     216     637   B     644   B     655   B     688   B     688   B     688   B
Hipace::ExplicitMGSolveBxBy()                4       4     497   B     501   B     510   B     512   B     512   B     512   B
MultiLaser::AdvanceSliceMG()                 4       4     497   B     501   B     510   B     512   B     512   B     512   B
PlasmaParticleContainer::InitParticles      64      64       0   B       0   B       0   B      16   B      16   B      16   B
hpmg::MultiGrid::solve1()               109967  109967       3   B       3   B       3   B      16   B      16   B      16   B
hpmg::MultiGrid::solve2()               100822  100822       3   B       3   B       3   B      16   B      16   B      16   B
shiftSlippedParticles()                   1536    1536       0   B       0   B       0   B      16   B      16   B      16   B
------------------------------------------------------------------------------------------------------------------------------

Total GPU global memory (MB) spread across MPI: [40370 ... 40370]
Free  GPU global memory (MB) spread across MPI: [2018 ... 9500]
[The         Arena] space (MB) allocated spread across MPI: [30277 ... 37727]
[The         Arena] space (MB) used      spread across MPI: [0 ... 0]
[The Managed Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The Managed Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Pinned Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The  Pinned Arena] space (MB) used      spread across MPI: [0 ... 0]
AMReX (24.03) finalized
```


Test with 4 A100 and `max_leading_slices` + `max_trailing_slices`:
```
Initializing AMReX (24.03)...
MPI initialized with 4 MPI processes
MPI initialized with thread support level 0
Initializing CUDA...
Multiple GPUs are visible to each MPI rank, This may lead to incorrect or suboptimal rank-to-GPU mapping.!
CUDA initialized with 4 devices.
AMReX (24.03) initialized
HiPACE++ (24.03-nogit) running in double precision
using CUDA version 11.8.89
using the leapfrog plasma particle pusher
using C2R cuFFT of sizes 1024 and 8192 with 129 MiB of work area
00:00:00 Rank 0 started step 0 at time = 0 with dt = 1.676676018e-13
00:00:00 Rank 1 started step 1 at time = 1.676676018e-13 with dt = 1.676676018e-13
00:00:00 Rank 2 started step 2 at time = 3.353352035e-13 with dt = 1.676676018e-13
00:00:00 Rank 3 started step 3 at time = 5.030028053e-13 with dt = 1.676676018e-13
00:00:15 Rank 0 started step 4 at time = 6.70670407e-13 with dt = 1.676676018e-13
00:00:18 Rank 1 started step 5 at time = 8.383380088e-13 with dt = 1.676676018e-13
00:00:23 Rank 2 started step 6 at time = 1.006005611e-12 with dt = 1.676676018e-13
00:00:27 Rank 3 started step 7 at time = 1.173673212e-12 with dt = 1.676676018e-13
00:00:32 Rank 0 started step 8 at time = 1.341340814e-12 with dt = 1.676676018e-13
00:00:35 Rank 1 started step 9 at time = 1.509008416e-12 with dt = 1.676676018e-13
00:00:39 Rank 2 started step 10 at time = 1.676676018e-12 with dt = 1.676676018e-13
00:00:44 Rank 3 started step 11 at time = 1.844343619e-12 with dt = 1.676676018e-13
00:00:48 Rank 0 started step 12 at time = 2.012011221e-12 with dt = 1.676676018e-13
00:00:51 Rank 1 started step 13 at time = 2.179678823e-12 with dt = 1.676676018e-13
00:00:56 Rank 2 started step 14 at time = 2.347346425e-12 with dt = 1.676676018e-13
00:01:00 Rank 3 started step 15 at time = 2.515014026e-12 with dt = 1.676676018e-13
00:01:04 Rank 0 started step 16 at time = 2.682681628e-12 with dt = 1.676676018e-13
00:01:08 Rank 1 started step 17 at time = 2.85034923e-12 with dt = 1.676676018e-13
00:01:12 Rank 2 started step 18 at time = 3.018016832e-12 with dt = 1.676676018e-13
00:01:16 Rank 3 started step 19 at time = 3.185684433e-12 with dt = 1.676676018e-13
00:01:21 Rank 0 started step 20 at time = 3.353352035e-12 with dt = 1.676676018e-13
00:01:24 Rank 1 started step 21 at time = 3.521019637e-12 with dt = 1.676676018e-13
00:01:28 Rank 2 started step 22 at time = 3.688687239e-12 with dt = 1.676676018e-13
00:01:33 Rank 3 started step 23 at time = 3.85635484e-12 with dt = 1.676676018e-13
00:01:37 Rank 0 started step 24 at time = 4.024022442e-12 with dt = 1.676676018e-13
00:01:41 Rank 1 started step 25 at time = 4.191690044e-12 with dt = 1.676676018e-13
00:01:45 Rank 2 started step 26 at time = 4.359357646e-12 with dt = 1.676676018e-13
00:01:49 Rank 3 started step 27 at time = 4.527025247e-12 with dt = 1.676676018e-13
00:01:53 Rank 0 started step 28 at time = 4.694692849e-12 with dt = 1.676676018e-13
00:01:57 Rank 1 started step 29 at time = 4.862360451e-12 with dt = 1.676676018e-13
00:02:01 Rank 2 started step 30 at time = 5.030028053e-12 with dt = 1.676676018e-13
00:02:05 Rank 3 started step 31 at time = 5.197695654e-12 with dt = 1.676676018e-13
00:02:10 Rank 0 started step 32 at time = 5.365363256e-12 with dt = 1.676676018e-13
00:02:14 Rank 1 started step 33 at time = 5.533030858e-12 with dt = 1.676676018e-13
00:02:18 Rank 2 started step 34 at time = 5.70069846e-12 with dt = 1.676676018e-13
00:02:22 Rank 3 started step 35 at time = 5.868366061e-12 with dt = 1.676676018e-13
00:02:26 Rank 0 started step 36 at time = 6.036033663e-12 with dt = 1.676676018e-13
00:02:30 Rank 1 started step 37 at time = 6.203701265e-12 with dt = 1.676676018e-13
00:02:35 Rank 2 started step 38 at time = 6.371368867e-12 with dt = 1.676676018e-13
00:02:38 Rank 3 started step 39 at time = 6.539036468e-12 with dt = 1.676676018e-13
00:02:43 Rank 0 started step 40 at time = 6.70670407e-12 with dt = 1.676676018e-13
00:02:47 Rank 1 started step 41 at time = 6.874371672e-12 with dt = 1.676676018e-13
00:02:51 Rank 2 started step 42 at time = 7.042039274e-12 with dt = 1.676676018e-13
00:02:55 Rank 3 started step 43 at time = 7.209706875e-12 with dt = 1.676676018e-13
00:02:59 Rank 0 started step 44 at time = 7.377374477e-12 with dt = 1.676676018e-13
00:03:03 Rank 1 started step 45 at time = 7.545042079e-12 with dt = 1.676676018e-13
00:03:08 Rank 2 started step 46 at time = 7.712709681e-12 with dt = 1.676676018e-13
00:03:12 Rank 3 started step 47 at time = 7.880377283e-12 with dt = 1.676676018e-13
00:03:16 Rank 0 started step 48 at time = 8.048044884e-12 with dt = 1.676676018e-13
00:03:20 Rank 1 started step 49 at time = 8.215712486e-12 with dt = 1.676676018e-13
00:03:24 Rank 2 started step 50 at time = 8.383380088e-12 with dt = 1.676676018e-13
00:03:28 Rank 3 started step 51 at time = 8.55104769e-12 with dt = 1.676676018e-13
00:03:32 Rank 0 started step 52 at time = 8.718715291e-12 with dt = 1.676676018e-13
00:03:36 Rank 1 started step 53 at time = 8.886382893e-12 with dt = 1.676676018e-13
00:03:41 Rank 2 started step 54 at time = 9.054050495e-12 with dt = 1.676676018e-13
00:03:45 Rank 3 started step 55 at time = 9.221718097e-12 with dt = 1.676676018e-13
00:03:49 Rank 0 started step 56 at time = 9.389385698e-12 with dt = 1.676676018e-13
00:03:53 Rank 1 started step 57 at time = 9.5570533e-12 with dt = 1.676676018e-13
00:03:57 Rank 2 started step 58 at time = 9.724720902e-12 with dt = 1.676676018e-13
00:04:01 Rank 3 started step 59 at time = 9.892388504e-12 with dt = 1.676676018e-13
00:04:05 Rank 0 started step 60 at time = 1.006005611e-11 with dt = 1.676676018e-13
00:04:09 Rank 1 started step 61 at time = 1.022772371e-11 with dt = 1.676676018e-13
00:04:14 Rank 2 started step 62 at time = 1.039539131e-11 with dt = 1.676676018e-13
00:04:18 Rank 3 started step 63 at time = 1.056305891e-11 with dt = 1.676676018e-13


TinyProfiler total time across processes [min...avg...max]: 266.2 ... 271.3 ... 274.5

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve1()                            6400      63.16      63.37      63.65  23.19%
hpmg::MultiGrid::solve2()                            6400      59.78       59.9      59.95  21.84%
AnyDST::Execute()                                   38400      35.39      35.43      35.46  12.92%
ExplicitDeposition()                                 6400       23.8      23.86      23.93   8.72%
AdvancePlasmaParticles()                             6400      16.67      16.68      16.69   6.08%
DepositCurrent_PlasmaParticleContainer()             6416      14.32      14.43      14.54   5.30%
MultiBuffer::put_data()                              6400      2.967      7.337      12.81   4.66%
MultiLaser::ShiftLaserSlices()                       6400      11.64      11.67       11.7   4.26%
MultiLaser::AdvanceSliceMG()                         6400      7.943      7.961      7.968   2.90%
FFTPoissonSolverDirichlet::SolvePoissonEquation()   19200      5.134       5.15      5.165   1.88%
MultiBuffer::get_data()                              6400       2.56      4.242      4.915   1.79%
Fields::InitializeSlices()                           6400      4.631      4.669      4.708   1.71%
main()                                                  1   0.001093      2.701      3.898   1.42%
Fields::ShiftSlices()                                6400      3.595      3.605      3.612   1.32%
Hipace::InitializeSxSyWithBeam()                     6400      2.422      2.426       2.43   0.89%
Fields::LinCombination()                            12800      2.077      2.081      2.086   0.76%
Fields::AddRhoIons()                                 6400      1.983      1.986      1.989   0.72%
Fields::SolvePoissonPsiExmByEypBxEzBz()              6400      1.278      1.283      1.285   0.47%
Fields::Multiply()                                   6400     0.7056     0.7079     0.7097   0.26%
AnyDST::C2Rfft()                                    76800     0.3828     0.4002     0.4181   0.15%
MultiLaser::InitLaserSlice()                          100          0    0.07136     0.2854   0.10%
AnyDST::ToSine()                                    76800     0.2271     0.2401     0.2536   0.09%
AnyDST::ToComplex()                                 76800      0.223     0.2363     0.2485   0.09%
AnyDST::Transpose()                                 76800     0.2163     0.2297     0.2424   0.09%
Hipace::SolveOneSlice()                              6400      0.212     0.2209     0.2276   0.08%
PlasmaParticleContainer::InitParticles                 16    0.09059    0.09108    0.09134   0.03%
AnyDST::CreatePlan()                                    1    0.05309    0.05509    0.05613   0.02%
Hipace::ExplicitMGSolveBxBy()                        6400    0.05153    0.05274    0.05351   0.02%
FabArray::setVal()                                     36    0.03611    0.03619    0.03624   0.01%
DepositCurrentSlice_BeamParticleContainer()         12800    0.03037    0.03121    0.03188   0.01%
BeamParticleContainer::resize()                     19293    0.02634    0.02815    0.02952   0.01%
Fields::SetBoundaryCondition()                      19200    0.02626    0.02747    0.02843   0.01%
AdvanceBeamParticlesSlice()                          6400    0.02318    0.02354    0.02393   0.01%
Hipace::Evolve()                                        1    0.01114    0.01481    0.01876   0.01%
shiftSlippedParticles()                              6400    0.01541    0.01604    0.01652   0.01%
FabArray::FillBoundary()                            25600    0.01105    0.01145    0.01166   0.00%
PlasmaParticleContainer::IonizationModule()          6400   0.009517   0.009958     0.0102   0.00%
BeamParticleContainer::ReorderParticles()            6400   0.008829   0.009395   0.009893   0.00%
GridCurrent::DepositCurrentSlice()                   6400   0.009128   0.009475   0.009828   0.00%
PlasmaParticleContainer::ReorderParticles()          6400   0.008779   0.009215   0.009518   0.00%
FillBoundary_nowait()                               25600   0.007795   0.008113   0.008464   0.00%
FabArrayBase::getFB()                               25600   0.005365   0.005492   0.005626   0.00%
FillBoundary_finish()                               25600   0.003778    0.00395   0.004051   0.00%
MultiBuffer::get_time()                                15  8.689e-05  0.0005004   0.001485   0.00%
BeamParticleContainer::InitBeamFixedWeightSlice()     100          0  0.0003329   0.001332   0.00%
BeamParticleContainer::intializeSlice()               100          0  0.0002911   0.001164   0.00%
MultiLaser::InitSliceEnvelope()                       100          0  0.0002902   0.001161   0.00%
FFTPoissonSolverDirichlet::define()                     1  0.0003175  0.0003206  0.0003251   0.00%
MultiLaser::InitData()                                  1  0.0003019  0.0003039  0.0003082   0.00%
Hipace::InitData()                                      1  0.0002157   0.000225  0.0002341   0.00%
MultiBuffer::put_time()                                15   5.59e-05  8.319e-05  0.0001262   0.00%
MultiPlasma::InitData()                                16  9.698e-05   0.000112  0.0001224   0.00%
sortBeamParticlesByBox()                                0          0  2.906e-05  0.0001162   0.00%
Diagnostic::ResizeFDiagFAB()                           16  5.517e-05  6.674e-05  7.995e-05   0.00%
Hipace::ResetAllQuantities()                           16  4.948e-05  5.053e-05  5.171e-05   0.00%
Fields::AllocData()                                     1  4.245e-05  4.646e-05   4.79e-05   0.00%
ParticleContainer::clearParticles()                    16  4.508e-05  4.611e-05  4.789e-05   0.00%
Hipace::ResetLaser()                                   16  2.845e-05   3.03e-05  3.146e-05   0.00%
FabArrayBase::FB::FB()                                  1  1.275e-05  1.891e-05  2.511e-05   0.00%
BeamParticleContainer::InitBeamFixedWeight3D()          1   1.84e-06  7.007e-06  2.187e-05   0.00%
--------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Incl. Min  Incl. Avg  Incl. Max   Max %
--------------------------------------------------------------------------------------------------
main()                                                  1      266.2      271.3      274.5 100.00%
Hipace::Evolve()                                        1      262.5      268.6      274.5  99.98%
Hipace::SolveOneSlice()                              6400      262.3      268.4      274.3  99.92%
MultiLaser::AdvanceSliceMG()                         6400      67.73      67.86      67.92  24.74%
Hipace::ExplicitMGSolveBxBy()                        6400      63.22      63.43       63.7  23.20%
hpmg::MultiGrid::solve1()                            6400      63.16      63.37      63.65  23.19%
hpmg::MultiGrid::solve2()                            6400      59.78       59.9      59.95  21.84%
Fields::SolvePoissonPsiExmByEypBxEzBz()              6400      45.73       45.8      45.87  16.71%
FFTPoissonSolverDirichlet::SolvePoissonEquation()   19200      41.63      41.69      41.75  15.21%
AnyDST::Execute()                                   38400      36.49      36.54      36.58  13.33%
ExplicitDeposition()                                 6400       23.8      23.86      23.93   8.72%
AdvancePlasmaParticles()                             6400      16.67      16.68      16.69   6.08%
DepositCurrent_PlasmaParticleContainer()             6416      14.32      14.43      14.54   5.30%
MultiBuffer::put_data()                              6400      2.977      7.346      12.81   4.67%
MultiLaser::ShiftLaserSlices()                       6400      11.64      11.67       11.7   4.26%
MultiBuffer::get_data()                              6400      2.858      4.324      4.925   1.79%
Fields::InitializeSlices()                           6400      4.631      4.669      4.708   1.71%
Fields::ShiftSlices()                                6400      3.595      3.605      3.612   1.32%
Hipace::InitializeSxSyWithBeam()                     6400      2.435       2.44      2.443   0.89%
Fields::LinCombination()                            12800      2.077      2.081      2.086   0.76%
Fields::AddRhoIons()                                 6400      1.983      1.986      1.989   0.72%
Fields::Multiply()                                   6400     0.7056     0.7079     0.7097   0.26%
AnyDST::C2Rfft()                                    76800     0.3828     0.4002     0.4181   0.15%
MultiLaser::InitSliceEnvelope()                       100          0    0.07165     0.2866   0.10%
MultiLaser::InitLaserSlice()                          100          0    0.07136     0.2854   0.10%
AnyDST::ToSine()                                    76800     0.2271     0.2401     0.2536   0.09%
AnyDST::ToComplex()                                 76800      0.223     0.2363     0.2485   0.09%
AnyDST::Transpose()                                 76800     0.2163     0.2297     0.2424   0.09%
MultiPlasma::InitData()                                16    0.09073    0.09123     0.0915   0.03%
PlasmaParticleContainer::InitParticles                 16    0.09064    0.09112    0.09139   0.03%
Hipace::InitData()                                      1    0.05639    0.05829    0.05932   0.02%
Fields::AllocData()                                     1    0.05481    0.05681    0.05787   0.02%
FFTPoissonSolverDirichlet::define()                     1     0.0536    0.05559    0.05665   0.02%
AnyDST::CreatePlan()                                    1    0.05309    0.05509    0.05613   0.02%
FabArray::setVal()                                     36    0.03611    0.03619    0.03624   0.01%
Hipace::ResetAllQuantities()                           16    0.03392    0.03399    0.03405   0.01%
DepositCurrentSlice_BeamParticleContainer()         12800    0.03037    0.03121    0.03188   0.01%
FabArray::FillBoundary()                            25600    0.02854    0.02902    0.02955   0.01%
BeamParticleContainer::resize()                     19293    0.02634    0.02815    0.02952   0.01%
Fields::SetBoundaryCondition()                      19200    0.02626    0.02747    0.02843   0.01%
AdvanceBeamParticlesSlice()                          6400    0.02318    0.02354    0.02393   0.01%
shiftSlippedParticles()                              6400    0.01568    0.01632    0.01681   0.01%
Hipace::ResetLaser()                                   16    0.01584    0.01591      0.016   0.01%
FillBoundary_nowait()                               25600    0.01335    0.01362    0.01411   0.01%
PlasmaParticleContainer::IonizationModule()          6400   0.009517   0.009958     0.0102   0.00%
BeamParticleContainer::ReorderParticles()            6400   0.008829   0.009395   0.009893   0.00%
GridCurrent::DepositCurrentSlice()                   6400   0.009128   0.009475   0.009828   0.00%
PlasmaParticleContainer::ReorderParticles()          6400   0.008779   0.009215   0.009518   0.00%
FabArrayBase::getFB()                               25600   0.005377   0.005511   0.005645   0.00%
FillBoundary_finish()                               25600   0.003778    0.00395   0.004051   0.00%
BeamParticleContainer::intializeSlice()               100          0  0.0007698   0.003079   0.00%
BeamParticleContainer::InitBeamFixedWeightSlice()     100          0  0.0004788   0.001915   0.00%
MultiBuffer::get_time()                                15  8.689e-05  0.0005004   0.001485   0.00%
MultiLaser::InitData()                                  1   0.001217   0.001219   0.001222   0.00%
MultiBuffer::put_time()                                15   5.59e-05  8.319e-05  0.0001262   0.00%
sortBeamParticlesByBox()                                0          0  2.906e-05  0.0001162   0.00%
Diagnostic::ResizeFDiagFAB()                           16  5.517e-05  6.674e-05  7.995e-05   0.00%
ParticleContainer::clearParticles()                    16  4.508e-05  4.611e-05  4.789e-05   0.00%
FabArrayBase::FB::FB()                                  1  1.275e-05  1.891e-05  2.511e-05   0.00%
BeamParticleContainer::InitBeamFixedWeight3D()          1   1.84e-06  7.007e-06  2.187e-05   0.00%
--------------------------------------------------------------------------------------------------

Device Memory Usage:
--------------------------------------------------------------------------------------------------------------------------------------
Name                                            Nalloc   Nfree  AvgMem min  AvgMem avg  AvgMem max  MaxMem min  MaxMem avg  MaxMem max
--------------------------------------------------------------------------------------------------------------------------------------
The_Arena::Initialize()                              4       4    9696 KiB    9710 KiB    9724 KiB      29 GiB      29 GiB      29 GiB
MultiBuffer::put_data()                          50330   50330      21 GiB      23 GiB      25 GiB      26 GiB      27 GiB      28 GiB
MultiLaser::InitData()                              16      16    1471 MiB    1506 MiB    1539 MiB    1539 MiB    1539 MiB    1539 MiB
Fields::AllocData()                                  4       4    1369 MiB    1396 MiB    1412 MiB    1412 MiB    1412 MiB    1412 MiB
MultiLaser::AdvanceSliceMG()                     51348   51348     701 MiB     715 MiB     729 MiB     875 MiB     875 MiB     875 MiB
PlasmaParticleContainer::InitParticles            1088    1088     754 MiB     769 MiB     778 MiB     842 MiB     842 MiB     842 MiB
Hipace::ExplicitMGSolveBxBy()                      148     148     571 MiB     584 MiB     596 MiB     598 MiB     598 MiB     598 MiB
MultiBuffer::get_data()                             70      70       0   B     552 KiB    1177 KiB       0   B     192 MiB     256 MiB
FFTPoissonSolverDirichlet::define()                 12      12     185 MiB     189 MiB     191 MiB     191 MiB     191 MiB     191 MiB
AnyDST::CreatePlan()                                 8       8     124 MiB     126 MiB     128 MiB     128 MiB     128 MiB     128 MiB
ResizeRandomSeed                                     4       4      40 MiB      40 MiB      40 MiB      40 MiB      40 MiB      40 MiB
hpmg::MultiGrid::solve2()                       100822  100822      51 KiB      51 KiB      51 KiB     432 KiB     432 KiB     432 KiB
hpmg::MultiGrid::solve1()                       109974  109974      53 KiB      53 KiB      53 KiB     432 KiB     432 KiB     432 KiB
BeamParticleContainer::resize()                    252     252     315 KiB     319 KiB     322 KiB     353 KiB     353 KiB     353 KiB
shiftSlippedParticles()                           1554    1554       2   B       2   B       2   B     108 KiB     108 KiB     108 KiB
sortBeamParticlesByBox()                             4       4       0   B      18 KiB      75 KiB       0   B      21 KiB      85 KiB
BeamParticleContainer::InitBeamFixedWeight3D()       1       1       0   B      18 KiB      75 KiB       0   B      19 KiB      78 KiB
main()                                              36      36     635   B     647   B     655   B     656   B     656   B     656   B
Hipace::InitData()                                  12      12     138   B     140   B     143   B     144   B     144   B     144   B
DepositCurrent_PlasmaParticleContainer()         25664   25664       0   B       0   B       0   B      16   B      16   B      16   B
--------------------------------------------------------------------------------------------------------------------------------------

Managed Memory Usage:
----------------------------------------------------------------------------------------------------------------------
Name                             Nalloc  Nfree  AvgMem min  AvgMem avg  AvgMem max  MaxMem min  MaxMem avg  MaxMem max
----------------------------------------------------------------------------------------------------------------------
The_Managed_Arena::Initialize()       4      4       1   B       2   B       4   B    8192 KiB    8192 KiB    8192 KiB
----------------------------------------------------------------------------------------------------------------------

Pinned Memory Usage:
------------------------------------------------------------------------------------------------------------------------------
Name                                    Nalloc   Nfree  AvgMem min  AvgMem avg  AvgMem max  MaxMem min  MaxMem avg  MaxMem max
------------------------------------------------------------------------------------------------------------------------------
The_Pinned_Arena::Initialize()               4       4      94   B      96   B      98   B    8192 KiB    8192 KiB    8192 KiB
Hipace::InitData()                          80      80    6266   B    6387   B    6462   B    6496   B    6496   B    6496   B
main()                                     216     216     635   B     647   B     655   B     688   B     688   B     688   B
Hipace::ExplicitMGSolveBxBy()                4       4     489   B     499   B     510   B     512   B     512   B     512   B
MultiLaser::AdvanceSliceMG()                 4       4     489   B     499   B     510   B     512   B     512   B     512   B
PlasmaParticleContainer::InitParticles      64      64       0   B       0   B       0   B      16   B      16   B      16   B
hpmg::MultiGrid::solve1()               109974  109974       3   B       3   B       3   B      16   B      16   B      16   B
hpmg::MultiGrid::solve2()               100822  100822       3   B       3   B       3   B      16   B      16   B      16   B
shiftSlippedParticles()                   1536    1536       0   B       0   B       0   B      16   B      16   B      16   B
------------------------------------------------------------------------------------------------------------------------------

Total GPU global memory (MB) spread across MPI: [40370 ... 40370]
Free  GPU global memory (MB) spread across MPI: [2018 ... 5114]
[The         Arena] space (MB) allocated spread across MPI: [34645 ... 37727]
[The         Arena] space (MB) used      spread across MPI: [0 ... 0]
[The Managed Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The Managed Arena] space (MB) used      spread across MPI: [0 ... 0]
[The  Pinned Arena] space (MB) allocated spread across MPI: [8 ... 8]
[The  Pinned Arena] space (MB) used      spread across MPI: [0 ... 0]
AMReX (24.03) finalized
```









- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
