### PR TITLE
Fix Plasma tiling in SALAME

### DIFF
--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -55,6 +55,11 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
         }
 
         for (int lev=0; lev<current_N_level; ++lev) {
+            if (hipace->m_do_tiling) {
+                hipace->m_multi_plasma.TileSort(
+                    hipace->m_slice_geom[lev].Domain(), hipace->m_slice_geom[lev]);
+            }
+
             // deposit plasma jx and jy on the next temp slice, to the SALAME slice
             hipace->m_multi_plasma.DepositCurrent(hipace->m_fields,
                     WhichSlice::Salame, true, false, false, false, false, hipace->m_3D_geom, lev);
@@ -108,6 +113,11 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
             }
 
             for (int lev=0; lev<current_N_level; ++lev) {
+                if (hipace->m_do_tiling) {
+                    hipace->m_multi_plasma.TileSort(
+                        hipace->m_slice_geom[lev].Domain(), hipace->m_slice_geom[lev]);
+                }
+
                 hipace->m_multi_plasma.DepositCurrent(hipace->m_fields,
                     WhichSlice::Salame, true, false, false, false, false, hipace->m_3D_geom, lev);
             }


### PR DESCRIPTION
Two calls to TileSort were missing in the SALAME module. This fixes a segfault that was reported by a user.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
