### PR TITLE
Laser circular polarization

### DIFF
--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -194,6 +194,7 @@ private:
      * the central wavelength influences the solver. As long as all the lasers are on the same grid
      * (part of MultiLaser), this must be a property of MultiLaser. */
     amrex::Real m_lambda0 {0.};
+    bool m_linear_polarization {true}; /**< Whether polarization is linear. Otherwise, circular */
     amrex::Vector<std::string> m_names {"no_laser"}; /**< name of the laser */
     int m_nlasers; /**< Number of laser pulses */
     amrex::Vector<Laser> m_all_lasers; /**< Each is a laser pulse */

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -34,6 +34,10 @@ MultiLaser::ReadParameters ()
     if (!m_use_laser) return;
     queryWithParser(pp, "lambda0", m_lambda0);
     DeprecatedInput("lasers", "3d_on_host", "comms_buffer.on_gpu", "", true);
+    std::string polarization = "linear";
+    queryWithParser(pp, "polarization", polarization);
+    AMREX_ALWAYS_ASSERT(polarization == "linear" || polarization == "circular");
+    m_linear_polarization = polarization == "linear" ? true : false;
     queryWithParser(pp, "use_phase", m_use_phase);
     queryWithParser(pp, "solver_type", m_solver_type);
     AMREX_ALWAYS_ASSERT(m_solver_type == "multigrid" || m_solver_type == "fft");
@@ -250,6 +254,7 @@ MultiLaser::UpdateLaserAabs (const int islice, const int current_N_level, Fields
         const int y_lo = m_slice_box.smallEnd(1);
         const int y_hi = m_slice_box.bigEnd(1);
 
+        const bool linear_polarization = m_linear_polarization;
         amrex::ParallelFor(
             amrex::TypeList<amrex::CompileTimeOptions<0, 1, 2, 3>>{},
             {m_interp_order},
@@ -279,7 +284,10 @@ MultiLaser::UpdateLaserAabs (const int islice, const int current_N_level, Fields
                         }
                     }
                 }
-
+                // The ponderomotive force is 2x larger in circular polarization:
+                // - circular: <|a|^2> = <|a_env|^2>
+                // - linear  : <|a|^2> = <|a_env|^2 * cos^2(k*z)> = <|a_env|^2> * 1/2
+                if (!linear_polarization) aabs *= 2;
                 field_arr(i,j) = aabs;
             });
     }

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -37,7 +37,7 @@ MultiLaser::ReadParameters ()
     std::string polarization = "linear";
     queryWithParser(pp, "polarization", polarization);
     AMREX_ALWAYS_ASSERT(polarization == "linear" || polarization == "circular");
-    m_linear_polarization = polarization == "linear" ? true : false;
+    m_linear_polarization = polarization == "linear";
     queryWithParser(pp, "use_phase", m_use_phase);
     queryWithParser(pp, "solver_type", m_solver_type);
     AMREX_ALWAYS_ASSERT(m_solver_type == "multigrid" || m_solver_type == "fft");


### PR DESCRIPTION
This PR proposes to add option for circular polarization for the laser. For the same peak vector potential, the ponderomotive force is 2x higher in circular polarization. This factor is directly applied when we store `|a^2|`, as I think this array is always used for ponderomotive force. This is done in `MultiLaser` as we cannot currently have different lasers with different polarization.

The option of laser polarization will also be relevant for PR #1190.