### PR TITLE
Add in-situ diagnostic for spin

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1065,7 +1065,8 @@ Thomas-Bargmann-Michel-Telegdi (TBMT) model, see
 [Z. Gong et al., Matter and Radiation at Extremes 8.6 (2023), https://doi.org/10.1063/5.0152382]
 for the details of the implementation.
 This will add three extra components to each beam particle to store the spin and output
-those as part of the beam diagnostic.
+those as part of the beam diagnostic as ``spin/x, spin/y, spin/z``
+or beam in-situ diagnostic as ``[sx], [sx^2], [sy], [sy^2], [sz], [sz^2]``.
 
 * ``<beam name> or beams.do_spin_tracking`` (`bool`) optional (default `0`)
     Enable spin tracking

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -336,6 +336,15 @@ private:
     /** Prefix/path for the output files */
     std::string m_insitu_file_prefix = "diags/insitu";
 
+    // spin insitu:
+
+    /** Number of real beam properties for spin in-situ per-slice reduced diagnostics. */
+    static constexpr int m_insitu_n_spin = 6;
+    /** Per-slice real beam spin properties */
+    amrex::Vector<amrex::Real> m_insitu_spin_data;
+    /** Sum of all per-slice real beam spin properties */
+    amrex::Vector<amrex::Real> m_insitu_sum_spin_data;
+
     // to estimate min uz
     friend AdaptiveTimeStep;
 };

--- a/src/utils/InsituUtil.H
+++ b/src/utils/InsituUtil.H
@@ -89,6 +89,28 @@ inline void write_data (const amrex::Vector<DataNode>& nodes, std::ofstream& ofs
     }
 }
 
+// merge two structured datatypes into onodes
+inline void merge_data (amrex::Vector<DataNode>& onodes, const amrex::Vector<DataNode>& inodes) {
+    for (auto& idn : inodes) {
+        if (idn.m_data_location) {
+            onodes.push_back(idn);
+        } else {
+            bool merged = false;
+            for (auto& odn : onodes) {
+                if (!odn.m_data_location && odn.m_name == idn.m_name) {
+                    // recursive call for nested structured datatypes
+                    merge_data(odn.m_structured_format, idn.m_structured_format);
+                    merged = true;
+                    break;
+                }
+            }
+            if (!merged) {
+                onodes.push_back(idn);
+            }
+        }
+    }
+}
+
 }
 
 #endif


### PR DESCRIPTION
This PR extends the beam in-situ diagnostic to include the first and second moment of spin in each direction if spin tracking is enabled. The following python script can read and plot the in-situ spin diagnostics: 
```python
import sys
sys.path.insert(1, "../hipace/tools/")
import read_insitu_diagnostics as diag
import matplotlib.pyplot as plt
import numpy as np

path = "/scratch/project/alex/debug/diags/new/spin_track_19/insitu/reduced_beam*"

all_data = diag.read_file(path)

time = all_data["time"]
sx_mean = all_data["average"]["[sx]"]
sy_mean = all_data["average"]["[sy]"]
sz_mean = all_data["average"]["[sz]"]
sx_std = np.sqrt(np.maximum(all_data["average"]["[sx^2]"] - all_data["average"]["[sx]"]**2, 0))
sy_std = np.sqrt(np.maximum(all_data["average"]["[sy^2]"] - all_data["average"]["[sy]"]**2, 0))
sz_std = np.sqrt(np.maximum(all_data["average"]["[sz^2]"] - all_data["average"]["[sz]"]**2, 0))
pol = np.sqrt(sx_mean**2 + sy_mean**2 + sz_mean**2)

fig, ax = plt.subplots(4, 1, dpi=150, figsize=(8, 11))
ax[0].plot(time, sx_std, label="HiPACE++ std sx")
ax[0].plot(time, sy_std, label="HiPACE++ std sy")
ax[0].plot(time, sz_std, label="HiPACE++ std sz")
ax[0].legend()
ax[0].axes.xaxis.set_ticklabels([])

ax[1].plot(time, 1-sx_mean, label="HiPACE++ 1-mean sx")
ax[1].legend()
ax[1].axes.xaxis.set_ticklabels([])

ax[2].plot(time, sy_mean, label="HiPACE++ mean sy")
ax[2].plot(time, sz_mean, label="HiPACE++ mean sz")
ax[2].legend()
ax[2].axes.xaxis.set_ticklabels([])

ax[3].plot(time, 1-pol, label="HiPACE++ 1-spin polarisation")
ax[3].legend()
ax[3].set_xlabel("time in s")

plt.tight_layout()
```

![image](https://github.com/Hi-PACE/hipace/assets/64009254/82ed6302-5377-4961-a435-3f455ffd3bb1)









- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
