### PR TITLE
OMP parallelize Beam pusher

### DIFF
--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -14,6 +14,7 @@
 #include "GetAndSetPosition.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/GPUUtil.H"
+#include "utils/OMPUtil.H"
 
 void
 AdvanceBeamParticlesSlice (
@@ -111,7 +112,8 @@ AdvanceBeamParticlesSlice (
     const amrex::Real E0 = Hipace::m_normalized_units ?
                            PhysConstSI::m_e * PhysConstSI::c / wp_inv / PhysConstSI::q_e : 1;
 
-    amrex::ParallelFor(
+    // Use OMP ParallelFor to use multiple threads when running on CPU
+    omp::ParallelFor(
         amrex::TypeList<
             amrex::CompileTimeOptions<0, 1, 2, 3>,
             amrex::CompileTimeOptions<false, true>

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -111,7 +111,7 @@ AdvanceBeamParticlesSlice (
                                      PhysConstSI::q_e*PhysConstSI::q_e )  ) : 1;
     const amrex::Real E0 = Hipace::m_normalized_units ?
                            PhysConstSI::m_e * PhysConstSI::c / wp_inv / PhysConstSI::q_e : 1;
-  
+
     // don't include slipped particles in count as they were already pushed
     Hipace::m_num_beam_particles_pushed += double(beam.getNumParticles(WhichBeamSlice::This));
 

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -16,6 +16,7 @@
 #include "GetAndSetPosition.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/GPUUtil.H"
+#include "utils/OMPUtil.H"
 #include "utils/DualNumbers.H"
 #include "particles/particles_utils/ParticleUtil.H"
 
@@ -72,211 +73,198 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
         const amrex::Real clight = phys_const.c;
         const amrex::Real clight_inv = 1._rt/phys_const.c;
         const amrex::Real charge_mass_clight_ratio = plasma.m_charge/(plasma.m_mass * phys_const.c);
-#ifdef AMREX_USE_OMP
-#pragma omp parallel
-#endif
-        {
-            amrex::Long const num_particles = pti.numParticles();
-#ifdef AMREX_USE_OMP
-            amrex::Long const idx_begin = (num_particles * omp_get_thread_num()) / omp_get_num_threads();
-            amrex::Long const idx_end = (num_particles * (omp_get_thread_num()+1)) / omp_get_num_threads();
-#else
-            amrex::Long constexpr idx_begin = 0;
-            amrex::Long const idx_end = num_particles;
-#endif
 
-            amrex::ParallelFor(
-                amrex::TypeList<
-                    amrex::CompileTimeOptions<0, 1, 2, 3>,
-                    amrex::CompileTimeOptions<false, true>
-                >{}, {
-                    Hipace::m_depos_order_xy,
-                    Hipace::m_use_laser
-                },
-                int(idx_end - idx_begin), // int ParallelFor is 3-5% faster than amrex::Long version
-                [=] AMREX_GPU_DEVICE (int idx, auto depos_order, auto use_laser) {
-                    const int ip = idx + idx_begin;
-                    // only push plasma particles on their according MR level
-                    if (!ptd.id(ip).is_valid() || ptd.cpu(ip) != lev) return;
+        // Use OMP ParallelFor to use multiple threads when running on CPU
+        omp::ParallelFor(
+            amrex::TypeList<
+                amrex::CompileTimeOptions<0, 1, 2, 3>,
+                amrex::CompileTimeOptions<false, true>
+            >{}, {
+                Hipace::m_depos_order_xy,
+                Hipace::m_use_laser
+            },
+            int(pti.numParticles()), // int ParallelFor is 3-5% faster than amrex::Long version
+            [=] AMREX_GPU_DEVICE (int ip, auto depos_order, auto use_laser) {
+                // only push plasma particles on their according MR level
+                if (!ptd.id(ip).is_valid() || ptd.cpu(ip) != lev) return;
 
-                    // define field at particle position reals
-                    amrex::Real ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
-                    amrex::Real Bxp = 0._rt, Byp = 0._rt, Bzp = 0._rt;
-                    amrex::Real Aabssqp = 0._rt, AabssqDxp = 0._rt, AabssqDyp = 0._rt;
+                // define field at particle position reals
+                amrex::Real ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
+                amrex::Real Bxp = 0._rt, Byp = 0._rt, Bzp = 0._rt;
+                amrex::Real Aabssqp = 0._rt, AabssqDxp = 0._rt, AabssqDyp = 0._rt;
 
-                    amrex::Real q_mass_clight_ratio = charge_mass_clight_ratio;
-                    amrex::Real laser_norm_ion = laser_norm;
-                    if (can_ionize) {
-                        q_mass_clight_ratio *= ptd.idata(PlasmaIdx::ion_lev)[ip];
-                        laser_norm_ion *=
-                            ptd.idata(PlasmaIdx::ion_lev)[ip] * ptd.idata(PlasmaIdx::ion_lev)[ip];
-                    }
+                amrex::Real q_mass_clight_ratio = charge_mass_clight_ratio;
+                amrex::Real laser_norm_ion = laser_norm;
+                if (can_ionize) {
+                    q_mass_clight_ratio *= ptd.idata(PlasmaIdx::ion_lev)[ip];
+                    laser_norm_ion *=
+                        ptd.idata(PlasmaIdx::ion_lev)[ip] * ptd.idata(PlasmaIdx::ion_lev)[ip];
+                }
 
-                    for (int i = 0; i < n_subcycles; i++) {
+                for (int i = 0; i < n_subcycles; i++) {
 
-                        amrex::Real xp = ptd.rdata(PlasmaIdx::x_prev)[ip];
-                        amrex::Real yp = ptd.rdata(PlasmaIdx::y_prev)[ip];
+                    amrex::Real xp = ptd.rdata(PlasmaIdx::x_prev)[ip];
+                    amrex::Real yp = ptd.rdata(PlasmaIdx::y_prev)[ip];
 
-                        if (lev == 0 || lev_bounds.contains(xp, yp)) {
-                            ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
-                            Bxp = 0._rt, Byp = 0._rt, Bzp = 0._rt;
-                            Aabssqp = 0._rt, AabssqDxp = 0._rt, AabssqDyp = 0._rt;
+                    if (lev == 0 || lev_bounds.contains(xp, yp)) {
+                        ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
+                        Bxp = 0._rt, Byp = 0._rt, Bzp = 0._rt;
+                        Aabssqp = 0._rt, AabssqDxp = 0._rt, AabssqDyp = 0._rt;
 
-                            doGatherShapeN<depos_order.value>(xp, yp, ExmByp, EypBxp, Ezp, Bxp, Byp,
-                                    Bzp, slice_arr, psi_comp, ez_comp, bx_comp, by_comp,
-                                    bz_comp, dx_inv, dy_inv, x_pos_offset, y_pos_offset);
+                        doGatherShapeN<depos_order.value>(xp, yp, ExmByp, EypBxp, Ezp, Bxp, Byp,
+                                Bzp, slice_arr, psi_comp, ez_comp, bx_comp, by_comp,
+                                bz_comp, dx_inv, dy_inv, x_pos_offset, y_pos_offset);
 
-                            if (use_laser.value) {
-                                doLaserGatherShapeN<depos_order.value>(xp, yp,
-                                    Aabssqp, AabssqDxp, AabssqDyp, slice_arr, aabs_comp,
-                                    dx_inv, dy_inv, x_pos_offset, y_pos_offset);
-                            }
-
-                            Bxp *= clight;
-                            Byp *= clight;
-                            Aabssqp *= 0.5_rt * laser_norm_ion;
-                            AabssqDxp *= 0.25_rt * clight * laser_norm_ion;
-                            AabssqDyp *= 0.25_rt * clight * laser_norm_ion;
+                        if (use_laser.value) {
+                            doLaserGatherShapeN<depos_order.value>(xp, yp,
+                                Aabssqp, AabssqDxp, AabssqDyp, slice_arr, aabs_comp,
+                                dx_inv, dy_inv, x_pos_offset, y_pos_offset);
                         }
+
+                        Bxp *= clight;
+                        Byp *= clight;
+                        Aabssqp *= 0.5_rt * laser_norm_ion;
+                        AabssqDxp *= 0.25_rt * clight * laser_norm_ion;
+                        AabssqDyp *= 0.25_rt * clight * laser_norm_ion;
+                    }
 
 #ifndef HIPACE_USE_AB5_PUSH
 
-                        constexpr int nsub = 4;
-                        const amrex::Real sdz = dz/nsub;
+                    constexpr int nsub = 4;
+                    const amrex::Real sdz = dz/nsub;
 
-                        amrex::Real ux = ptd.rdata(PlasmaIdx::ux_half_step)[ip];
-                        amrex::Real uy = ptd.rdata(PlasmaIdx::uy_half_step)[ip];
-                        amrex::Real psi = ptd.rdata(PlasmaIdx::psi_half_step)[ip];
+                    amrex::Real ux = ptd.rdata(PlasmaIdx::ux_half_step)[ip];
+                    amrex::Real uy = ptd.rdata(PlasmaIdx::uy_half_step)[ip];
+                    amrex::Real psi = ptd.rdata(PlasmaIdx::psi_half_step)[ip];
 
-                        // full push in momentum
-                        // from t-1/2 to t+1/2
-                        // using the fields at t
-                        for (int isub=0; isub<nsub; ++isub) {
+                    // full push in momentum
+                    // from t-1/2 to t+1/2
+                    // using the fields at t
+                    for (int isub=0; isub<nsub; ++isub) {
 
-                            const amrex::Real psi_inv = 1._rt/psi;
-
-                            auto [dz_ux, dz_uy, dz_psi] = PlasmaMomentumPush(
-                                ux, uy, psi_inv, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
-                                Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
-
-                            const DualNumber ux_dual{ux, dz_ux};
-                            const DualNumber uy_dual{uy, dz_uy};
-                            const DualNumber psi_inv_dual{psi_inv, -psi_inv*psi_inv*dz_psi};
-
-                            auto [dz_ux_dual, dz_uy_dual, dz_psi_dual] = PlasmaMomentumPush(
-                                ux_dual, uy_dual, psi_inv_dual, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
-                                Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
-
-                            ux += sdz*dz_ux + 0.5_rt*sdz*sdz*dz_ux_dual.epsilon;
-                            uy += sdz*dz_uy + 0.5_rt*sdz*sdz*dz_uy_dual.epsilon;
-                            psi += sdz*dz_psi + 0.5_rt*sdz*sdz*dz_psi_dual.epsilon;
-
-                        }
-
-                        // full push in position
-                        // from t to t+1
-                        // using the momentum at t+1/2
-                        xp += dz*clight_inv*(ux * (1._rt/psi));
-                        yp += dz*clight_inv*(uy * (1._rt/psi));
-
-                        if (enforceBC(ptd, ip, xp, yp, ux, uy, PlasmaIdx::w)) return;
-                        ptd.pos(0, ip) = xp;
-                        ptd.pos(1, ip) = yp;
-
-                        if (!temp_slice) {
-                            // update values of the last non temp slice
-                            // the next push always starts from these
-                            ptd.rdata(PlasmaIdx::ux_half_step)[ip] = ux;
-                            ptd.rdata(PlasmaIdx::uy_half_step)[ip] = uy;
-                            ptd.rdata(PlasmaIdx::psi_half_step)[ip] = psi;
-                            ptd.rdata(PlasmaIdx::x_prev)[ip] = xp;
-                            ptd.rdata(PlasmaIdx::y_prev)[ip] = yp;
-                        }
-
-                        // half push in momentum
-                        // from t+1/2 to t+1
-                        // still using the fields at t as an approximation
-                        // the result is used for current deposition etc. but not in the pusher
-                        for (int isub=0; isub<(nsub/2); ++isub) {
-
-                            const amrex::Real psi_inv = 1._rt/psi;
-
-                            auto [dz_ux, dz_uy, dz_psi] = PlasmaMomentumPush(
-                                ux, uy, psi_inv, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
-                                Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
-
-                            const DualNumber ux_dual{ux, dz_ux};
-                            const DualNumber uy_dual{uy, dz_uy};
-                            const DualNumber psi_inv_dual{psi_inv, -psi_inv*psi_inv*dz_psi};
-
-                            auto [dz_ux_dual, dz_uy_dual, dz_psi_dual] = PlasmaMomentumPush(
-                                ux_dual, uy_dual, psi_inv_dual, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
-                                Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
-
-                            ux += sdz*dz_ux + 0.5_rt*sdz*sdz*dz_ux_dual.epsilon;
-                            uy += sdz*dz_uy + 0.5_rt*sdz*sdz*dz_uy_dual.epsilon;
-                            psi += sdz*dz_psi + 0.5_rt*sdz*sdz*dz_psi_dual.epsilon;
-
-                        }
-                        ptd.rdata(PlasmaIdx::ux)[ip] = ux;
-                        ptd.rdata(PlasmaIdx::uy)[ip] = uy;
-                        ptd.rdata(PlasmaIdx::psi)[ip] = psi;
-#else
-                        amrex::Real ux = ptd.rdata(PlasmaIdx::ux_half_step)[ip];
-                        amrex::Real uy = ptd.rdata(PlasmaIdx::uy_half_step)[ip];
-                        amrex::Real psi = ptd.rdata(PlasmaIdx::psi_half_step)[ip];
                         const amrex::Real psi_inv = 1._rt/psi;
 
                         auto [dz_ux, dz_uy, dz_psi] = PlasmaMomentumPush(
                             ux, uy, psi_inv, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
                             Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
 
-                        ptd.rdata(PlasmaIdx::Fx1)[ip] = clight_inv*(ux * psi_inv);
-                        ptd.rdata(PlasmaIdx::Fy1)[ip] = clight_inv*(uy * psi_inv);
-                        ptd.rdata(PlasmaIdx::Fux1)[ip] = dz_ux;
-                        ptd.rdata(PlasmaIdx::Fuy1)[ip] = dz_uy;
-                        ptd.rdata(PlasmaIdx::Fpsi1)[ip] = dz_psi;
+                        const DualNumber ux_dual{ux, dz_ux};
+                        const DualNumber uy_dual{uy, dz_uy};
+                        const DualNumber psi_inv_dual{psi_inv, -psi_inv*psi_inv*dz_psi};
 
-                        const amrex::Real ab5_coeffs[5] = {
-                            ( 1901._rt / 720._rt ) * dz,    // a1 times dz
-                            ( -1387._rt / 360._rt ) * dz,   // a2 times dz
-                            ( 109._rt / 30._rt ) * dz,      // a3 times dz
-                            ( -637._rt / 360._rt ) * dz,    // a4 times dz
-                            ( 251._rt / 720._rt ) * dz      // a5 times dz
-                        };
+                        auto [dz_ux_dual, dz_uy_dual, dz_psi_dual] = PlasmaMomentumPush(
+                            ux_dual, uy_dual, psi_inv_dual, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
+                            Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
+
+                        ux += sdz*dz_ux + 0.5_rt*sdz*sdz*dz_ux_dual.epsilon;
+                        uy += sdz*dz_uy + 0.5_rt*sdz*sdz*dz_uy_dual.epsilon;
+                        psi += sdz*dz_psi + 0.5_rt*sdz*sdz*dz_psi_dual.epsilon;
+
+                    }
+
+                    // full push in position
+                    // from t to t+1
+                    // using the momentum at t+1/2
+                    xp += dz*clight_inv*(ux * (1._rt/psi));
+                    yp += dz*clight_inv*(uy * (1._rt/psi));
+
+                    if (enforceBC(ptd, ip, xp, yp, ux, uy, PlasmaIdx::w)) return;
+                    ptd.pos(0, ip) = xp;
+                    ptd.pos(1, ip) = yp;
+
+                    if (!temp_slice) {
+                        // update values of the last non temp slice
+                        // the next push always starts from these
+                        ptd.rdata(PlasmaIdx::ux_half_step)[ip] = ux;
+                        ptd.rdata(PlasmaIdx::uy_half_step)[ip] = uy;
+                        ptd.rdata(PlasmaIdx::psi_half_step)[ip] = psi;
+                        ptd.rdata(PlasmaIdx::x_prev)[ip] = xp;
+                        ptd.rdata(PlasmaIdx::y_prev)[ip] = yp;
+                    }
+
+                    // half push in momentum
+                    // from t+1/2 to t+1
+                    // still using the fields at t as an approximation
+                    // the result is used for current deposition etc. but not in the pusher
+                    for (int isub=0; isub<(nsub/2); ++isub) {
+
+                        const amrex::Real psi_inv = 1._rt/psi;
+
+                        auto [dz_ux, dz_uy, dz_psi] = PlasmaMomentumPush(
+                            ux, uy, psi_inv, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
+                            Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
+
+                        const DualNumber ux_dual{ux, dz_ux};
+                        const DualNumber uy_dual{uy, dz_uy};
+                        const DualNumber psi_inv_dual{psi_inv, -psi_inv*psi_inv*dz_psi};
+
+                        auto [dz_ux_dual, dz_uy_dual, dz_psi_dual] = PlasmaMomentumPush(
+                            ux_dual, uy_dual, psi_inv_dual, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
+                            Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
+
+                        ux += sdz*dz_ux + 0.5_rt*sdz*sdz*dz_ux_dual.epsilon;
+                        uy += sdz*dz_uy + 0.5_rt*sdz*sdz*dz_uy_dual.epsilon;
+                        psi += sdz*dz_psi + 0.5_rt*sdz*sdz*dz_psi_dual.epsilon;
+
+                    }
+                    ptd.rdata(PlasmaIdx::ux)[ip] = ux;
+                    ptd.rdata(PlasmaIdx::uy)[ip] = uy;
+                    ptd.rdata(PlasmaIdx::psi)[ip] = psi;
+#else
+                    amrex::Real ux = ptd.rdata(PlasmaIdx::ux_half_step)[ip];
+                    amrex::Real uy = ptd.rdata(PlasmaIdx::uy_half_step)[ip];
+                    amrex::Real psi = ptd.rdata(PlasmaIdx::psi_half_step)[ip];
+                    const amrex::Real psi_inv = 1._rt/psi;
+
+                    auto [dz_ux, dz_uy, dz_psi] = PlasmaMomentumPush(
+                        ux, uy, psi_inv, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
+                        Aabssqp, AabssqDxp, AabssqDyp, clight_inv, q_mass_clight_ratio);
+
+                    ptd.rdata(PlasmaIdx::Fx1)[ip] = clight_inv*(ux * psi_inv);
+                    ptd.rdata(PlasmaIdx::Fy1)[ip] = clight_inv*(uy * psi_inv);
+                    ptd.rdata(PlasmaIdx::Fux1)[ip] = dz_ux;
+                    ptd.rdata(PlasmaIdx::Fuy1)[ip] = dz_uy;
+                    ptd.rdata(PlasmaIdx::Fpsi1)[ip] = dz_psi;
+
+                    const amrex::Real ab5_coeffs[5] = {
+                        ( 1901._rt / 720._rt ) * dz,    // a1 times dz
+                        ( -1387._rt / 360._rt ) * dz,   // a2 times dz
+                        ( 109._rt / 30._rt ) * dz,      // a3 times dz
+                        ( -637._rt / 360._rt ) * dz,    // a4 times dz
+                        ( 251._rt / 720._rt ) * dz      // a5 times dz
+                    };
 
 #ifdef AMREX_USE_GPU
 #pragma unroll
 #endif
-                        for (int iab=0; iab<5; ++iab) {
-                            xp  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fx1   + iab)[ip];
-                            yp  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fy1   + iab)[ip];
-                            ux  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fux1  + iab)[ip];
-                            uy  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fuy1  + iab)[ip];
-                            psi += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fpsi1 + iab)[ip];
-                        }
+                    for (int iab=0; iab<5; ++iab) {
+                        xp  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fx1   + iab)[ip];
+                        yp  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fy1   + iab)[ip];
+                        ux  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fux1  + iab)[ip];
+                        uy  += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fuy1  + iab)[ip];
+                        psi += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fpsi1 + iab)[ip];
+                    }
 
-                        if (enforceBC(ptd, ip, xp, yp, ux, uy, PlasmaIdx::w)) return;
-                        ptd.pos(0, ip) = xp;
-                        ptd.pos(1, ip) = yp;
+                    if (enforceBC(ptd, ip, xp, yp, ux, uy, PlasmaIdx::w)) return;
+                    ptd.pos(0, ip) = xp;
+                    ptd.pos(1, ip) = yp;
 
-                        if (!temp_slice) {
-                            // update values of the last non temp slice
-                            // the next push always starts from these
-                            ptd.rdata(PlasmaIdx::ux_half_step)[ip] = ux;
-                            ptd.rdata(PlasmaIdx::uy_half_step)[ip] = uy;
-                            ptd.rdata(PlasmaIdx::psi_half_step)[ip] = psi;
-                            ptd.rdata(PlasmaIdx::x_prev)[ip] = xp;
-                            ptd.rdata(PlasmaIdx::y_prev)[ip] = yp;
-                        }
+                    if (!temp_slice) {
+                        // update values of the last non temp slice
+                        // the next push always starts from these
+                        ptd.rdata(PlasmaIdx::ux_half_step)[ip] = ux;
+                        ptd.rdata(PlasmaIdx::uy_half_step)[ip] = uy;
+                        ptd.rdata(PlasmaIdx::psi_half_step)[ip] = psi;
+                        ptd.rdata(PlasmaIdx::x_prev)[ip] = xp;
+                        ptd.rdata(PlasmaIdx::y_prev)[ip] = yp;
+                    }
 
-                        ptd.rdata(PlasmaIdx::ux)[ip] = ux;
-                        ptd.rdata(PlasmaIdx::uy)[ip] = uy;
-                        ptd.rdata(PlasmaIdx::psi)[ip] = psi;
+                    ptd.rdata(PlasmaIdx::ux)[ip] = ux;
+                    ptd.rdata(PlasmaIdx::uy)[ip] = uy;
+                    ptd.rdata(PlasmaIdx::psi)[ip] = psi;
 #endif
-                    } // loop over subcycles
-                });
-        }
+                } // loop over subcycles
+            });
 
 #ifdef HIPACE_USE_AB5_PUSH
         if (!temp_slice) {

--- a/src/utils/OMPUtil.H
+++ b/src/utils/OMPUtil.H
@@ -1,0 +1,54 @@
+/* Copyright 2024
+ *
+ * This file is part of HiPACE++.
+ *
+ * Authors: AlexanderSinn
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef HIPACE_OMPUTIL_H_
+#define HIPACE_OMPUTIL_H_
+
+#include <AMReX_Gpu.H>
+#include <AMReX_MFIter.H>
+
+#include <array>
+
+namespace omp {
+
+#if defined(AMREX_USE_GPU) || !defined(AMREX_USE_OMP)
+using amrex::ParallelFor;
+#else
+
+// When compiling for CPUs, amrex::ParallelFor only uses a single OMP thread.
+// Some ParallelFor loops in hipace are outside MFIter loops, so to use multiple threads
+// we need to define our own PrallelFor that uses OMP when compiling for CPU.
+// When compiling for GPU the normal amrex::ParallelFor is used.
+
+// 1D ParallelFor
+template <typename T, typename F>
+void ParallelFor (T n, F&& f) noexcept
+{
+#pragma omp parallel for simd
+    for (T i = 0; i < n; ++i) {
+        f(i);
+    }
+}
+
+// 1D ParallelFor with CTO
+template <typename T, class F, typename... CTOs>
+void ParallelFor (amrex::TypeList<CTOs...> ctos,
+                  std::array<int,sizeof...(CTOs)> const& runtime_options,
+                  T N, F&& f)
+{
+    amrex::AnyCTO(ctos, runtime_options,
+        [&](auto cto_func){
+            ParallelFor(N, cto_func);
+        },
+        std::forward<F>(f)
+    );
+}
+
+#endif
+}
+
+#endif


### PR DESCRIPTION
When compiling for CPUs, amrex::ParallelFor only uses a single OMP thread. Some ParallelFor loops in hipace are outside MFIter loops, so to use multiple threads we need to define our own PrallelFor that uses OMP when compiling for CPU.

When compiling for GPU the normal  amrex::ParallelFor is used.

The new omp ParallelFor is used in both the beam and plasma pushers. The plasma pusher was omp parallelized previously. The new version has the same performance but is cleaner (hide whitespace). The beam pusher was not omp parallelized before and could be comparatively very slow when using many threads. Now it's fast.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
