### PR TITLE
Use less than or equal for min_density with beam

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -704,7 +704,7 @@ Option: ``fixed_ppc``
     This function uses the parser, see above.
 
 * ``<beam name>.min_density`` (`float`) optional (default `0`)
-    Minimum density. Particles with a lower density are not injected.
+    Particles with a density less than or equal to the minimal density won't be injected.
     The absolute value of this parameter is used when initializing the beam.
 
 * ``<beam name>.position_mean`` (3 `float`)

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -165,7 +165,7 @@ InitBeamFixedPPC3D ()
                 }
 
                 const amrex::Real density = get_density(x, y, z);
-                if (density < min_density) continue;
+                if (density <= min_density) continue;
 
                 ++count;
             }
@@ -253,7 +253,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
                 }
 
                 const amrex::Real density = get_density(x, y, z);
-                if (density < min_density) continue;
+                if (density <= min_density) continue;
 
                 ++count;
             }
@@ -310,7 +310,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
                 }
 
                 const amrex::Real density = get_density(x, y, z);
-                if (density < min_density) continue;
+                if (density <= min_density) continue;
 
                 amrex::Real u[3] = {0.,0.,0.};
                 get_momentum(u[0], u[1], u[2], engine);


### PR DESCRIPTION
This will prevent particles with zero weight from being injected. Same as #947 but for a fixed ppc beam.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
