### PR TITLE
Fix SALAME overloaded beam removal

### DIFF
--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -423,11 +423,11 @@ SalameMultiplyBeamWeight (const amrex::Real W, Hipace* hipace)
             [=] AMREX_GPU_DEVICE (long ip) {
                 // Skip invalid particles and ghost particles not in the last slice
                 auto id = amrex::ParticleIDWrapper(idcpup[ip]);
-                if (id < 0) return;
+                if (!id.is_valid()) return;
 
                 // invalidate particles with a weight of zero
                 if (W == 0) {
-                    id = -id;
+                    id.make_invalid();
                     return;
                 }
 


### PR DESCRIPTION
Since #1090 changed the beam id format in hipace, the first 2^24 beam particles have id=0 according to the amrex IDWrapper. This breaks the `id = -id` to make the particle invalid. This PR fixes this by using `is_valid` and `make_valid` functions that only look at the first bit of the id and are compatible with both formats.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
