### PR TITLE
Clean-up TinyProfiler output

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -74,9 +74,6 @@ General parameters
       * ``hipace.do_device_synchronize = 1``, synchronizes most functions (all that are profiled
         via ``HIPACE_PROFILE``)
 
-      * ``hipace.do_device_synchronize = 2`` additionally synchronizes low-level functions (all that
-        are profiled via ``HIPACE_DETAIL_PROFILE``)
-
 * ``amrex.the_arena_is_managed`` (`bool`) optional (default `0`)
     Whether managed memory is used. Note that large simulations sometimes only fit on a GPU if managed memory is used,
     but generally it is recommended to not use it.

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -123,9 +123,6 @@ public:
      */
     void ResetAllQuantities ();
 
-    /** \brief reset all laser slices to 0 */
-    void ResetLaser ();
-
     /**
      * \brief does Coulomb collisions between plasmas and beams
      */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -41,6 +41,7 @@ Hipace_early_init::Hipace_early_init (Hipace* instance)
     Parser::addConstantsToParser();
     Parser::replaceAmrexParamsWithParser();
 
+    queryWithParser(pph, "do_device_synchronize", DO_DEVICE_SYNCHRONIZE);
     queryWithParser(pph, "depos_order_xy", m_depos_order_xy);
     queryWithParser(pph, "depos_order_z", m_depos_order_z);
     queryWithParser(pph, "depos_derivative_type", m_depos_derivative_type);
@@ -105,7 +106,6 @@ Hipace::Hipace () :
     queryWithParser(pph, "deposit_rho_individual", m_deposit_rho_individual);
     queryWithParser(pph, "interpolate_neutralizing_background",
         m_interpolate_neutralizing_background);
-    queryWithParser(pph, "do_device_synchronize", DO_DEVICE_SYNCHRONIZE);
     bool do_mfi_sync = false;
     queryWithParser(pph, "do_MFIter_synchronize", do_mfi_sync);
     DfltMfi.SetDeviceSync(do_mfi_sync).UseDefaultStream();
