### PR TITLE
Re-enable warnings as errors in doxygen CI

### DIFF
--- a/.github/workflows/source/buildDoxygen
+++ b/.github/workflows/source/buildDoxygen
@@ -14,6 +14,6 @@ curl -L -o amrex-doxygen-web.tag.xml \
   https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml
 
 # treat all warnings as errors
-#echo "WARN_AS_ERROR = YES" >> Doxyfile
+echo "WARN_AS_ERROR = YES" >> Doxyfile
 
 doxygen


### PR DESCRIPTION
Now fixed in AMReX https://github.com/AMReX-Codes/amrex/pull/4314

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
