### PR TITLE
CI: CCache for macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,9 +18,9 @@ jobs:
       #CMAKE_GENERATOR: Ninja
       SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Brew Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       # - once stored under a key, they become immutable (even if local cache path content changes)
       # - for a refresh the key has to change, e.g., hash of a tracked file in the key
       with:
@@ -90,11 +90,20 @@ jobs:
 
     - name: build HiPACE++
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        export CCACHE_SLOPPINESS=time_macros
+        ccache -z
+
         cmake -S . -B build_sp          \
           -DCMAKE_VERBOSE_MAKEFILE=ON   \
           -DHiPACE_openpmd_internal=OFF \
           -DHiPACE_PRECISION=SINGLE
         cmake --build build_sp -j 2
+
+        du -hs ~/Library/Caches/ccache
+        ccache -s
 
 #    - name: test HiPACE++
 #      run: |


### PR DESCRIPTION
Add environment options to make CCache work better on macOS.

X-ref: https://github.com/ECP-WarpX/WarpX/pull/5007

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [x] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
