### PR TITLE
Fix float assert in Parser

### DIFF
--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -101,7 +101,7 @@ namespace Parser
         double v = parser.compileHost<0>()();
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             v <= std::numeric_limits<float>::max() &&
-            v >= std::numeric_limits<float>::min(),
+            v >= std::numeric_limits<float>::lowest(),
             "Error: Overflow detected when casting to float"
         );
         val = static_cast<float>(v);
@@ -113,7 +113,7 @@ namespace Parser
         amrex::Long v = parser.compileHost<0>()();
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             v <= std::numeric_limits<int>::max() &&
-            v >= std::numeric_limits<int>::min(),
+            v >= std::numeric_limits<int>::lowest(),
             "Error: Overflow detected when casting to int"
         );
         val = static_cast<int>(v);


### PR DESCRIPTION
`std::numeric_limits<float>::min()` is positive which would cause the assert to prevent negative values from being used in the input script.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
