### PR TITLE
Improve performance of in-situ diagnostic data reading

### DIFF
--- a/tools/read_insitu_diagnostics.py
+++ b/tools/read_insitu_diagnostics.py
@@ -11,10 +11,24 @@ import glob
 import json
 from scipy import constants
 
+def count_braces(b):
+    num_open_braces = 0
+    num_char = 0
+    for bb in b:
+        num_char += 1
+        if bb == b'{'[0]:
+            num_open_braces += 1
+        elif bb == b'}'[0]:
+            num_open_braces -= 1
+        if num_open_braces == 0:
+            break
+    return num_char
+
 def get_buffer(file):
     with open(file, "rb") as f:
         bytes = f.read()
-        datatype_obj = json.JSONDecoder().raw_decode(bytes.decode(errors="replace"))
+        end = count_braces(bytes)
+        datatype_obj = json.JSONDecoder().raw_decode(bytes[:end].decode())
     return {"buffer" : bytes, "dtype" : np.dtype(datatype_obj[0]), "offset" : datatype_obj[1]}
 
 def read_file(filenames):


### PR DESCRIPTION
By only decoding the part of the in-situ data that contains the JSON numpy datatype the time spent in read_file() can be significantly reduced.

PR
```
CPU times: user 5.92 s, sys: 4.23 s, total: 10.1 s
Wall time: 11.6 s
```
Dev
```
CPU times: user 45.2 s, sys: 6.52 s, total: 51.7 s
Wall time: 53.2 
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
