### PR TITLE
CMake: Replace `FetchContent_Populate`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,13 +38,6 @@ if(POLICY CMP0104)
     cmake_policy(SET CMP0104 OLD)
 endif()
 
-# We use simple syntax in cmake_dependent_option, so we are compatible with the
-# extended syntax in CMake 3.22+
-# https://cmake.org/cmake/help/v3.22/policy/CMP0127.html
-if(POLICY CMP0127)
-    cmake_policy(SET CMP0127 NEW)
-endif()
-
 
 # C++ Standard in Superbuilds #################################################
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.24.0)
 project(HiPACE VERSION 24.08)
 
 # helper functions

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -74,32 +74,19 @@ macro(find_amrex)
             list(APPEND CMAKE_MODULE_PATH "${HiPACE_amrex_src}/Tools/CMake")
             if(HiPACE_COMPUTE STREQUAL CUDA)
                 enable_language(CUDA)
-                # AMReX 21.06+ supports CUDA_ARCHITECTURES
-                if(CMAKE_VERSION VERSION_LESS 3.20)
-                    include(AMReX_SetupCUDA)
-                endif()
             endif()
             add_subdirectory(${HiPACE_amrex_src} _deps/localamrex-build/)
         else()
+            if(HiPACE_COMPUTE STREQUAL CUDA)
+                enable_language(CUDA)
+            endif()
             FetchContent_Declare(fetchedamrex
                 GIT_REPOSITORY ${HiPACE_amrex_repo}
                 GIT_TAG        ${HiPACE_amrex_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedamrex)
-
-            if(NOT fetchedamrex_POPULATED)
-                FetchContent_Populate(fetchedamrex)
-                list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
-                if(HiPACE_COMPUTE STREQUAL CUDA)
-                    enable_language(CUDA)
-                    # AMReX 21.06+ supports CUDA_ARCHITECTURES
-                    if(CMAKE_VERSION VERSION_LESS 3.20)
-                        include(AMReX_SetupCUDA)
-                    endif()
-                endif()
-                add_subdirectory(${fetchedamrex_SOURCE_DIR} ${fetchedamrex_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedamrex)
+            list(APPEND CMAKE_MODULE_PATH "${fetchedamrex_SOURCE_DIR}/Tools/CMake")
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -29,12 +29,7 @@ function(find_openpmd)
                 GIT_TAG        ${HiPACE_openpmd_branch}
                 BUILD_IN_SOURCE 0
             )
-            FetchContent_GetProperties(fetchedopenpmd)
-
-            if(NOT fetchedopenpmd_POPULATED)
-                FetchContent_Populate(fetchedopenpmd)
-                add_subdirectory(${fetchedopenpmd_SOURCE_DIR} ${fetchedopenpmd_BINARY_DIR})
-            endif()
+            FetchContent_MakeAvailable(fetchedopenpmd)
 
             # advanced fetch options
             mark_as_advanced(FETCHCONTENT_BASE_DIR)

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -31,7 +31,7 @@ HiPACE++ depends on the following popular third party software.
 Please see installation instructions below in the Developers section.
 
 - a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B14>`__ compiler: e.g. GCC 7, Clang 7, NVCC 11.0, MSVC 19.15 or newer
-- `CMake 3.18.0+ <https://cmake.org/>`__
+- `CMake 3.24.0+ <https://cmake.org/>`__
 - `AMReX development <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
 - `openPMD-api 0.15.1+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api
 
@@ -123,7 +123,7 @@ The dependencies can be installed via the package manager
    brew install pkg-config  # for fftw
    brew install open-mpi
 
-Now, ``cmake --version`` should be at version 3.15.0 or newer.
+Now, ``cmake --version`` should be at version 3.24.0 or newer.
 
 Configure your compiler
 -----------------------

--- a/docs/source/building/platforms/perlmutter_nersc.rst
+++ b/docs/source/building/platforms/perlmutter_nersc.rst
@@ -17,7 +17,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    export proj=<your project id>_g  # _g for GPU accounting
 
    # required dependencies
-   module load cmake/3.22.0
+   module load cmake/3.24.3
    module load cray-hdf5-parallel/1.12.2.3
 
    # necessary to use CUDA-Aware MPI and run a job


### PR DESCRIPTION
In CMake superbuilds, `FetchContent_Populate` is now deprecated. Use `FetchContent_MakeAvailable` instead.

Bump CMake to 3.24+.

- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [x] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [x] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [x] **Proper label and GitHub project**, if applicable
