### PR TITLE
Remove particles with negative psi_inv

### DIFF
--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -193,7 +193,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
                 + 1._rt
             );
 
-            if ((gamma_psi < 0.0_rt || gamma_psi > max_qsa_weighting_factor))
+            if (gamma_psi < 0.0_rt || gamma_psi > max_qsa_weighting_factor || psi_inv < 0.0_rt)
             {
                 // This particle violates the QSA, discard it and do not deposit its current
                 amrex::Gpu::Atomic::Add(p_n_qsa_violation, 1);


### PR DESCRIPTION
With a low zeta resolution and a strong wakefield, it can happen that psi goes below zero. These particles will cause a negative chi which can blow up the simulation pretty quickly.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
