### PR TITLE
Fix openPMD crash if beam has no particles

### DIFF
--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -245,6 +245,12 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
         SetupPos(beam_species, beam, np_total, geom);
         SetupRealProperties(beam_species, real_names, np_total);
 
+        if (np_total == 0) {
+            amrex::ErrorStream() << "WARNING: Beam '" << name
+                                 << "' has no particles! No output will be written.\n";
+            continue;
+        }
+
         for (std::size_t idx=0; idx<m_uint64_beam_data[ibeam].size(); idx++) {
             uint64_t * const uint64_data = m_uint64_beam_data[ibeam][idx].get();
 


### PR DESCRIPTION
Previously, if `currRecordComp.storeChunk()` was called with no particles, one would get:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Chunks cannot be written for a constant RecordComponent.
SIGABRT
See Backtrace.0 file for details
```


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
