### PR TITLE
Remove outer_depos_loop

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -131,9 +131,6 @@ General parameters
 * ``hipace.depos_derivative_type`` (`int`) optional (default `2`)
     Type of derivative used in explicit deposition. `0`: analytic, `1`: nodal, `2`: centered
 
-* ``hipace.outer_depos_loop`` (`bool`) optional (default `0`)
-    If the loop over depos_order is included in the loop over particles.
-
 * ``hipace.do_beam_jx_jy_deposition`` (`bool`) optional (default `1`)
     Using the default, the beam deposits all currents ``Jx``, ``Jy``, ``Jz``. Using
     ``hipace.do_beam_jx_jy_deposition = 0`` disables the transverse current deposition of the beams.

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -57,9 +57,6 @@ struct Hipace_early_init
     /** Type of derivative used in explicit deposition. 0: analytic, 1: nodal, 2: centered
      */
     inline static int m_depos_derivative_type = 2;
-    /* if the loop over depos_order is included in the loop over particles
-     */
-    inline static bool m_outer_depos_loop = false;
 
     /* Number of mesh refinement levels */
     int m_N_level = 1;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -47,7 +47,6 @@ Hipace_early_init::Hipace_early_init (Hipace* instance)
     queryWithParser(pph, "depos_derivative_type", m_depos_derivative_type);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_depos_order_xy != 0 || m_depos_derivative_type != 0,
                             "Analytic derivative with depos_order=0 would vanish");
-    queryWithParser(pph, "outer_depos_loop", m_outer_depos_loop);
 
     amrex::ParmParse pp_amr("amr");
     int max_level = 0;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -197,7 +197,12 @@ PlasmaParticleContainer::ReorderParticles (const int islice)
 {
     if (m_reorder_period > 0 && islice % m_reorder_period == 0) {
         HIPACE_PROFILE("PlasmaParticleContainer::ReorderParticles()");
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
+        // SortParticlesForDeposition only works for CUDA and HIP
         SortParticlesForDeposition(m_reorder_idx_type);
+#else
+        SortParticlesByCell();
+#endif
     }
 }
 

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -28,9 +28,6 @@ InitParticles (const amrex::RealVect& a_u_std,
     const auto dx = ParticleGeom(lev).CellSizeArray();
     const auto plo = ParticleGeom(lev).ProbLoArray();
     const amrex::RealBox a_bounds = ParticleGeom(lev).ProbDomain();
-
-    const int depos_order_1 = Hipace::m_depos_order_xy + 1;
-    const bool outer_depos_loop = Hipace::m_outer_depos_loop;
     const bool use_fine_patch = m_use_fine_patch;
 
     const amrex::Array<int, 2> ppc_coarse = m_ppc;
@@ -224,24 +221,12 @@ InitParticles (const amrex::RealVect& a_u_std,
                 unsigned int uiy = amrex::min(ny-1,amrex::max(0,iy));
                 unsigned int uiz = amrex::min(nz-1,amrex::max(0,iz));
 
-                unsigned int cellid = 0;
-                if (outer_depos_loop) {
-                    // ordering of axes from fastest to slowest:
-                    // x/depos_order_1 to match deposition
-                    // x%depos_order_1
-                    // y
-                    // z (not used)
-                    // ppc
-                    cellid = (uiz * ny + uiy) * nx +
-                    uix/depos_order_1 + ((uix%depos_order_1)*nx+depos_order_1-1)/depos_order_1;
-                } else {
-                    // ordering of axes from fastest to slowest:
-                    // x
-                    // y
-                    // z (not used)
-                    // ppc
-                    cellid = (uiz * ny + uiy) * nx + uix;
-                }
+                // ordering of axes from fastest to slowest:
+                // x
+                // y
+                // z (not used)
+                // ppc
+                unsigned int cellid = (uiz * ny + uiy) * nx + uix;
 
                 pcount[cellid] = 1;
             });
@@ -264,13 +249,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                 unsigned int uiy = amrex::min(ny-1,amrex::max(0,iy));
                 unsigned int uiz = amrex::min(nz-1,amrex::max(0,iz));
 
-                unsigned int cellid = 0;
-                if (outer_depos_loop) {
-                    cellid = (uiz * ny + uiy) * nx +
-                    uix/depos_order_1 + ((uix%depos_order_1)*nx+depos_order_1-1)/depos_order_1;
-                } else {
-                    cellid = (uiz * ny + uiy) * nx + uix;
-                }
+                unsigned int cellid = (uiz * ny + uiy) * nx + uix;
 
                 const amrex::Long pidx = poffset[cellid] - poffset[0] + old_size;
 

--- a/tests/blowout_wake.2Rank.sh
+++ b/tests/blowout_wake.2Rank.sh
@@ -64,12 +64,12 @@ $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --test-name blowout_wake.2Rank \
     --skip "{'beam': 'id'}"
 
-echo "Start testing new current deposition"
+echo "Start testing plasma reordering"
 
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         plasmas.sort_bin_size = 8 \
         hipace.file_prefix=normalized_data_cd2/ \
-        hipace.outer_depos_loop = true \
+        plasmas.reorder_period = 4 \
         max_step=1
 
 # Compare the results with checksum benchmark

--- a/tests/blowout_wake_explicit.2Rank.sh
+++ b/tests/blowout_wake_explicit.2Rank.sh
@@ -41,12 +41,12 @@ $HIPACE_TEST_DIR/checksum/checksumAPI.py \
     --test-name $TEST_NAME \
     --skip "{'lev=0' : ['Sy', 'Sx', 'chi']}"
 
-echo "Start testing new current deposition"
+echo "Start testing plasma reordering"
 
 mpiexec -n 2 $HIPACE_EXECUTABLE $HIPACE_EXAMPLE_DIR/inputs_normalized \
         plasmas.sort_bin_size = 8 \
         hipace.file_prefix=${TEST_NAME}_cd2 \
-        hipace.outer_depos_loop=true \
+        plasmas.reorder_period = 4 \
         max_step=1
 
 $HIPACE_TEST_DIR/checksum/checksumAPI.py \


### PR DESCRIPTION
Since we now have particle sorting, outer_depos_loop is not necessary anymore. It couldn't work with Explicit deposition because the shape factor could have a different size. As a replacement for the CI test, I added a CPU version for plasmas.reorder_period that uses SortParticlesByCell from amrex.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
