### PR TITLE
Improve performance of FFTDirichletFast

### DIFF
--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -35,7 +35,7 @@ Fields::Fields (const int nlev)
 #ifdef AMREX_USE_GPU
     m_poisson_solver_str = "FFTDirichletFast";
 #else
-    m_poisson_solver_str = "FFTDirichletDirect";
+    m_poisson_solver_str = "FFTDirichletFast";
 #endif
     queryWithParser(ppf, "poisson_solver", m_poisson_solver_str);
     queryWithParser(ppf, "extended_solve", m_extended_solve);

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -35,7 +35,7 @@ Fields::Fields (const int nlev)
 #ifdef AMREX_USE_GPU
     m_poisson_solver_str = "FFTDirichletFast";
 #else
-    m_poisson_solver_str = "FFTDirichletFast";
+    m_poisson_solver_str = "FFTDirichletDirect";
 #endif
     queryWithParser(ppf, "poisson_solver", m_poisson_solver_str);
     queryWithParser(ppf, "extended_solve", m_extended_solve);

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.H
@@ -71,9 +71,9 @@ private:
     AnyFFT m_y_fft;
     /** work area for both DST plans */
     amrex::Gpu::DeviceVector<char> m_fft_work_area;
-
+    /** x prefactor for ToSine */
     amrex::Gpu::DeviceVector<amrex::Real> m_sine_x_factor;
-
+    /** y prefactor for ToSine */
     amrex::Gpu::DeviceVector<amrex::Real> m_sine_y_factor;
 };
 

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.H
@@ -61,8 +61,8 @@ public:
 private:
     /** Spectral fields, contains (real) field in Fourier space */
     amrex::MultiFab m_tmpSpectralField;
-    /** Multifab eigenvalues, to solve Poisson equation with Dirichlet BC. */
-    amrex::MultiFab m_eigenvalue_matrix;
+    /** FArrayBox eigenvalues, to solve Poisson equation with Dirichlet BC. */
+    amrex::FArrayBox m_eigenvalue_matrix;
     /** Real array for the FFTs */
     amrex::Gpu::DeviceVector<amrex::Real> m_position_array;
     /** Complex array for the FFTs */

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.H
@@ -59,8 +59,6 @@ public:
     virtual amrex::Real BoundaryFactor() override final { return 1.; }
 
 private:
-    /** Spectral fields, contains (real) field in Fourier space */
-    amrex::MultiFab m_tmpSpectralField;
     /** FArrayBox eigenvalues, to solve Poisson equation with Dirichlet BC. */
     amrex::FArrayBox m_eigenvalue_matrix;
     /** Real array for the FFTs */
@@ -73,6 +71,10 @@ private:
     AnyFFT m_y_fft;
     /** work area for both DST plans */
     amrex::Gpu::DeviceVector<char> m_fft_work_area;
+
+    amrex::Gpu::DeviceVector<amrex::Real> m_sine_x_factor;
+
+    amrex::Gpu::DeviceVector<amrex::Real> m_sine_y_factor;
 };
 
 #endif

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.cpp
@@ -60,12 +60,14 @@ amrex::GpuComplex<amrex::Real> to_complex (T&& in, int i, int j, int n_half, int
  * \param[in] j y index to compute
  * \param[in] n_data number of (contiguous) rows in position matrix
  * \param[in] sine_facor prefactor for ToSine equal to 1/(2*sin((idx+1)*pi/(n_data+1)))
- * \param[in] n_data number of (contiguous) rows in position matrix
  */
 template<class T> AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::Real to_sine (T&& in, int i, int j, int n_data, const amrex::Real* sine_facor) {
     const amrex::Real in_a = in(i+1, j);
     const amrex::Real in_b = in(n_data-i, j);
+    // possible optimization:
+    // iterate over the elements is such a way that each thread computes (i,j) and (n_data-i-1,j)
+    // so in_a and in_b can be reused
     return amrex::Real(0.5)*(in_b - in_a + (in_a + in_b) * sine_facor[i]);
 }
 

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.cpp
@@ -324,7 +324,7 @@ FFTPoissonSolverDirichletFast::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
     m_x_fft.Execute();
 
     amrex::Box lhs_bx = lhs_mf[0].box();
-    lhs_bx += m_stagingArea[0].box().smallEnd();
+    lhs_bx -= m_stagingArea[0].box().smallEnd();
     Array2<amrex::Real> lhs_arr {{lhs_mf[0].dataPtr(), amrex::begin(lhs_bx), amrex::end(lhs_bx), 1}};
 
     ToSine(real_arr, lhs_arr, m_sine_x_factor.dataPtr(), nx, ny);

--- a/src/utils/GPUUtil.H
+++ b/src/utils/GPUUtil.H
@@ -23,6 +23,7 @@ struct Array2 {
     int ncomp=0;
 #endif
 
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Array2 (const amrex::Array4<T>& rhs) noexcept
         : p(rhs.p),
           jstride(rhs.jstride),
@@ -34,7 +35,7 @@ struct Array2 {
 #endif
     {
         // slice is only one cell thick if allocated
-        AMREX_ALWAYS_ASSERT(!rhs.p || rhs.begin.z + 1 == rhs.end.z);
+        AMREX_IF_ON_HOST((AMREX_ALWAYS_ASSERT(!rhs.p || rhs.begin.z + 1 == rhs.end.z);));
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE


### PR DESCRIPTION
This PR improves the performence of FFTDirichletFast by combining the GPU kernels between the FFTs into a single kernel. This reduces memory usage by getting rid of the temporary field and increases performance by reducing the memory bandwidth needed (to the temporary field) and reducing kernel launch overhead for small resolutions.


On MI250X with 4095^2 cells, this gives a speed-up of 40%.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
