### PR TITLE
Add fix for slow GPU aware MPI to JSC booster script

### DIFF
--- a/docs/source/building/platforms/booster_jsc.rst
+++ b/docs/source/building/platforms/booster_jsc.rst
@@ -22,8 +22,6 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    module load CUDA
    module load HDF5
    module load ccache # optional, accelerates recompilation
-   export GPUS_PER_SOCKET=2
-   export GPUS_PER_NODE=4
    # optimize CUDA compilation for A100
    export AMREX_CUDA_ARCH=8.0 # 8.0 for A100, 7.0 for V100
 
@@ -59,6 +57,8 @@ You can then create your directory in your ``$SCRATCH_<project id>``, where you 
    module load OpenMPI
    module load CUDA
    module load HDF5
+   # fix issue with MPI
+   export UCX_CUDA_COPY_REG_WHOLE_ALLOC=on
    srun -n 8 --cpu_bind=sockets $HOME/src/hipace/build/bin/hipace.MPI.CUDA.DP.LF inputs
 
 and use it to submit a simulation.


### PR DESCRIPTION
In my testing so far, setting this environment variable greatly improves performance of GPU-aware MPI on the booster. 
```
export UCX_CUDA_COPY_REG_WHOLE_ALLOC=on
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
