### PR TITLE
Remove invalid beam particle from first diagnostic step

### DIFF
--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -401,6 +401,10 @@ BeamParticleContainer::initializeSlice (int slice, int which_slice) {
             }
         );
     }
+
+    // remove invalid particles so they don't show up in the beam diagnostic of the first time step
+    amrex::removeInvalidParticles(getBeamSlice(which_slice));
+    resize(which_slice, getBeamSlice(which_slice).size(), 0);
 }
 
 void

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -102,7 +102,7 @@ namespace
         ptd.rdata(BeamIdx::ux )[ip] = uxp;
         ptd.rdata(BeamIdx::uy )[ip] = uyp;
         ptd.rdata(BeamIdx::uz )[ip] = uz * speed_of_light;
-        ptd.rdata(BeamIdx::w  )[ip] = std::abs(weight);
+        ptd.rdata(BeamIdx::w  )[ip] = is_valid ? std::abs(weight) : amrex::Real{0};
 
         ptd.idata(BeamIdx::nsubcycles)[ip] = 0;
         ptd.idata(BeamIdx::mr_level)[ip] = 0;

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -428,7 +428,6 @@ SalameMultiplyBeamWeight (const amrex::Real W, Hipace* hipace)
                 // invalidate particles with a weight of zero
                 if (W == 0) {
                     id.make_invalid();
-                    return;
                 }
 
                 // Multiply SALAME beam particles on this slice with W


### PR DESCRIPTION
When using a Gaussian fixed_weight beam with zmin and zmax, the particles outside the zmin and zmax range would be initialized as invalid particles. Outputting the beam in the first time step these would still be in the output (but not in the subsequent steps). When reading the file into another simulation, it would look like zmin and zmax was ignored.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
