### PR TITLE
Remove conda from CI

### DIFF
--- a/.github/workflows/cudaLocal.yml
+++ b/.github/workflows/cudaLocal.yml
@@ -45,4 +45,5 @@ jobs:
     - name: Run Tests
       run: |
         source $HOME/profile.hipace
+        conda activate openpmd
         ctest --test-dir build --output-on-failure

--- a/.github/workflows/cudaLocal.yml
+++ b/.github/workflows/cudaLocal.yml
@@ -45,5 +45,4 @@ jobs:
     - name: Run Tests
       run: |
         source $HOME/profile.hipace
-        conda activate openpmd
         ctest --test-dir build --output-on-failure

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -31,11 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: s-weigand/setup-conda@v1
-      with:
-        update-conda: true
-        conda-channels: conda-forge
     - name: Install
-      run: conda install -c conda-forge doxygen
+      run: sudo apt-get install -y --no-install-recommends doxygen
     - name: Doxygen
       run: .github/workflows/source/buildDoxygen


### PR DESCRIPTION
Updating Conda now seems to introduce some broken environment variables https://github.com/Hi-PACE/hipace/actions/runs/13287421800/job/37166666339

One notable difference to when this was working is the new line `CI detected...` under updating Conda. Anaconda changed their license so maybe we should try to use apt now (like in the amrex doc CI).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
