### PR TITLE
hipace.profile -> profile.hipace

### DIFF
--- a/docs/source/building/hpc.rst
+++ b/docs/source/building/hpc.rst
@@ -9,17 +9,17 @@ Follow the guide here instead of the generic installation routines for optimal s
 
 .. _install-hpc-profile:
 
-hipace.profile
+profile.hipace
 --------------
 
-Use a ``hipace.profile`` file to set up your software environment without colliding with other software.
+Use a ``profile.hipace`` file to set up your software environment without colliding with other software.
 Ideally, store that file directly in your ``$HOME/`` and source it after connecting to the machine:
 
 .. code-block:: bash
 
-   source $HOME/hipace.profile
+   source $HOME/profile.hipace
 
-We list example ``hipace.profile`` files below, which can be used to set up HiPACE++ on various HPC systems.
+We list example ``profile.hipace`` files below, which can be used to set up HiPACE++ on various HPC systems.
 
 
 .. _install-hpc-machines:

--- a/docs/source/building/platforms/booster_jsc.rst
+++ b/docs/source/building/platforms/booster_jsc.rst
@@ -117,7 +117,7 @@ You can then create your directory in your ``$SCRATCH_<project id>``, where you 
    #SBATCH --output=hipace-%j-%N.txt
    #SBATCH --error=hipace-%j-%N.err
 
-   source $HOME/hipace.profile
+   source $HOME/profile.hipace
 
    # These options give the best performance, in particular for the threaded FFTW
    export OMP_PROC_BIND=false # true false master close spread


### PR DESCRIPTION
Previously, both hipace.profile and profile.hipace were used interchangeably, causing errors and confusion.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