@@ -615,23 +615,15 @@ Hipace::SolveOneSlice (int islice, int step)
 void
 Hipace::ResetAllQuantities ()
 {
-    HIPACE_PROFILE("Hipace::ResetAllQuantities()");
-
-    if (m_use_laser) ResetLaser();
+    if (m_use_laser) {
+        m_multi_laser.getSlices().setVal(0.);
+    }
 
     for (int lev=0; lev<m_N_level; ++lev) {
         if (m_fields.getSlices(lev).nComp() != 0) {
             m_fields.getSlices(lev).setVal(0., m_fields.m_slices_nguards);
         }
     }
-}
-
-void
-Hipace::ResetLaser ()
-{
-    HIPACE_PROFILE("Hipace::ResetLaser()");
-
-    m_multi_laser.getSlices().setVal(0.);
 }
 
 void

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -223,8 +223,6 @@ Diagnostic::ResizeFDiagFAB (const amrex::Box a_domain, const int lev,
                             amrex::Geometry const& geom, int output_step, int max_step,
                             amrex::Real output_time, amrex::Real max_time)
 {
-    HIPACE_PROFILE("Diagnostic::ResizeFDiagFAB()");
-
     AMREX_ALWAYS_ASSERT(m_initialized);
 
     for (auto& fd : m_field_data) {
@@ -280,6 +278,7 @@ Diagnostic::ResizeFDiagFAB (const amrex::Box a_domain, const int lev,
                          && hasFieldOutput(fd, output_step, max_step, output_time, max_time);
 
         if(fd.m_has_field) {
+            HIPACE_PROFILE("Diagnostic::ResizeFDiagFAB()");
             fd.m_F.resize(domain, fd.m_nfields, amrex::The_Pinned_Arena());
             fd.m_F.setVal<amrex::RunOn::Host>(0);
 

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -475,6 +475,10 @@ public:
         std::array<int, sizeof...(comps)> c_idx = {Comps[islice][comps]...};
         amrex::MultiFab& mfab = getSlices(lev);
 
+        if (!period.isAnyPeriodic() && mfab.size() <= 1) {
+            return; // no work to do
+        }
+
         // optimize adjacent fields to one FillBoundary call
         std::sort(c_idx.begin(), c_idx.end());
         int scomp = 0;

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -374,8 +374,6 @@ LinCombination (const amrex::IntVect box_grow, amrex::MultiFab dst,
                 const amrex::Real factor_a, const FVA& src_a,
                 const amrex::Real factor_b, const FVB& src_b)
 {
-    HIPACE_PROFILE("Fields::LinCombination()");
-
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -410,8 +408,6 @@ void
 Multiply (const amrex::IntVect box_grow, amrex::MultiFab dst,
           const amrex::Real factor, const FV& src)
 {
-    HIPACE_PROFILE("Fields::Multiply()");
-
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -698,11 +694,10 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
                               amrex::MultiFab&& staging_area, amrex::IntVect box_grow,
                               amrex::Real offset, amrex::Real factor)
 {
-    HIPACE_PROFILE("Fields::SetBoundaryCondition()");
-
     const amrex::Box staging_box = amrex::grow(geom[lev].Domain(), box_grow);
 
     if (lev == 0 && m_open_boundary) {
+        HIPACE_PROFILE("Fields::SetOpenBoundaryCondition()");
         // Coarsest level: use Taylor expansion of the Green's function
         // to get Dirichlet boundary conditions
 
@@ -760,6 +755,7 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
         );
 
     } else if (lev > 0) {
+        HIPACE_PROFILE("Fields::SetMRBoundaryCondition()");
         // Fine level: interpolate solution from coarser level to get Dirichlet boundary conditions
         constexpr int interp_order = 2;
 

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichlet.cpp
@@ -28,7 +28,6 @@ FFTPoissonSolverDirichlet::define (amrex::BoxArray const& a_realspace_ba,
 {
     using namespace amrex::literals;
 
-    HIPACE_PROFILE("FFTPoissonSolverDirichlet::define()");
     // If we are going to support parallel FFT, the constructor needs to take a communicator.
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(a_realspace_ba.size() == 1, "Parallel FFT not supported yet");
 
@@ -103,7 +102,7 @@ FFTPoissonSolverDirichlet::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
 
     for ( amrex::MFIter mfi(m_stagingArea, DfltMfi); mfi.isValid(); ++mfi ){
         // Perform Fourier transform from the staging area to `tmpSpectralField`
-        AnyDST::Execute<AnyDST::direction::forward>(m_plan[mfi]);
+        AnyDST::Execute(m_plan[mfi], AnyDST::direction::forward);
     }
 
 #ifdef AMREX_USE_OMP
@@ -123,7 +122,7 @@ FFTPoissonSolverDirichlet::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
 
     for ( amrex::MFIter mfi(m_stagingArea, DfltMfi); mfi.isValid(); ++mfi ){
         // Perform Fourier transform from `tmpSpectralField` to the staging area
-        AnyDST::Execute<AnyDST::direction::backward>(m_plan[mfi]);
+        AnyDST::Execute(m_plan[mfi], AnyDST::direction::backward);
     }
 
 #ifdef AMREX_USE_OMP

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
@@ -28,7 +28,6 @@ FFTPoissonSolverPeriodic::define ( amrex::BoxArray const& realspace_ba,
 {
     using namespace amrex::literals;
 
-    HIPACE_PROFILE("FFTPoissonSolverPeriodic::define()");
     // If we are going to support parallel FFT, the constructor needs to take a communicator.
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(realspace_ba.size() == 1, "Parallel FFT not supported yet");
 

--- a/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
+++ b/src/fields/fft_poisson_solver/MGPoissonSolverDirichlet.cpp
@@ -17,8 +17,6 @@ MGPoissonSolverDirichlet::MGPoissonSolverDirichlet (
     amrex::DistributionMapping const& dm,
     amrex::Geometry const& gm )
 {
-    HIPACE_PROFILE("MGPoissonSolverDirichlet::define()");
-
     // need extra ghost cell for 2^n-1 HPMG
     m_stagingArea = amrex::MultiFab(ba, dm, 1, Fields::m_poisson_nguards + amrex::IntVect{1, 1, 0});
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ba.size() == 1, "Parallel MG not supported");

--- a/src/fields/fft_poisson_solver/fft/AnyDST.H
+++ b/src/fields/fft_poisson_solver/fft/AnyDST.H
@@ -78,12 +78,9 @@ namespace AnyDST
 
     /** \brief Perform FFT with backend library.
      * \param[out] dst_plan plan for which the FFT is performed
+     * \param[in] d direction of the FFT
      */
-    template<AnyDST::direction d>
-    void Execute (DSTplan& dst_plan);
-
-    extern template void Execute<direction::forward>(DSTplan& dst_plan);
-    extern template void Execute<direction::backward>(DSTplan& dst_plan);
+    void Execute (DSTplan& dst_plan, AnyDST::direction d);
 }
 
 #endif // ANYDST_H_

--- a/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuDST.cpp
@@ -30,7 +30,6 @@ namespace AnyDST
      */
     void ExpandR2R (amrex::FArrayBox& dst, amrex::FArrayBox& src)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ExpandR2R()");
         constexpr int scomp = 0;
         constexpr int dcomp = 0;
 
@@ -64,7 +63,6 @@ namespace AnyDST
      */
     void ShrinkC2R (amrex::FArrayBox& dst, amrex::BaseFab<amrex::GpuComplex<amrex::Real>>& src)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ShrinkC2R()");
         constexpr int scomp = 0;
         constexpr int dcomp = 0;
 
@@ -94,7 +92,6 @@ namespace AnyDST
                     amrex::GpuComplex<amrex::Real>* const AMREX_RESTRICT out,
                     const int n_data, const int n_batch)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ToComplex()");
         const int n_half = (n_data+1)/2;
         if((n_data%2 == 1)) {
             amrex::ParallelFor({{0,0,0}, {n_half,n_batch-1,0}},
@@ -134,7 +131,6 @@ namespace AnyDST
     void C2Rfft (AnyFFT::VendorFFTPlan& plan, amrex::GpuComplex<amrex::Real>* AMREX_RESTRICT in,
                  amrex::Real* const AMREX_RESTRICT out)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::C2Rfft()");
         cudaStream_t stream = amrex::Gpu::Device::cudaStream();
         cufftSetStream(plan, stream);
         cufftResult result;
@@ -162,7 +158,6 @@ namespace AnyDST
     void ToSine (const amrex::Real* const AMREX_RESTRICT in, amrex::Real* const AMREX_RESTRICT out,
                  const int n_data, const int n_batch)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ToSine()");
         using namespace amrex::literals;
 
         const amrex::Real n_1_real = n_data+1._rt;
@@ -199,7 +194,6 @@ namespace AnyDST
                     amrex::Real* const AMREX_RESTRICT out,
                     const int n_data, const int n_batch)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::Transpose()");
         constexpr int tile_dim = 32; //must be power of 2
         constexpr int block_rows = 8;
         const int num_blocks_x = (n_data + tile_dim - 1)/tile_dim;
@@ -365,8 +359,7 @@ namespace AnyDST
         cufftDestroy( dst_plan.m_plan_b );
     }
 
-    template<direction d>
-    void Execute (DSTplan& dst_plan){
+    void Execute (DSTplan& dst_plan, direction d){
         HIPACE_PROFILE("AnyDST::Execute()");
 
         if(!dst_plan.use_small_dst) {
@@ -433,7 +426,4 @@ namespace AnyDST
             Transpose(pos_arr, fourier_arr, ny, nx);
         }
     }
-
-    template void Execute<direction::forward>(DSTplan& dst_plan);
-    template void Execute<direction::backward>(DSTplan& dst_plan);
 }

--- a/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
@@ -29,6 +29,7 @@ namespace AnyFFT
     FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
                         Complex * const complex_array, const direction dir)
     {
+        HIPACE_PROFILE("AnyFFT::CreatePlan()");
         FFTplan fft_plan;
 
         if (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 1) {

--- a/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapDSTW.cpp
@@ -71,8 +71,7 @@ namespace AnyDST
 #  endif
     }
 
-    template<direction d>
-    void Execute (DSTplan& dst_plan){
+    void Execute (DSTplan& dst_plan, direction d){
         HIPACE_PROFILE("AnyDST::Execute()");
         // Swap position and fourier space based on execute direction
         AnyFFT::VendorFFTPlan& plan = (d==direction::forward) ? dst_plan.m_plan : dst_plan.m_plan_b;
@@ -82,8 +81,4 @@ namespace AnyDST
         fftw_execute( plan );
 #  endif
     }
-
-    template void Execute<direction::forward>(DSTplan& dst_plan);
-    template void Execute<direction::backward>(DSTplan& dst_plan);
-
 }

--- a/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
@@ -31,6 +31,7 @@ namespace AnyFFT
     FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
                         Complex * const complex_array, const direction dir)
     {
+        HIPACE_PROFILE("AnyFFT::CreatePlan()");
         FFTplan fft_plan;
 
         // Initialize fft_plan.m_plan with the vendor fft plan.

--- a/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocDST.cpp
@@ -19,7 +19,6 @@ namespace AnyDST
     // see WrapCuDST for documentation
     void ExpandR2R (amrex::FArrayBox& dst, amrex::FArrayBox& src)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ExpandR2R()");
         constexpr int scomp = 0;
         constexpr int dcomp = 0;
 
@@ -49,7 +48,6 @@ namespace AnyDST
     // see WrapCuDST for documentation
     void ShrinkC2R (amrex::FArrayBox& dst, amrex::BaseFab<amrex::GpuComplex<amrex::Real>>& src)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ShrinkC2R()");
         constexpr int scomp = 0;
         constexpr int dcomp = 0;
 
@@ -71,7 +69,6 @@ namespace AnyDST
                     amrex::GpuComplex<amrex::Real>* const AMREX_RESTRICT out,
                     const int n_data, const int n_batch)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ToComplex()");
         const int n_half = (n_data+1)/2;
         if((n_data%2 == 1)) {
             amrex::ParallelFor({{0,0,0}, {n_half,n_batch-1,0}},
@@ -105,7 +102,6 @@ namespace AnyDST
     void C2Rfft (AnyFFT::VendorFFTPlan& plan, amrex::GpuComplex<amrex::Real>* AMREX_RESTRICT in,
                  amrex::Real* const AMREX_RESTRICT out, rocfft_execution_info execinfo)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::C2Rfft()");
         rocfft_status result;
 
         void* in_arr[2] = {in, nullptr};
@@ -119,7 +115,6 @@ namespace AnyDST
     void ToSine (const amrex::Real* const AMREX_RESTRICT in, amrex::Real* const AMREX_RESTRICT out,
                  const int n_data, const int n_batch)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::ToSine()");
         using namespace amrex::literals;
 
         const amrex::Real n_1_real = n_data+1._rt;
@@ -149,7 +144,6 @@ namespace AnyDST
                     amrex::Real* const AMREX_RESTRICT out,
                     const int n_data, const int n_batch)
     {
-        HIPACE_DETAIL_PROFILE("AnyDST::Transpose()");
         constexpr int tile_dim = 32; //must be power of 2
         constexpr int block_rows = 8;
         const int num_blocks_x = (n_data + tile_dim - 1)/tile_dim;
@@ -367,8 +361,7 @@ namespace AnyDST
         rocfft_execution_info_destroy(dst_plan.m_execinfo);
     }
 
-    template<direction d>
-    void Execute (DSTplan& dst_plan){
+    void Execute (DSTplan& dst_plan, direction d){
         HIPACE_PROFILE("AnyDST::Execute()");
 
         if(!dst_plan.use_small_dst) {
@@ -425,7 +418,4 @@ namespace AnyDST
             Transpose(pos_arr, fourier_arr, ny, nx);
         }
     }
-
-    template void Execute<direction::forward>(DSTplan& dst_plan);
-    template void Execute<direction::backward>(DSTplan& dst_plan);
 }

--- a/src/fields/fft_poisson_solver/fft/WrapRocFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocFFT.cpp
@@ -14,12 +14,14 @@
 
 #include "AnyFFT.H"
 #include "RocFFTUtils.H"
+#include "utils/HipaceProfilerWrapper.H"
 
 namespace AnyFFT
 {
     FFTplan CreatePlan (const amrex::IntVect& real_size, amrex::Real * const real_array,
                         Complex * const complex_array, const direction dir)
     {
+        HIPACE_PROFILE("AnyFFT::CreatePlan()");
         const int dim = 2;
         FFTplan fft_plan;
 
@@ -58,6 +60,7 @@ namespace AnyFFT
 
     void Execute (FFTplan& fft_plan)
     {
+        HIPACE_PROFILE("AnyFFT::Execute()");
         rocfft_execution_info execinfo = NULL;
         rocfft_status result = rocfft_execution_info_create(&execinfo);
         RocFFTUtils::assert_rocfft_status("rocfft_execution_info_create", result);

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -357,8 +357,6 @@ void BeamParticleContainer::TagByLevel (const int current_N_level,
 
 void
 BeamParticleContainer::intializeSlice (int slice, int which_slice) {
-    HIPACE_PROFILE("BeamParticleContainer::intializeSlice()");
-
     if (m_injection_type == "fixed_ppc") {
         InitBeamFixedPPCSlice(slice, which_slice);
     } else if (m_injection_type == "fixed_weight") {
@@ -366,6 +364,7 @@ BeamParticleContainer::intializeSlice (int slice, int which_slice) {
     } else if (m_injection_type == "fixed_weight_pdf") {
         InitBeamFixedWeightPDFSlice(slice, which_slice);
     } else {
+        HIPACE_PROFILE("BeamParticleContainer::intializeSlice()");
         const int num_particles = m_init_sorter.m_box_counts_cpu[slice];
 
         resize(which_slice, num_particles, 0);
@@ -394,6 +393,7 @@ BeamParticleContainer::intializeSlice (int slice, int which_slice) {
     }
 
     if (m_do_spin_tracking) {
+        HIPACE_PROFILE("BeamParticleContainer::intializeSpin()");
         auto ptd = getBeamSlice(which_slice).getParticleTileData();
 
         const amrex::RealVect initial_spin_norm = m_initial_spin / m_initial_spin.vectorLength();
@@ -421,8 +421,8 @@ BeamParticleContainer::resize (int which_slice, int num_particles, int num_slipp
 
 void
 BeamParticleContainer::ReorderParticles (int beam_slice, int step, amrex::Geometry& slice_geom) {
-    HIPACE_PROFILE("BeamParticleContainer::ReorderParticles()");
     if (m_reorder_period > 0 && step % m_reorder_period == 0) {
+        HIPACE_PROFILE("BeamParticleContainer::ReorderParticles()");
 
         const int np = getNumParticles(beam_slice);
         const int np_total = getNumParticlesIncludingSlipped(beam_slice);

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -41,7 +41,6 @@ MultiPlasma::InitData (amrex::Vector<amrex::BoxArray> slice_ba,
                        amrex::Vector<amrex::DistributionMapping> slice_dm,
                        amrex::Vector<amrex::Geometry> slice_gm, amrex::Vector<amrex::Geometry> gm)
 {
-    HIPACE_PROFILE("MultiPlasma::InitData()");
     for (auto& plasma : m_all_plasmas) {
         // make it think there is only level 0
         plasma.SetParGDB(slice_gm[0], slice_dm[0], slice_ba[0]);

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -195,8 +195,8 @@ PlasmaParticleContainer::InitData (const amrex::Geometry& geom)
 void
 PlasmaParticleContainer::ReorderParticles (const int islice)
 {
-    HIPACE_PROFILE("PlasmaParticleContainer::ReorderParticles()");
     if (m_reorder_period > 0 && islice % m_reorder_period == 0) {
+        HIPACE_PROFILE("PlasmaParticleContainer::ReorderParticles()");
         SortParticlesForDeposition(m_reorder_idx_type);
     }
 }
@@ -272,11 +272,11 @@ IonizationModule (const int lev,
                   const Fields& fields,
                   const amrex::Real background_density_SI)
 {
+    if (!m_can_ionize) return;
     HIPACE_PROFILE("PlasmaParticleContainer::IonizationModule()");
 
     using namespace amrex::literals;
 
-    if (!m_can_ionize) return;
     const PhysConst phys_const = get_phys_const();
 
     // Loop over particle boxes with both ion and electron Particle Containers at the same time

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -21,7 +21,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                const amrex::Real a_radius,
                const amrex::Real a_hollow_core_radius)
 {
-    HIPACE_PROFILE("PlasmaParticleContainer::InitParticles");
+    HIPACE_PROFILE("PlasmaParticleContainer::InitParticles()");
     using namespace amrex::literals;
     clearParticles();
     const int lev = 0;

--- a/src/particles/sorting/SliceSort.cpp
+++ b/src/particles/sorting/SliceSort.cpp
@@ -12,12 +12,12 @@
 void
 shiftSlippedParticles (BeamParticleContainer& beam, const int slice, amrex::Geometry const& geom)
 {
-    HIPACE_PROFILE("shiftSlippedParticles()");
-
     if (beam.getNumParticlesIncludingSlipped(WhichBeamSlice::This) == 0) {
         // nothing to do
         return;
     }
+
+    HIPACE_PROFILE("shiftSlippedParticles()");
 
     // remove all invalid particles from WhichBeamSlice::This (including slipped)
     amrex::removeInvalidParticles(beam.getBeamSlice(WhichBeamSlice::This));

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -26,10 +26,10 @@ void
 GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, int const lev,
                                   const int islice)
 {
+    if (m_use_grid_current == 0) return;
+
     HIPACE_PROFILE("GridCurrent::DepositCurrentSlice()");
     using namespace amrex::literals;
-
-    if (m_use_grid_current == 0) return;
 
     const auto plo = geom.ProbLoArray();
     amrex::Real const * AMREX_RESTRICT dx = geom.CellSize();

--- a/src/utils/HipaceProfilerWrapper.H
+++ b/src/utils/HipaceProfilerWrapper.H
@@ -45,11 +45,4 @@ struct synchronizeOnDestruct {
 #define HIPACE_PROFILE_VAR_STOP(vname) doStreamSynchronize<1>(); BL_PROFILE_VAR_STOP(vname)
 #define HIPACE_PROFILE_REGION(rname) doStreamSynchronize<1>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<1> BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){}
 
-#define HIPACE_DETAIL_PROFILE(fname) doStreamSynchronize<2>(); BL_PROFILE(fname); synchronizeOnDestruct<2> BL_PROFILE_PASTE(SYNC_SCOPE_, __COUNTER__){}
-#define HIPACE_DETAIL_PROFILE_VAR(fname, vname) doStreamSynchronize<2>(); BL_PROFILE_VAR(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
-#define HIPACE_DETAIL_PROFILE_VAR_NS(fname, vname) BL_PROFILE_VAR_NS(fname, vname); synchronizeOnDestruct<2> SYNC_V_##vname{}
-#define HIPACE_DETAIL_PROFILE_VAR_START(vname) doStreamSynchronize<2>(); BL_PROFILE_VAR_START(vname)
-#define HIPACE_DETAIL_PROFILE_VAR_STOP(vname) doStreamSynchronize<2>(); BL_PROFILE_VAR_STOP(vname)
-#define HIPACE_DETAIL_PROFILE_REGION(rname) doStreamSynchronize<2>(); BL_PROFILE_REGION(rname); synchronizeOnDestruct<2> BL_PROFILE_PASTE(SYNC_R_, __COUNTER__){}
-
 #endif // HIPACE_PROFILERWRAPPER_H_

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -502,8 +502,6 @@ void MultiBuffer::put_data (int slice, MultiBeam& beams, MultiLaser& laser, int 
 }
 
 amrex::Real MultiBuffer::get_time () {
-    HIPACE_PROFILE("MultiBuffer::get_time()");
-
     if (m_is_serial) {
         return m_time_send_buffer;
     }
@@ -525,8 +523,6 @@ amrex::Real MultiBuffer::get_time () {
 }
 
 void MultiBuffer::put_time (amrex::Real time) {
-    HIPACE_PROFILE("MultiBuffer::put_time()");
-
     if (m_is_serial) {
         m_time_send_buffer = time;
         return;


### PR DESCRIPTION
This PR cleans-up the TinyProfiler by:
* Making sure profiling regions are not activated in functions that return immediately.
* Removing some profiling regions that don’t have GPU kernels in them.
* Removing some profiling regions that are not necessary otherwise, e.g. already profiled through other regions or never give performance insights in practice.
* Removing `HIPACE_DETAIL_PROFILE` as it is usually not used. The functions it is profiling have very predictable performance. Additionally a critical flaw was that the detailed profile regions would still show up in the output with incorrect timing if it was not used.


New:
```
TinyProfiler total time across processes [min...avg...max]: 109.8 ... 115.3 ... 116.4

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve2()                            2000      21.04      22.08      23.58  20.25%
hpmg::MultiGrid::solve1()                            2000      20.74      21.34      22.03  18.92%
AnyDST::Execute()                                   12000      18.69       19.2      20.32  17.45%
MultiBuffer::get_data()                              2000    0.00241       8.22      17.23  14.80%
ExplicitDeposition()                                 2000       10.1      10.25      10.49   9.01%
Fields::ShiftSlices()                                2000      1.126      3.857      9.757   8.38%
MultiLaser::ShiftLaserSlices()                       2000      4.615      6.165      8.981   7.71%
AdvancePlasmaParticles()                             2000      7.112      7.288      7.883   6.77%
main()                                                  1   0.001265     0.7609      5.988   5.14%
DepositCurrent_PlasmaParticleContainer()             2001      4.677      4.858      5.418   4.65%
MultiLaser::AdvanceSliceMG()                         2000      2.212      2.571      2.749   2.36%
Fields::InitializeSlices()                           2000      1.788      1.894      2.057   1.77%
MultiBuffer::put_data()                              2000   0.003416      1.098      2.012   1.73%
FFTPoissonSolverDirichlet::SolvePoissonEquation()    6000      1.743      1.801      1.943   1.67%
MultiLaser::InitLaserSlice()                          250          0     0.1995      1.596   1.37%
Fields::SolvePoissonPsiExmByEypBxEzBz()              2000      1.306      1.354      1.463   1.26%
Hipace::InitializeSxSyWithBeam()                     2000      0.851     0.9134      1.228   1.05%
Fields::AddRhoIons()                                 2000     0.6711     0.7171     0.8688   0.75%
AnyDST::CreatePlan()                                    1      0.648      0.651     0.6528   0.56%
PlasmaParticleContainer::InitParticles()                1    0.02109    0.02206    0.02289   0.02%
Hipace::SolveOneSlice()                              2000    0.01718     0.0178    0.01929   0.02%
AdvanceBeamParticlesSlice()                          2000    0.01409    0.01476    0.01655   0.01%
Hipace::InitData()                                      1   0.004214    0.01148    0.01476   0.01%
FabArray::setVal()                                      6    0.01167    0.01229    0.01334   0.01%
DepositCurrentSlice_BeamParticleContainer()          4000   0.009248   0.009908    0.01234   0.01%
Hipace::ExplicitMGSolveBxBy()                        2000   0.007921   0.008593   0.009203   0.01%
shiftSlippedParticles()                                51   0.005341   0.005903   0.006865   0.01%
Hipace::Evolve()                                        1    0.00183   0.003323   0.006159   0.01%
Fields::AllocData()                                     1   0.005244   0.005652   0.006048   0.01%
BeamParticleContainer::InitBeamFixedWeight3D()          1   9.91e-07  0.0005189   0.004142   0.00%
sortBeamParticlesByBox()                                0          0  0.0005072   0.004058   0.00%
BeamParticleContainer::InitBeamFixedWeightSlice()     250          0  0.0005063   0.004051   0.00%
BeamParticleContainer::resize()                      5801   0.001978    0.00263   0.003073   0.00%
MultiLaser::InitSliceEnvelope()                       250          0   0.000199   0.001592   0.00%
MultiLaser::InitData()                                  1  0.0003237  0.0003341  0.0003557   0.00%
ParticleContainer::clearParticles()                     1   3.11e-07   4.32e-07   5.51e-07   0.00%
--------------------------------------------------------------------------------------------------
```
Old:
```
TinyProfiler total time across processes [min...avg...max]: 109.9 ... 115.4 ... 116.5

--------------------------------------------------------------------------------------------------
Name                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
--------------------------------------------------------------------------------------------------
hpmg::MultiGrid::solve2()                            2000      21.03      22.02      23.93  20.54%
hpmg::MultiGrid::solve1()                            2000      20.95       21.6      22.09  18.96%
AnyDST::Execute()                                   12000       17.3      17.81      18.91  16.23%
MultiBuffer::get_data()                              2000   0.002554      8.126      17.25  14.81%
ExplicitDeposition()                                 2000       10.1      10.28      10.75   9.23%
MultiLaser::ShiftLaserSlices()                       2000      4.693      6.152      9.013   7.74%
Fields::ShiftSlices()                                2000      1.126      3.846      8.456   7.26%
AdvancePlasmaParticles()                             2000       7.11      7.266      7.696   6.60%
main()                                                  1   0.001299     0.7584      5.992   5.14%
DepositCurrent_PlasmaParticleContainer()             2001      4.679      4.904      5.505   4.73%
MultiLaser::AdvanceSliceMG()                         2000      2.212      2.544      2.643   2.27%
Fields::InitializeSlices()                           2000      1.825      1.902      2.038   1.75%
FFTPoissonSolverDirichlet::SolvePoissonEquation()    6000      1.739      1.805      1.954   1.68%
MultiLaser::InitLaserSlice()                          250          0        0.2        1.6   1.37%
MultiBuffer::put_data()                              2000   0.003203     0.9842      1.582   1.36%
Hipace::InitializeSxSyWithBeam()                     2000     0.8515     0.9102      1.211   1.04%
Fields::AddRhoIons()                                 2000     0.6713     0.7242     0.9411   0.81%
Fields::LinCombination()                             4000     0.6844     0.7093     0.7759   0.67%
AnyDST::CreatePlan()                                    1     0.6487     0.6506     0.6522   0.56%
AnyDST::C2Rfft()                                    24000     0.4175      0.476      0.504   0.43%
AnyDST::Transpose()                                 24000     0.4655     0.4724     0.4875   0.42%
Fields::SolvePoissonPsiExmByEypBxEzBz()              2000     0.3932     0.4002     0.4155   0.36%
AnyDST::ToSine()                                    24000     0.3809     0.4008      0.413   0.35%
Fields::Multiply()                                   2000     0.2422     0.2579     0.3215   0.28%
AnyDST::ToComplex()                                 24000    0.05091    0.06682    0.09276   0.08%
PlasmaParticleContainer::InitParticles                  1    0.02198    0.02295    0.02385   0.02%
Hipace::SolveOneSlice()                              2000    0.01953    0.02035    0.02119   0.02%
FabArray::setVal()                                      6    0.01205    0.01301    0.01553   0.01%
AdvanceBeamParticlesSlice()                          2000      0.014    0.01462    0.01537   0.01%
Hipace::InitData()                                      1   0.005058    0.01138    0.01527   0.01%
DepositCurrentSlice_BeamParticleContainer()          4000   0.009407       0.01    0.01233   0.01%
Hipace::ExplicitMGSolveBxBy()                        2000   0.008403   0.008898   0.009568   0.01%
shiftSlippedParticles()                              2000   0.006138   0.006637   0.006949   0.01%
FFTPoissonSolverDirichlet::define()                     1   0.005005   0.005372    0.00589   0.01%
Hipace::Evolve()                                        1   0.001697   0.003172   0.005573   0.00%
BeamParticleContainer::InitBeamFixedWeight3D()          1  1.042e-06  0.0005359   0.004278   0.00%
sortBeamParticlesByBox()                                0          0  0.0005204   0.004163   0.00%
BeamParticleContainer::InitBeamFixedWeightSlice()     250          0   0.000514   0.004112   0.00%
FabArray::FillBoundary()                             8000   0.002637   0.002907   0.003079   0.00%
BeamParticleContainer::resize()                      5801   0.002049   0.002752    0.00295   0.00%
Fields::SetBoundaryCondition()                       6000   0.002234   0.002387   0.002592   0.00%
FillBoundary_nowait()                                8000   0.002006   0.002186   0.002437   0.00%
MultiLaser::InitSliceEnvelope()                       250          0   0.000243   0.001944   0.00%
BeamParticleContainer::intializeSlice()               250          0  0.0002217   0.001774   0.00%
FabArrayBase::getFB()                                8000    0.00136   0.001486   0.001577   0.00%
PlasmaParticleContainer::IonizationModule()          2000   0.001057   0.001114    0.00122   0.00%
FillBoundary_finish()                                8000   0.001039   0.001099   0.001203   0.00%
BeamParticleContainer::ReorderParticles()            2000  0.0008475  0.0008951  0.0009854   0.00%
GridCurrent::DepositCurrentSlice()                   2000  0.0008023  0.0008713  0.0009802   0.00%
PlasmaParticleContainer::ReorderParticles()          2000  0.0007612  0.0008351  0.0008909   0.00%
MultiBuffer::get_time()                                 0          0  0.0001982  0.0004981   0.00%
MultiLaser::InitData()                                  1  0.0003231  0.0003306  0.0003394   0.00%
Fields::AllocData()                                     1  8.261e-05  0.0001152  0.0001396   0.00%
MultiPlasma::InitData()                                 1  1.641e-05  1.927e-05  3.256e-05   0.00%
FabArrayBase::FB::FB()                                  1  2.546e-05  2.997e-05  3.217e-05   0.00%
MultiBuffer::put_time()                                 0          0  1.434e-05  2.809e-05   0.00%
Diagnostic::ResizeFDiagFAB()                            1   5.04e-06  5.324e-06  5.691e-06   0.00%
Hipace::ResetAllQuantities()                            1  1.393e-06  1.576e-06  1.964e-06   0.00%
Hipace::ResetLaser()                                    1    6.6e-07  9.558e-07  1.323e-06   0.00%
ParticleContainer::clearParticles()                     1   3.21e-07  3.955e-07   6.32e-07   0.00%
--------------------------------------------------------------------------------------------------
```



- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
