### PR TITLE
Sort plasma after initialization when running on CPU

### DIFF
--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -383,6 +383,12 @@ InitParticles (const amrex::RealVect& a_u_std,
             });
         }
     }
+#ifndef AMREX_USE_GPU
+    // The index order for initializing plasma particles is optimized for GPU.
+    // On CPU, especially with multiple particles per cell,
+    // reordering particles by cell gives better performance for plasma deposition and push.
+    SortParticlesByCell();
+#endif
 }
 
 void


### PR DESCRIPTION
The plasma initialization is optimized for GPU. When running on CPUs its very beneficial for deposition and push performance to sort the particles after initialization.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
