### PR TITLE
Fix compilation without openpmd

### DIFF
--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -483,7 +483,6 @@ MultiLaser::GetEnvelopeFromFile () {
         } // End of 3 loops (1 per dimension) over laser array from simulation
     } // End if statement over file laser geometry (rt or xyt)
 #else
-    amrex::ignore_unused(gm);
     amrex::Abort("loading a laser envelope from an external file requires openPMD support: "
                  "Add HiPACE_OPENPMD=ON when compiling HiPACE++.\n");
 #endif // HIPACE_USE_OPENPMD

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -23,6 +23,7 @@
 
 namespace
 {
+#ifdef HIPACE_USE_OPENPMD
     /** \brief Adds a single beam particle
      *
      * \param[in,out] ptd real and int beam data
@@ -55,6 +56,7 @@ namespace
         ptd.idcpu(ip) = pid + ip;
         ptd.id(ip).make_valid();
     }
+#endif // HIPACE_USE_OPENPMD
 
     /** \brief Adds a single beam particle into the per-slice BeamTile
      *

--- a/src/utils/IOUtil.cpp
+++ b/src/utils/IOUtil.cpp
@@ -140,6 +140,7 @@ utils::getUnitDimension ( std::string const & record_name )
     };
     else return {};
 }
+#endif
 
 std::ostream& operator<<(std::ostream& os, utils::format_time ft) {
     long long seconds = static_cast<long long>(std::floor(ft.seconds));
@@ -162,4 +163,3 @@ std::ostream& operator<<(std::ostream& os, utils::format_time ft) {
 
     return os;
 }
-#endif


### PR DESCRIPTION
There were a few errors and warnings when compiling without openPMD.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
