### PR TITLE
NVCC 11.5 fixes

### DIFF
--- a/.github/workflows/setup/nvcc11.sh
+++ b/.github/workflows/setup/nvcc11.sh
@@ -41,14 +41,14 @@ echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x8
 
 sudo apt-get update
 sudo apt-get install -y          \
-    cuda-command-line-tools-11-5 \
-    cuda-compiler-11-5           \
-    cuda-cupti-dev-11-5          \
-    cuda-minimal-build-11-5      \
-    cuda-nvml-dev-11-5           \
-    cuda-nvtx-11-5               \
-    libcufft-dev-11-5            \
-    libcurand-dev-11-5
+    cuda-command-line-tools-11-8 \
+    cuda-compiler-11-8           \
+    cuda-cupti-dev-11-8          \
+    cuda-minimal-build-11-8      \
+    cuda-nvml-dev-11-8           \
+    cuda-nvtx-11-8               \
+    libcufft-dev-11-8            \
+    libcurand-dev-11-8
 sudo ln -s cuda-11.8 /usr/local/cuda
 
 # cmake-easyinstall

--- a/.github/workflows/setup/nvcc11.sh
+++ b/.github/workflows/setup/nvcc11.sh
@@ -41,14 +41,14 @@ echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x8
 
 sudo apt-get update
 sudo apt-get install -y          \
-    cuda-command-line-tools-11-8 \
-    cuda-compiler-11-8           \
-    cuda-cupti-dev-11-8          \
-    cuda-minimal-build-11-8      \
-    cuda-nvml-dev-11-8           \
-    cuda-nvtx-11-8               \
-    libcufft-dev-11-8            \
-    libcurand-dev-11-8
+    cuda-command-line-tools-11-5 \
+    cuda-compiler-11-5           \
+    cuda-cupti-dev-11-5          \
+    cuda-minimal-build-11-5      \
+    cuda-nvml-dev-11-5           \
+    cuda-nvtx-11-5               \
+    libcufft-dev-11-5            \
+    libcurand-dev-11-5
 sudo ln -s cuda-11.8 /usr/local/cuda
 
 # cmake-easyinstall

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -1321,8 +1321,8 @@ Fields::InSituComputeDiags (int step, amrex::Real time, int islice, const amrex:
 
     amrex::constexpr_for<0, m_insitu_nrp>(
         [&] (auto idx) {
-            m_insitu_rdata[islice + idx.value * nslices] = amrex::get<idx.value>(a)*dxdydz;
-            m_insitu_sum_rdata[idx.value] += amrex::get<idx.value>(a)*dxdydz;
+            m_insitu_rdata[islice + idx * nslices] = amrex::get<idx>(a)*dxdydz;
+            m_insitu_sum_rdata[idx] += amrex::get<idx>(a)*dxdydz;
         }
     );
 }

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1130,21 +1130,19 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice, const am
 
     amrex::constexpr_for<0, m_insitu_nrp>(
         [&] (auto idx) {
-            if (idx.value == 0) {
-                m_insitu_rdata[islice + idx.value * nslices] = amrex::get<idx.value>(a);
-                m_insitu_sum_rdata[idx.value] =
-                    std::max(m_insitu_sum_rdata[idx.value], amrex::get<idx.value>(a));
+            if (idx == 0) {
+                m_insitu_rdata[islice + idx * nslices] = amrex::get<idx>(a);
+                m_insitu_sum_rdata[idx] = std::max(m_insitu_sum_rdata[idx], amrex::get<idx>(a));
             } else {
-                m_insitu_rdata[islice + idx.value * nslices] = amrex::get<idx.value>(a)*dxdydz;
-                m_insitu_sum_rdata[idx.value] += amrex::get<idx.value>(a)*dxdydz;
+                m_insitu_rdata[islice + idx * nslices] = amrex::get<idx>(a)*dxdydz;
+                m_insitu_sum_rdata[idx] += amrex::get<idx>(a)*dxdydz;
             }
         }
     );
 
     amrex::constexpr_for<0, m_insitu_ncp>(
         [&] (auto idx) {
-            m_insitu_cdata[islice + idx.value * nslices] =
-                amrex::get<m_insitu_nrp+idx.value>(a) * mid_factor;
+            m_insitu_cdata[islice + idx * nslices] = amrex::get<m_insitu_nrp+idx>(a) * mid_factor;
         }
     );
 }

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -531,17 +531,17 @@ BeamParticleContainer::InSituComputeDiags (int islice)
 
     amrex::constexpr_for<0, m_insitu_nrp>(
         [&] (auto idx) {
-            m_insitu_rdata[islice + idx.value * m_nslices] = amrex::get<idx.value>(a) *
+            m_insitu_rdata[islice + idx * m_nslices] = amrex::get<idx>(a) *
                 // sum(w) is not multiplied by sum_w_inv
-                ( idx.value == 0 ? 1 : sum_w_inv );
-            m_insitu_sum_rdata[idx.value] += amrex::get<idx.value>(a);
+                ( idx == 0 ? 1 : sum_w_inv );
+            m_insitu_sum_rdata[idx] += amrex::get<idx>(a);
         }
     );
 
     amrex::constexpr_for<0, m_insitu_nip>(
         [&] (auto idx) {
-            m_insitu_idata[islice + idx.value * m_nslices] = amrex::get<m_insitu_nrp+idx.value>(a);
-            m_insitu_sum_idata[idx.value] += amrex::get<m_insitu_nrp+idx.value>(a);
+            m_insitu_idata[islice + idx * m_nslices] = amrex::get<m_insitu_nrp+idx>(a);
+            m_insitu_sum_idata[idx] += amrex::get<m_insitu_nrp+idx>(a);
         }
     );
 }

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -519,17 +519,17 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
 
         amrex::constexpr_for<0, m_insitu_nrp>(
             [&] (auto idx) {
-                m_insitu_rdata[islice + idx.value * m_nslices] = amrex::get<idx.value>(a) *
+                m_insitu_rdata[islice + idx * m_nslices] = amrex::get<idx>(a) *
                     // sum(w) and [(ga-1)*(1-vz)] are not multiplied by sum_w_inv
-                    ( idx.value == 0 || idx.value == (m_insitu_nrp-1) ? 1 : sum_w_inv );
-                m_insitu_sum_rdata[idx.value] += amrex::get<idx.value>(a);
+                    ( idx == 0 || idx == (m_insitu_nrp-1) ? 1 : sum_w_inv );
+                m_insitu_sum_rdata[idx] += amrex::get<idx>(a);
             }
         );
 
         amrex::constexpr_for<0, m_insitu_nip>(
             [&] (auto idx) {
-                m_insitu_idata[islice + idx.value * m_nslices] = amrex::get<m_insitu_nrp+idx.value>(a);
-                m_insitu_sum_idata[idx.value] += amrex::get<m_insitu_nrp+idx.value>(a);
+                m_insitu_idata[islice + idx * m_nslices] = amrex::get<m_insitu_nrp+idx>(a);
+                m_insitu_sum_idata[idx] += amrex::get<m_insitu_nrp+idx>(a);
             }
         );
     }


### PR DESCRIPTION
Issue and fix for CUDA discovered in https://github.com/ECP-WarpX/impactx/pull/561/

Note that this works around a compiler bug in NVCC 11.5, and is fixed in 11.6+.
It is recommended to use at least NVCC/CUDA 11.8 for HiPACE++.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
