### PR TITLE
Use correct geometry for Laser diagnostics

### DIFF
--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -488,7 +488,8 @@ Fields::Copy (const int lev, const int i_slice, FieldDiagnosticData& fd,
     auto& slice_mf = m_slices[lev];
     auto slice_func = interpolated_field_xy<depos_order_xy, guarded_field_xy>{{slice_mf}, calc_geom};
     auto& laser_mf = multi_laser.getSlices();
-    auto laser_func = interpolated_field_xy<depos_order_xy, guarded_field_xy>{{laser_mf}, calc_geom};
+    auto laser_func = interpolated_field_xy<depos_order_xy,
+        guarded_field_xy>{{laser_mf}, multi_laser.GetLaserGeom()};
 
 #ifdef AMREX_USE_GPU
     // This async copy happens on the same stream as the ParallelFor below, which uses the copied array.

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -224,6 +224,9 @@ public:
     /** Get the central wavelength */
     amrex::Real GetLambda0 () const { return m_lambda0; }
 
+    /** Get the geometry of the Laser Box */
+    const amrex::Geometry& GetLaserGeom () const { return m_laser_geom_3D; }
+
     bool m_use_laser {false}; /**< whether a laser is used or not */
 
 private:


### PR DESCRIPTION
Surprisingly, MR with Laser already works, however in the diagnostics for laserEnvelope, the geometry for fields was used and not that of the laser. This made laserEnvelope on level 1 incorrect (but not aabs). Now, laserEnvelope will be interpolated correctly to the level 1 diagnostics.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
