### PR TITLE
New option to disable the pusher for plasma particles

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -519,6 +519,9 @@ When both are specified, the per-species value is used.
     the domain. However, this will also result in a gap at the domain boundary,
     which can lead to noise.
 
+* ``<plasma name> or plasmas.do_push`` (`bool`) optional (default `1`)
+    When set to `0`, disables the particle pusher.
+
 Beam parameters
 ---------------
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -698,12 +698,12 @@ Hipace::SolveOneSlice (int islice, int step)
     // plasma laser ionization
     m_multi_plasma.DoLaserIonization(islice, m_multi_laser.GetLaserGeom(), m_multi_laser);
 
-   
+
     // Push plasma particles
     for (int lev=0; lev<current_N_level; ++lev) {
         m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, false, lev);
     }
-    
+
 
     // get minimum beam acceleration on level 0
     m_adaptive_time_step.GatherMinAccSlice(m_multi_beam, m_3D_geom[0], m_fields);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -698,12 +698,10 @@ Hipace::SolveOneSlice (int islice, int step)
     // plasma laser ionization
     m_multi_plasma.DoLaserIonization(islice, m_multi_laser.GetLaserGeom(), m_multi_laser);
 
-
     // Push plasma particles
     for (int lev=0; lev<current_N_level; ++lev) {
         m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, false, lev, current_N_level);
     }
-
 
     // get minimum beam acceleration on level 0
     m_adaptive_time_step.GatherMinAccSlice(m_multi_beam, m_3D_geom[0], m_fields);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -698,10 +698,12 @@ Hipace::SolveOneSlice (int islice, int step)
     // plasma laser ionization
     m_multi_plasma.DoLaserIonization(islice, m_multi_laser.GetLaserGeom(), m_multi_laser);
 
+   
     // Push plasma particles
     for (int lev=0; lev<current_N_level; ++lev) {
         m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, false, lev);
     }
+    
 
     // get minimum beam acceleration on level 0
     m_adaptive_time_step.GatherMinAccSlice(m_multi_beam, m_3D_geom[0], m_fields);

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -101,7 +101,7 @@ MultiPlasma::AdvanceParticles (
 {
     for (int i=0; i<m_nplasmas; i++) {
         if (m_all_plasmas[i].m_do_push){
-            AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice, lev);
+            AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice, lev, current_N_level);
         }
     }
 }

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -99,7 +99,7 @@ MultiPlasma::AdvanceParticles (
     const Fields & fields, amrex::Vector<amrex::Geometry> const& gm, bool temp_slice, int lev)
 {
     for (int i=0; i<m_nplasmas; i++) {
-        if (m_all_plasmas[i].do_push){
+        if (m_all_plasmas[i].m_do_push){
             AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice, lev);
         }
     }

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -99,7 +99,9 @@ MultiPlasma::AdvanceParticles (
     const Fields & fields, amrex::Vector<amrex::Geometry> const& gm, bool temp_slice, int lev)
 {
     for (int i=0; i<m_nplasmas; i++) {
-        AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice, lev);
+        if (m_all_plasmas[i].do_push){
+            AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice, lev);
+        }
     }
 }
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -195,7 +195,7 @@ public:
     amrex::Real m_mass = 0; /**< mass of each particle of this species */
     amrex::Real m_charge = 0; /**< charge of each particle of this species, per Ion level */
     int m_n_subcycles = 1; /**< number of subcycles in the plasma particle push */
-    bool m_do_push = true; /**< whether the plasma pusher is disabled */
+    bool m_do_push = true; /**< whether the plasma pusher is enabled */
 
     // ionization:
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -195,7 +195,7 @@ public:
     amrex::Real m_mass = 0; /**< mass of each particle of this species */
     amrex::Real m_charge = 0; /**< charge of each particle of this species, per Ion level */
     int m_n_subcycles = 1; /**< number of subcycles in the plasma particle push */
-    bool m_do_push = true;
+    bool m_do_push = true; /**< whether the plasma pusher is disabled */
 
     // ionization:
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -195,6 +195,7 @@ public:
     amrex::Real m_mass = 0; /**< mass of each particle of this species */
     amrex::Real m_charge = 0; /**< charge of each particle of this species, per Ion level */
     int m_n_subcycles = 1; /**< number of subcycles in the plasma particle push */
+    bool m_do_push = true;
 
     // ionization:
 

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -174,6 +174,7 @@ PlasmaParticleContainer::ReadParameters ()
         "to use the fine plasma patch feature");
     queryWithParserAlt(pp, "prevent_centered_particle", m_prevent_centered_particle, pp_alt);
     queryWithParser(pp, "do_push", m_do_push);
+}
 
 void
 PlasmaParticleContainer::InitData (const amrex::Geometry& geom)

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -173,7 +173,7 @@ PlasmaParticleContainer::ReadParameters ()
         "Both 'fine_ppc' and 'fine_patch(x,y)' must be specified "
         "to use the fine plasma patch feature");
     queryWithParserAlt(pp, "prevent_centered_particle", m_prevent_centered_particle, pp_alt);
-}
+    queryWithParser(pp, "do_push", m_do_push);
 
 void
 PlasmaParticleContainer::InitData (const amrex::Geometry& geom)


### PR DESCRIPTION
New plasma and plasmas parameter to disable the particle pusher.
``<plasma>.do_push`` (or ` <plasmas>.do_push` for all species), by default set as `True`.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
