### PR TITLE
Add pre_register_memory option

### DIFF
--- a/docs/source/building/platforms/booster_jsc.rst
+++ b/docs/source/building/platforms/booster_jsc.rst
@@ -26,7 +26,6 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    export GPUS_PER_NODE=4
    # optimize CUDA compilation for A100
    export AMREX_CUDA_ARCH=8.0 # 8.0 for A100, 7.0 for V100
-   export CUDAFLAGS="-arch=sm_80" # sm_80 for A100
 
 Install HiPACE++ (the first time, and whenever you want the latest version):
 

--- a/docs/source/building/platforms/booster_jsc.rst
+++ b/docs/source/building/platforms/booster_jsc.rst
@@ -26,6 +26,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    export GPUS_PER_NODE=4
    # optimize CUDA compilation for A100
    export AMREX_CUDA_ARCH=8.0 # 8.0 for A100, 7.0 for V100
+   export CUDAFLAGS="-arch=sm_80" # sm_80 for A100
 
 Install HiPACE++ (the first time, and whenever you want the latest version):
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -117,6 +117,12 @@ General parameters
     ranks there is enough capacity to store every slice to avoid a deadlock, i.e.
     ``comms_buffer.max_trailing_slices * nranks > nslices``.
 
+* ``comms_buffer.pre_register_memory`` (`bool`) optional (default `false`)
+    On some platforms, such as JUWELS booster, the memory passed into MPI needs to be
+    registered to the network card, which can take a long time. When using this option, all ranks
+    can do this at once in initialization instead of one after another
+    as part of the communication pipeline.
+
 * ``hipace.do_tiling`` (`bool`) optional (default `true`)
     Whether to use tiling, when running on CPU.
     Currently, this option only affects plasma operations (gather, push and deposition).

--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -130,6 +130,9 @@ private:
     std::array<int, comm_progress::nprogress> m_async_metadata_slice {};
     std::array<int, comm_progress::nprogress> m_async_data_slice {};
 
+    // send some dummy messages so MPI can pre-register the memory
+    void pre_register_memory ();
+
     // helper functions to read 2D metadata array
     std::size_t get_metadata_size ();
     std::size_t* get_metadata_location (int slice);


### PR DESCRIPTION
On some platforms, such as JUWELS booster, the memory passed into MPI needs to be registered to the network card, which can take a long time. When using this option, all ranks can do this at once in initialization instead of one after another as part of the communication pipeline.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
