### PR TITLE
RTD: Fix GA Integration

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,7 @@
 sphinx>=5.3
 sphinx-copybutton
 sphinx_rtd_theme>=1.1.1
+sphinxcontrib-googleanalytics
 recommonmark
 # docutils 0.17 breaks HTML tags & RTD theme
 # https://github.com/sphinx-doc/sphinx/issues/9001

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,12 @@ release = u'24.08'
 extensions = [
     "breathe",
     "sphinx_copybutton",
+    "sphinxcontrib.googleanalytics",
 ]
+
+# Google Analytics
+googleanalytics_id = "G-Z1D5ZZDNC6"
+googleanalytics_enabled = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
GA was dropped from RTD in early Oct, 2024. This adds it again.
