### PR TITLE
Add a relative tolerance to SALAME

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -780,8 +780,11 @@ For more information on the algorithm, see the corresponding publication `S. Die
     It is recommended to use this option with a fixed weight can beam.
     If a gaussian beam profile is used, then the zmin and zmax parameters should be used.
 
-* ``hipace.salame_n_iter`` (`int`) optional (default `3`)
-    Number of iterations the SALAME algorithm should do when it is used.
+* ``hipace.salame_n_iter`` (`int`) optional (default `5`)
+    The maximum number of iterations the SALAME algorithm should do when it is used.
+
+* ``hipace.salame_relative_tolerance`` (`float`) optional (default `1e-4`)
+    Relative error tolerance to finish SALAME iterations early.
 
 * ``hipace.salame_do_advance`` (`bool`) optional (default `1`)
     Whether the SALAME algorithm should calculate the SALAME-beam-only Ez field

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -250,7 +250,7 @@ public:
     OpenPMDWriter m_openpmd_writer;
 #endif
     /** the number of SALAME iterations to be done */
-    int m_salame_n_iter = 3;
+    int m_salame_n_iter = 5;
     /** if the SALAME-only field should be computed exactly with plasma particles */
     bool m_salame_do_advance = true;
     /** the slice index of the previous slice with SALAME */
@@ -263,6 +263,8 @@ public:
     amrex::Parser m_salame_parser;
     /** Function to get the target Ez field for SALAME */
     amrex::ParserExecutor<3> m_salame_target_func;
+    /** relative error tolerance to finish SALAME iterations early */
+    amrex::Real m_salame_relative_tolerance = 1e-4;
 
 private:
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -134,6 +134,7 @@ Hipace::Hipace () :
     queryWithParser(pph, "salame_Ez_target(zeta,zeta_initial,Ez_initial)", salame_target_str);
     m_salame_target_func = makeFunctionWithParser<3>(salame_target_str, m_salame_parser,
                                                      {"zeta", "zeta_initial", "Ez_initial"});
+    queryWithParser(pph, "salame_relative_tolerance", m_salame_relative_tolerance);
 
     std::string solver = "explicit";
     queryWithParser(pph, "bxby_solver", solver);
@@ -566,7 +567,7 @@ Hipace::SolveOneSlice (int islice, int step)
         // Modify the beam particle weights on this slice to flatten Ez.
         // As the beam current is modified, Bx and By are also recomputed.
         SalameModule(this, m_salame_n_iter, m_salame_do_advance, m_salame_last_slice,
-                    m_salame_overloaded, current_N_level, step, islice);
+                    m_salame_overloaded, current_N_level, step, islice, m_salame_relative_tolerance);
     }
 
     // get beam diagnostics after SALAME but before beam push

--- a/src/salame/Salame.H
+++ b/src/salame/Salame.H
@@ -20,6 +20,7 @@
  * \param[in] current_N_level number of MR levels active on the current slice
  * \param[in] step time step of simulation
  * \param[in] islice slice index of the whole domain
+ * \param[in] relative_tolerance relative error tolerance to finish SALAME iterations early
  */
 void
 SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last_islice,

--- a/src/salame/Salame.H
+++ b/src/salame/Salame.H
@@ -23,7 +23,8 @@
  */
 void
 SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last_islice,
-              bool& overloaded, const int current_N_level, const int step, const int islice);
+              bool& overloaded, const int current_N_level, const int step, const int islice,
+              const amrex::Real relative_tolerance);
 
 /** Initialize Sx and Sy with the contribution from the SALAME beam
  * \param[in] hipace pointer to Hipace instance

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -12,7 +12,8 @@
 
 void
 SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last_islice,
-              bool& overloaded, const int current_N_level, const int step, const int islice)
+              bool& overloaded, const int current_N_level, const int step, const int islice,
+              const amrex::Real relative_tolerance)
 {
     HIPACE_PROFILE("SalameModule()");
 
@@ -154,7 +155,15 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
         }
 
         amrex::Print() << "Salame weight factor on slice " << islice << " is " << W
-                       << " Total weight is " << W_total << '\n';
+                       << " Total weight is " << W_total;
+
+        if (!overloaded && iter >= 1 && std::abs(W - 1.) < relative_tolerance) {
+            // SALAME is converged
+            iter = n_iter-1; // this is the last iteration
+            amrex::Print() << " (converged)";
+        }
+
+        amrex::Print() << '\n';
 
         SalameMultiplyBeamWeight(W, hipace);
 


### PR DESCRIPTION
This PR adds the option for SALAME to stop early if a relative tolerance is met (default 1e-4). New example output:
```
Salame weight factor on slice 6463 is 36.08182156 Total weight is 29197.82958
Salame weight factor on slice 6463 is 1.000378897 Total weight is 29208.89254
Salame weight factor on slice 6463 is 0.9998989475 Total weight is 29205.94091
Salame weight factor on slice 6463 is 0.9999670285 Total weight is 29204.97795 (converged)
Salame weight factor on slice 6462 is 35.56048808 Total weight is 28607.47294
Salame weight factor on slice 6462 is 1.000389669 Total weight is 28618.62038
Salame weight factor on slice 6462 is 0.9999003436 Total weight is 28615.76835 (converged)
Salame weight factor on slice 6461 is 33.50595155 Total weight is 27013.89738
Salame weight factor on slice 6461 is 1.000379709 Total weight is 27024.15479
Salame weight factor on slice 6461 is 0.9999002078 Total weight is 27021.45799 (converged)
Salame weight factor on slice 6460 is 35.7203742 Total weight is 28676.00284
Salame weight factor on slice 6460 is 1.000379521 Total weight is 28686.88598
Salame weight factor on slice 6460 is 0.9998988096 Total weight is 28683.98314
Salame weight factor on slice 6460 is 0.9999667186 Total weight is 28683.02849 (converged)
Salame weight factor on slice 6459 is 37.78257352 Total weight is 30305.57401
Salame weight factor on slice 6459 is 1.000390985 Total weight is 30317.42304
Salame weight factor on slice 6459 is 0.9998727361 Total weight is 30313.56473
Salame weight factor on slice 6459 is 0.9999880633 Total weight is 30313.20289 (converged)
Salame weight factor on slice 6458 is 37.24980293 Total weight is 30098.21133
Salame weight factor on slice 6458 is 1.00040052 Total weight is 30110.26625
Salame weight factor on slice 6458 is 0.9998771699 Total weight is 30106.56781
Salame weight factor on slice 6458 is 0.9999882093 Total weight is 30106.21283 (converged)
Salame weight factor on slice 6457 is 36.93648945 Total weight is 29767.69271
Salame weight factor on slice 6457 is 1.000402982 Total weight is 29779.68855
Salame weight factor on slice 6457 is 0.9999004664 Total weight is 29776.72447 (converged)
Salame weight factor on slice 6456 is 35.76575861 Total weight is 29113.98382
Salame weight factor on slice 6456 is 1.000426648 Total weight is 29126.40526
Salame weight factor on slice 6456 is 0.9999030711 Total weight is 29123.58207 (converged)
Salame weight factor on slice 6455 is 35.69385948 Total weight is 28724.57073
Salame weight factor on slice 6455 is 1.000412055 Total weight is 28736.40683
Salame weight factor on slice 6455 is 0.9998751713 Total weight is 28732.81971
Salame weight factor on slice 6455 is 0.9999878974 Total weight is 28732.47196 (converged)
```
The default number of iterations was increased from 3 to 5 since it can now stop early if appropriate.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
