### PR TITLE
Fix issue with AB5 pusher and MR

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -700,7 +700,7 @@ Hipace::SolveOneSlice (int islice, int step)
 
     // Push plasma particles
     for (int lev=0; lev<current_N_level; ++lev) {
-        m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, false, lev);
+        m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, false, lev, current_N_level);
     }
 
     // get minimum beam acceleration on level 0
@@ -968,7 +968,7 @@ Hipace::PredictorCorrectorLoopToSolveBxBy (const int islice, const int current_N
 
         for (int lev=0; lev<current_N_level; ++lev) {
             // Push particles to the next temp slice
-            m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, true, lev);
+            m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, true, lev, current_N_level);
         }
 
         if (m_N_level > 1) {

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -75,9 +75,11 @@ public:
      * \param[in] gm Geometry of the simulation, to get the cell size etc.
      * \param[in] temp_slice if true, the temporary data (x_temp, ...) will be used
      * \param[in] lev MR level
+     * \param[in] current_N_level number of MR levels
      */
     void AdvanceParticles (
-        const Fields & fields, amrex::Vector<amrex::Geometry> const& gm, bool temp_slice, int lev);
+        const Fields & fields, amrex::Vector<amrex::Geometry> const& gm, bool temp_slice, int lev,
+        int const current_N_level);
 
     /** \brief Loop over plasma species and deposit their neutralizing background, if needed
      *

--- a/src/particles/plasma/MultiPlasma.cpp
+++ b/src/particles/plasma/MultiPlasma.cpp
@@ -96,10 +96,11 @@ MultiPlasma::ExplicitDeposition (Fields& fields, amrex::Vector<amrex::Geometry> 
 
 void
 MultiPlasma::AdvanceParticles (
-    const Fields & fields, amrex::Vector<amrex::Geometry> const& gm, bool temp_slice, int lev)
+    const Fields & fields, amrex::Vector<amrex::Geometry> const& gm, bool temp_slice, int lev,
+    int const current_N_level)
 {
     for (int i=0; i<m_nplasmas; i++) {
-        AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice, lev);
+        AdvancePlasmaParticles(m_all_plasmas[i], fields, gm, temp_slice, lev, current_N_level);
     }
 }
 

--- a/src/particles/pusher/PlasmaParticleAdvance.H
+++ b/src/particles/pusher/PlasmaParticleAdvance.H
@@ -19,10 +19,11 @@
  * \param[in] gm Geometry of the simulation, to get the cell size etc.
  * \param[in] temp_slice if true, the temporary data (x_temp, ...) will be used
  * \param[in] lev MR level
+ * \param[in] current_N_level number of MR levels
  */
 void
 AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Vector<amrex::Geometry> const& gm, const bool temp_slice,
-                        int const lev);
+                        int const lev, int const current_N_level);
 
 #endif //  PLASMAPARTICLEADVANCE_H_

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -29,7 +29,7 @@ template struct PlasmaMomentumDerivative<DualNumber>;
 void
 AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         amrex::Vector<amrex::Geometry> const& gm, const bool temp_slice,
-                        int const lev)
+                        int const lev, int const current_N_level)
 {
     HIPACE_PROFILE("AdvancePlasmaParticles()");
     using namespace amrex::literals;
@@ -272,7 +272,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
             });
 
 #ifdef HIPACE_USE_AB5_PUSH
-        if (!temp_slice) {
+        if (!temp_slice && lev == current_N_level - 1) {
             auto& rd = pti.GetStructOfArrays().GetRealData();
 
             // shift force terms

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -44,7 +44,8 @@ SalameModule (Hipace* hipace, const int n_iter, const bool do_advance, int& last
 
         for (int lev=0; lev<current_N_level; ++lev) {
             // advance plasma to the temp slice
-            hipace->m_multi_plasma.AdvanceParticles(hipace->m_fields, hipace->m_3D_geom, true, lev);
+            hipace->m_multi_plasma.AdvanceParticles(hipace->m_fields, hipace->m_3D_geom, true, lev,
+                                                    current_N_level);
 
             hipace->m_fields.duplicate(lev, WhichSlice::Salame, {"jx", "jy"},
                                             WhichSlice::Next, {"jx_beam", "jy_beam"});


### PR DESCRIPTION
There was an issue where, when using the AB5 plasma pusher and MR, the AB5 coefficients would be changed too quickly, causing incorrect results. See #1202

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
