### PR TITLE
correct the direction of the spatial rotation

### DIFF
--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1041,8 +1041,8 @@ MultiLaser::InitLaserSlice (const amrex::Geometry& geom, const int islice, const
                     const amrex::Real x = (i+0.5_rt)*dx_arr[0]+plo[0]-x0;
                     const amrex::Real y = (j+0.5_rt)*dx_arr[1]+plo[1]-y0;
                     // Coordinate rotation in yz plane for a laser propagating at an angle.
-                    const amrex::Real yp=std::cos(propagation_angle_yz)*y+std::sin(propagation_angle_yz)*z;
-                    const amrex::Real zp=-std::sin(propagation_angle_yz)*y+std::cos(propagation_angle_yz)*z;
+                    const amrex::Real yp=std::cos(propagation_angle_yz)*y-std::sin(propagation_angle_yz)*z;
+                    const amrex::Real zp=std::sin(propagation_angle_yz)*y+std::cos(propagation_angle_yz)*z;
                     // For first laser, setval to 0.
                     if (ilaser == 0) {
                         arr(i, j, k, comp ) = 0._rt;


### PR DESCRIPTION
This PR is to correct a mistake I made on PR #1057 . The rotation of the spatial distribution of the pulse and the propagating direction weren't in consistency. And this is now fixed.
<img width="798" alt="Screenshot 2024-04-03 at 17 34 30" src="https://github.com/Hi-PACE/hipace/assets/151739545/13975615-4b40-41e1-ac83-e1258e4a458a">

