### PR TITLE
Don't use Laser FFT array in Laser MG solver

### DIFF
--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -102,11 +102,11 @@ MultiLaser::InitData (const amrex::BoxArray& slice_ba,
 
     m_laser_geom_3D = geom_3D;
     m_slice_box = slice_ba[0];
-    m_sol.resize(m_slice_box, 1, amrex::The_Arena());
-    m_rhs.resize(m_slice_box, 1, amrex::The_Arena());
-    m_rhs_fourier.resize(m_slice_box, 1, amrex::The_Arena());
 
     if (m_solver_type == "fft") {
+        m_sol.resize(m_slice_box, 1, amrex::The_Arena());
+        m_rhs.resize(m_slice_box, 1, amrex::The_Arena());
+        m_rhs_fourier.resize(m_slice_box, 1, amrex::The_Arena());
 
         // Create FFT plans
         amrex::IntVect fft_size = m_slice_box.length();
@@ -615,7 +615,6 @@ MultiLaser::AdvanceSliceMG (const Fields& fields, amrex::Real dt, int step)
         Array3<amrex::Real> arr = m_slices.array(mfi);
         Array3<amrex::Real> rhs_mg_arr = rhs_mg.array();
         Array3<amrex::Real> acoeff_real_arr = acoeff_real.array();
-        Array3<Complex> rhs_arr = m_rhs.array();
 
         constexpr int lev = 0;
         const amrex::FArrayBox& isl_fab = fields.getSlices(lev)[mfi];
@@ -750,7 +749,6 @@ MultiLaser::AdvanceSliceMG (const Fields& fields, amrex::Real dt, int step)
                         rhs += isl_arr(i,j,chi) * an00j00 * 2._rt;
                     }
                 }
-                rhs_arr(i,j,0) = rhs;
                 rhs_mg_arr(i,j,0) = rhs.real();
                 rhs_mg_arr(i,j,1) = rhs.imag();
             });


### PR DESCRIPTION
Some arrays only used by the Laser FFT solver where allocated and written to in the Laser MG solve.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
