### PR TITLE
Clean in-situ diagnostic with TupleSplit and tupleToArray

### DIFF
--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -1323,14 +1323,12 @@ Fields::InSituComputeDiags (int step, amrex::Real time, int islice, const amrex:
             });
     }
 
-    ReduceTuple a = reduce_data.value();
+    auto real_arr = amrex::tupleToArray(reduce_data.value());
 
-    amrex::constexpr_for<0, m_insitu_nrp>(
-        [&] (auto idx) {
-            m_insitu_rdata[islice + idx * nslices] = amrex::get<idx>(a)*dxdydz;
-            m_insitu_sum_rdata[idx] += amrex::get<idx>(a)*dxdydz;
-        }
-    );
+    for (int i=0; i<m_insitu_nrp; ++i) {
+        m_insitu_rdata[islice + i * nslices] = real_arr[i] * dxdydz;
+        m_insitu_sum_rdata[i] += real_arr[i] * dxdydz;
+    }
 }
 
 void

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1246,25 +1246,25 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
             });
     }
 
-    ReduceTuple a = reduce_data.value();
+    auto [real_tup, cplx_tup] = amrex::TupleSplit<m_insitu_nrp, m_insitu_ncp>(reduce_data.value());
 
-    amrex::constexpr_for<0, m_insitu_nrp>(
-        [&] (auto idx) {
-            if (idx == 0) {
-                m_insitu_rdata[laser_slice + idx * nslices] = amrex::get<idx>(a);
-                m_insitu_sum_rdata[idx] = std::max(m_insitu_sum_rdata[idx], amrex::get<idx>(a));
-            } else {
-                m_insitu_rdata[laser_slice + idx * nslices] = amrex::get<idx>(a)*dxdydz;
-                m_insitu_sum_rdata[idx] += amrex::get<idx>(a)*dxdydz;
-            }
-        }
-    );
+    auto real_arr = amrex::tupleToArray(real_tup);
 
-    amrex::constexpr_for<0, m_insitu_ncp>(
-        [&] (auto idx) {
-            m_insitu_cdata[laser_slice + idx * nslices] = amrex::get<m_insitu_nrp+idx>(a) * mid_factor;
+    for (int i=0; i<m_insitu_nrp; ++i) {
+        if (i == 0) {
+            m_insitu_rdata[laser_slice + i * nslices] = real_arr[i];
+            m_insitu_sum_rdata[i] = std::max(m_insitu_sum_rdata[i], real_arr[i]);
+        } else {
+            m_insitu_rdata[laser_slice + i * nslices] = real_arr[i] * dxdydz;
+            m_insitu_sum_rdata[i] += real_arr[i] * dxdydz;
         }
-    );
+    }
+
+    auto cplx_arr = amrex::tupleToArray(cplx_tup);
+
+    for (int i=0; i<m_insitu_ncp; ++i) {
+        m_insitu_cdata[laser_slice + i * nslices] = cplx_arr[i] * mid_factor;
+    }
 }
 
 void

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -548,24 +548,25 @@ BeamParticleContainer::InSituComputeDiags (int islice)
             };
         });
 
-    ReduceTuple a = reduce_data.value();
-    const amrex::Real sum_w_inv = amrex::get<0>(a) <= 0._rt ? 0._rt : 1._rt / amrex::get<0>(a);
+    auto [real_tup, int_tup] = amrex::TupleSplit<m_insitu_nrp, m_insitu_nip>(reduce_data.value());
 
-    amrex::constexpr_for<0, m_insitu_nrp>(
-        [&] (auto idx) {
-            m_insitu_rdata[islice + idx * m_nslices] = amrex::get<idx>(a) *
-                // sum(w) is not multiplied by sum_w_inv
-                ( idx == 0 ? 1 : sum_w_inv );
-            m_insitu_sum_rdata[idx] += amrex::get<idx>(a);
-        }
-    );
+    auto real_arr = amrex::tupleToArray(real_tup);
 
-    amrex::constexpr_for<0, m_insitu_nip>(
-        [&] (auto idx) {
-            m_insitu_idata[islice + idx * m_nslices] = amrex::get<m_insitu_nrp+idx>(a);
-            m_insitu_sum_idata[idx] += amrex::get<m_insitu_nrp+idx>(a);
-        }
-    );
+    const amrex::Real sum_w_inv = real_arr[0] <= 0._rt ? 0._rt : 1._rt / real_arr[0];
+
+    for (int i=0; i<m_insitu_nrp; ++i) {
+        m_insitu_rdata[islice + i * m_nslices] = real_arr[i] *
+            // sum(w) is not multiplied by sum_w_inv
+            ( i == 0 ? 1 : sum_w_inv );
+        m_insitu_sum_rdata[i] += real_arr[i];
+    }
+
+    auto int_arr = amrex::tupleToArray(int_tup);
+
+    for (int i=0; i<m_insitu_nip; ++i) {
+        m_insitu_idata[islice + i * m_nslices] = int_arr[i];
+        m_insitu_sum_idata[i] += int_arr[i];
+    }
 
     if (m_do_spin_tracking) {
         amrex::TypeMultiplier<amrex::ReduceOps, amrex::ReduceOpSum[m_insitu_n_spin]> reduce_op_spin;
@@ -595,15 +596,12 @@ BeamParticleContainer::InSituComputeDiags (int islice)
                 };
             });
 
-        ReduceTupleSpin a_spin = reduce_data_spin.value();
+        auto spin_arr = amrex::tupleToArray(reduce_data_spin.value());
 
-        amrex::constexpr_for<0, m_insitu_n_spin>(
-            [&] (auto idx) {
-                m_insitu_spin_data[islice + idx * m_nslices] =
-                    amrex::get<idx>(a_spin) * sum_w_inv;
-                m_insitu_sum_spin_data[idx] += amrex::get<idx>(a_spin);
-            }
-        );
+        for (int i=0; i<m_insitu_n_spin; ++i) {
+            m_insitu_spin_data[islice + i * m_nslices] = spin_arr[i] * sum_w_inv;
+            m_insitu_sum_spin_data[i] += spin_arr[i];
+        }
     }
 }
 


### PR DESCRIPTION
The previous version with constexpr_for was already relatively good, however using the new amrex functions TupleSplit and tupleToArray it can be simplified further.



- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
