### PR TITLE
Use amrex::GpuArray instead of std::array in deposition

### DIFF
--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -100,7 +100,8 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
                 beam.getNumParticles(which_beam_slice), is_valid, get_cell, deposit,
                 isl_fab.array(), isl_fab.box(),
                 beam.getBeamSlice(which_beam_slice).getParticleTileData(),
-                amrex::GpuArray<int, 0>{}, amrex::GpuArray{jxb_cmp, jyb_cmp, jzb_cmp, rhomjzb_cmp});
+                amrex::GpuArray<int, 0>{},
+                amrex::GpuArray<int, 4>{jxb_cmp, jyb_cmp, jzb_cmp, rhomjzb_cmp});
         },
         // is_valid
         // return whether the particle is valid and should deposit

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -100,7 +100,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
                 beam.getNumParticles(which_beam_slice), is_valid, get_cell, deposit,
                 isl_fab.array(), isl_fab.box(),
                 beam.getBeamSlice(which_beam_slice).getParticleTileData(),
-                std::array<int, 0>{}, std::array{jxb_cmp, jyb_cmp, jzb_cmp, rhomjzb_cmp});
+                amrex::GpuArray<int, 0>{}, amrex::GpuArray{jxb_cmp, jyb_cmp, jzb_cmp, rhomjzb_cmp});
         },
         // is_valid
         // return whether the particle is valid and should deposit

--- a/src/particles/deposition/DepositionUtil.H
+++ b/src/particles/deposition/DepositionUtil.H
@@ -155,8 +155,8 @@ SharedMemoryDeposition (int num_particles,
                 }
 
                 // calculate the local field components of the shared memory
-                std::array<int, max_cache> loc_idx_cache;
-                std::array<int, max_depos> loc_idx_depos;
+                amrex::GpuArray<int, max_cache> loc_idx_cache;
+                amrex::GpuArray<int, max_depos> loc_idx_depos;
 
                 for (int n=0; n != max_cache; ++n) {
                     loc_idx_cache[n] = (dynamic_comps && idx_cache[n]==-1) ? -1 : n;

--- a/src/particles/deposition/DepositionUtil.H
+++ b/src/particles/deposition/DepositionUtil.H
@@ -38,15 +38,15 @@
  */
 template<int stencil_x, int stencil_y, bool dynamic_comps,
          class F1, class F2, class F3,
-         std::size_t max_depos, std::size_t max_cache,
+         unsigned int max_depos, unsigned int max_cache,
          class PTD>
 AMREX_FLATTEN
 void
 SharedMemoryDeposition (int num_particles,
                         F1&& is_valid, F2&& get_start_cell, F3&& do_deposit,
                         Array3<amrex::Real> field, amrex::Box box, const PTD& ptd,
-                        std::array<int, max_cache> idx_cache,
-                        std::array<int, max_depos> idx_depos) {
+                        amrex::GpuArray<int, max_cache> idx_cache,
+                        amrex::GpuArray<int, max_depos> idx_depos) {
 #ifdef AMREX_USE_GPU
     if (Hipace::m_do_shared_depos) {
         constexpr int threads_per_tile = 256;

--- a/src/particles/deposition/ExplicitDeposition.cpp
+++ b/src/particles/deposition/ExplicitDeposition.cpp
@@ -83,13 +83,13 @@ ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields,
                     SharedMemoryDeposition<stencil_size, stencil_size, false>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        std::array{Bz, Ez, ExmBy, EypBx, aabs_comp}, std::array{Sy, Sx});
+                        amrex::GpuArray{Bz, Ez, ExmBy, EypBx, aabs_comp}, amrex::GpuArray{Sy, Sx});
                 } else {
                     constexpr int stencil_size = depos_order + derivative_type + 1;
                     SharedMemoryDeposition<stencil_size, stencil_size, false>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        std::array{Bz, Ez, ExmBy, EypBx}, std::array{Sy, Sx});
+                        amrex::GpuArray{Bz, Ez, ExmBy, EypBx}, amrex::GpuArray{Sy, Sx});
                 }
             },
             // is_valid

--- a/src/particles/deposition/ExplicitDeposition.cpp
+++ b/src/particles/deposition/ExplicitDeposition.cpp
@@ -83,13 +83,15 @@ ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields,
                     SharedMemoryDeposition<stencil_size, stencil_size, false>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        amrex::GpuArray{Bz, Ez, ExmBy, EypBx, aabs_comp}, amrex::GpuArray{Sy, Sx});
+                        amrex::GpuArray<int, 5>{Bz, Ez, ExmBy, EypBx, aabs_comp},
+                        amrex::GpuArray<int, 2>{Sy, Sx});
                 } else {
                     constexpr int stencil_size = depos_order + derivative_type + 1;
                     SharedMemoryDeposition<stencil_size, stencil_size, false>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        amrex::GpuArray{Bz, Ez, ExmBy, EypBx}, amrex::GpuArray{Sy, Sx});
+                        amrex::GpuArray<int, 4>{Bz, Ez, ExmBy, EypBx},
+                        amrex::GpuArray<int, 2>{Sy, Sx});
                 }
             },
             // is_valid

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -111,12 +111,12 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
                     SharedMemoryDeposition<stencil_size, stencil_size, true>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        std::array{aabs}, std::array{jx, jy, jz, rho, chi, rhomjz});
+                        amrex::GpuArray{aabs}, amrex::GpuArray{jx, jy, jz, rho, chi, rhomjz});
                 } else {
                     SharedMemoryDeposition<stencil_size, stencil_size, true>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        std::array<int, 0>{}, std::array{jx, jy, jz, rho, chi, rhomjz});
+                        amrex::GpuArray<int, 0>{}, amrex::GpuArray{jx, jy, jz, rho, chi, rhomjz});
                 }
             },
             // is_valid

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -118,7 +118,7 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
                         amrex::GpuArray<int, 0>{},
-                        amrex::GpuArray<int, 6{jx, jy, jz, rho, chi, rhomjz});
+                        amrex::GpuArray<int, 6>{jx, jy, jz, rho, chi, rhomjz});
                 }
             },
             // is_valid

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -111,12 +111,14 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
                     SharedMemoryDeposition<stencil_size, stencil_size, true>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        amrex::GpuArray{aabs}, amrex::GpuArray{jx, jy, jz, rho, chi, rhomjz});
+                        amrex::GpuArray<int, 1>{aabs},
+                        amrex::GpuArray<int, 6>{jx, jy, jz, rho, chi, rhomjz});
                 } else {
                     SharedMemoryDeposition<stencil_size, stencil_size, true>(
                         int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
-                        amrex::GpuArray<int, 0>{}, amrex::GpuArray{jx, jy, jz, rho, chi, rhomjz});
+                        amrex::GpuArray<int, 0>{},
+                        amrex::GpuArray<int, 6{jx, jy, jz, rho, chi, rhomjz});
                 }
             },
             // is_valid


### PR DESCRIPTION
`std::array` should also work on GPU, like in the HIP CI, however on LUMI it doesn't.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
