### PR TITLE
Add nanoseconds per particle push printout

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -266,6 +266,17 @@ public:
     OpenPMDWriter m_openpmd_writer;
 #endif
 
+    // Performance Counters
+
+    /** total number of plasma particle pushes for performance printout */
+    inline static double m_num_plasma_particles_pushed = 0;
+    /** total number of beam particle pushes for performance printout */
+    inline static double m_num_beam_particles_pushed = 0;
+    /** total number of field cell updates for performance printout */
+    inline static double m_num_field_cells_updated = 0;
+    /** total number of laser cell updates for performance printout */
+    inline static double m_num_laser_cells_updated = 0;
+
     // SALAME
 
     /** the number of SALAME iterations to be done */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -508,7 +508,7 @@ Hipace::Evolve ()
 
     if (m_verbose >= 1) {
         // print total time, time per particle push and time per cell update
-        amrex::ParallelDescriptor::ReduceRealSum({
+        amrex::ParallelDescriptor::ReduceRealSum(amrex::Vector<std::reference_wrapper<double>>{
             m_num_plasma_particles_pushed,
             m_num_beam_particles_pushed,
             m_num_field_cells_updated,

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -21,6 +21,7 @@
 
 #include <AMReX_ParmParse.H>
 #include <AMReX_IntVect.H>
+#include <AMReX_IOFormat.H>
 #ifdef AMREX_USE_LINEAR_SOLVERS
 #  include <AMReX_MLALaplacian.H>
 #  include <AMReX_MLMG.H>
@@ -504,6 +505,52 @@ Hipace::Evolve ()
 
         FlushDiagnostics();
     }
+
+    if (m_verbose >= 1) {
+        // print total time, time per particle push and time per cell update
+        amrex::ParallelDescriptor::ReduceRealSum({
+            m_num_plasma_particles_pushed,
+            m_num_beam_particles_pushed,
+            m_num_field_cells_updated,
+            m_num_laser_cells_updated
+        }, HeadRankID());
+
+        if (HeadRank()) {
+            const double total_time_s = (amrex::second() - start_time);
+
+            amrex::IOFormatSaver iofmtsaver(std::cout);
+            std::cout << std::setprecision(4);
+
+            std::cout << '\n' << "Finished Evolve after " << total_time_s << " seconds using "
+                      << m_numprocs << (m_numprocs > 1 ? " ranks" : " rank" ) << std::endl;
+
+            if (m_num_plasma_particles_pushed + m_num_beam_particles_pushed > 0.) {
+                std::cout << "Total time per particle push: "
+                          << 1e9 * total_time_s /
+                            (m_num_plasma_particles_pushed + m_num_beam_particles_pushed)
+                          << " nanoseconds";
+                if (m_num_plasma_particles_pushed > 0. && m_num_beam_particles_pushed > 0.) {
+                    std::cout << " ("
+                              << 1e9 * total_time_s / m_num_plasma_particles_pushed << " plasma, "
+                              << 1e9 * total_time_s / m_num_beam_particles_pushed << " beam)";
+                }
+                std::cout << std::endl;
+            }
+
+            if (m_num_field_cells_updated + m_num_laser_cells_updated > 0.) {
+                std::cout << "Total time per cell update: "
+                          << 1e9 * total_time_s /
+                            (m_num_field_cells_updated + m_num_laser_cells_updated)
+                          << " nanoseconds";
+                if (m_num_field_cells_updated > 0. && m_num_laser_cells_updated > 0.) {
+                    std::cout << " ("
+                              << 1e9 * total_time_s / m_num_field_cells_updated << " field, "
+                              << 1e9 * total_time_s / m_num_laser_cells_updated << " laser)";
+                }
+                std::cout << std::endl;
+            }
+        }
+    }
 }
 
 void
@@ -526,6 +573,10 @@ Hipace::SolveOneSlice (int islice, int step)
             m_3D_geom[lev].Domain().bigEnd(Direction::z) >= islice) {
             current_N_level = lev + 1;
         }
+    }
+
+    for (int lev=0; lev<current_N_level; ++lev) {
+        m_num_field_cells_updated += m_slice_geom[lev].Domain().d_numPts();
     }
 
     if (islice == m_3D_geom[0].Domain().bigEnd(2)) {

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -728,6 +728,8 @@ MultiLaser::AdvanceSlice (const int islice, const Fields& fields, amrex::Real dt
 
     if (!UseLaser(islice)) return;
 
+    Hipace::m_num_laser_cells_updated += m_slice_box.d_numPts();
+
     InterpolateChi(fields, geom_field_lev0);
 
     if (m_solver_type == "multigrid") {

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -111,6 +111,9 @@ AdvanceBeamParticlesSlice (
     const amrex::Real E0 = Hipace::m_normalized_units ?
                            PhysConstSI::m_e * PhysConstSI::c / wp_inv / PhysConstSI::q_e : 1;
 
+    // don't include slipped particles in count as they were already pushed
+    Hipace::m_num_beam_particles_pushed += double(beam.getNumParticles(WhichBeamSlice::This));
+
     amrex::ParallelFor(
         amrex::TypeList<
             amrex::CompileTimeOptions<0, 1, 2, 3>,

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -67,6 +67,11 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
         const auto enforceBC = EnforceBC();
         const amrex::Real dz = gm[0].CellSize(2) / n_subcycles;
 
+        if (!temp_slice && lev == 0) {
+            // only count particles on non-temp slices and only once for all MR levels
+            Hipace::m_num_plasma_particles_pushed += double(pti.numParticles());
+        }
+
         const amrex::Real laser_norm = (plasma.m_charge/phys_const.q_e) * (phys_const.m_e/plasma.m_mass)
             * (plasma.m_charge/phys_const.q_e) * (phys_const.m_e/plasma.m_mass);
         const amrex::Real clight = phys_const.c;


### PR DESCRIPTION
```
Finished Evolve after 44.95 seconds using 4 ranks
Total time per particle push: 0.6635 nanoseconds (0.6701 plasma, 67.01 beam)
Total time per cell update: 0.6701 nanoseconds
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
