### PR TITLE
update openPMD to latest version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,8 @@ jobs:
           ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-
           ccache-windows-winmsvc-
     - name: install dependencies
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: 3.5
       run: |
         Invoke-WebRequest http://fftw.org/fftw-3.3.10.tar.gz -OutFile fftw-3.3.10.tar.gz
         7z.exe x -r fftw-3.3.10.tar.gz
@@ -32,6 +34,7 @@ jobs:
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build_fftw --config Debug --target install --parallel 2
         if(!$?) { Exit $LASTEXITCODE }
+        unset CMAKE_POLICY_VERSION_MINIMUM
     - name: Build & Install
       run: |
         $env:FFTW3_DIR = "C:/Program Files (x86)/fftw/"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,11 +24,13 @@ jobs:
           ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-
           ccache-windows-winmsvc-
     - name: install dependencies
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: 3.5
       run: |
         Invoke-WebRequest http://fftw.org/fftw-3.3.10.tar.gz -OutFile fftw-3.3.10.tar.gz
         7z.exe x -r fftw-3.3.10.tar.gz
         7z.exe x -r fftw-3.3.10.tar
-        cmake -S fftw-3.3.10 -B build_fftw -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        cmake -S fftw-3.3.10 -B build_fftw -DCMAKE_BUILD_TYPE=Debug
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build_fftw --config Debug --target install --parallel 2
         if(!$?) { Exit $LASTEXITCODE }
@@ -73,6 +75,8 @@ jobs:
         7z.exe x -r fftw-3.3.10.tar
     - name: install dependencies
       shell: cmd
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: 3.5
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         cmake -S fftw-3.3.10  ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,17 +24,14 @@ jobs:
           ccache-windows-winmsvc-${{ hashFiles('.github/workflows/windows.yml') }}-
           ccache-windows-winmsvc-
     - name: install dependencies
-      env:
-        CMAKE_POLICY_VERSION_MINIMUM: 3.5
       run: |
         Invoke-WebRequest http://fftw.org/fftw-3.3.10.tar.gz -OutFile fftw-3.3.10.tar.gz
         7z.exe x -r fftw-3.3.10.tar.gz
         7z.exe x -r fftw-3.3.10.tar
-        cmake -S fftw-3.3.10 -B build_fftw -DCMAKE_BUILD_TYPE=Debug
+        cmake -S fftw-3.3.10 -B build_fftw -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build_fftw --config Debug --target install --parallel 2
         if(!$?) { Exit $LASTEXITCODE }
-        unset CMAKE_POLICY_VERSION_MINIMUM
     - name: Build & Install
       run: |
         $env:FFTW3_DIR = "C:/Program Files (x86)/fftw/"

--- a/cmake/dependencies/openPMD.cmake
+++ b/cmake/dependencies/openPMD.cmake
@@ -13,7 +13,7 @@ function(find_openpmd)
     if(HiPACE_openpmd_internal OR HiPACE_openpmd_src)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-        # see https://openpmd-api.readthedocs.io/en/0.16.0/dev/buildoptions.html
+        # see https://openpmd-api.readthedocs.io/en/0.16.1/dev/buildoptions.html
         set(openPMD_USE_MPI         ${HiPACE_openpmd_mpi} CACHE INTERNAL "")
         set(openPMD_USE_PYTHON      OFF                   CACHE INTERNAL "")
         set(openPMD_BUILD_CLI_TOOLS OFF                   CACHE INTERNAL "")
@@ -63,7 +63,7 @@ function(find_openpmd)
         else()
             set(COMPONENT_WMPI NOMPI)
         endif()
-        find_package(openPMD 0.16.0 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
+        find_package(openPMD 0.16.1 CONFIG REQUIRED COMPONENTS ${COMPONENT_WMPI})
         message(STATUS "openPMD-api: Found version '${openPMD_VERSION}'")
     endif()
 endfunction()
@@ -79,7 +79,7 @@ if(HiPACE_OPENPMD)
     set(HiPACE_openpmd_repo "https://github.com/openPMD/openPMD-api.git"
         CACHE STRING
         "Repository URI to pull and build openPMD-api from if(HiPACE_openpmd_internal)")
-    set(HiPACE_openpmd_branch "0.16.0"
+    set(HiPACE_openpmd_branch "0.16.1"
         CACHE STRING
         "Repository branch for HiPACE_openpmd_repo if(HiPACE_openpmd_internal)")
 

--- a/docs/source/building/building.rst
+++ b/docs/source/building/building.rst
@@ -33,7 +33,7 @@ Please see installation instructions below in the Developers section.
 - a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B14>`__ compiler: e.g. GCC 7, Clang 7, NVCC 11.0, MSVC 19.15 or newer
 - `CMake 3.24.0+ <https://cmake.org/>`__
 - `AMReX development <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
-- `openPMD-api 0.16.0+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api
+- `openPMD-api 0.16.1+ <https://github.com/openPMD/openPMD-api>`__: we automatically download and compile a copy of openPMD-api
 
   - `HDF5 <https://support.hdfgroup.org/HDF5>`__ 1.8.13+ (optional; for ``.h5`` file support)
   - `ADIOS2 <https://github.com/ornladios/ADIOS2>`__ 2.7.0+ (optional; for ``.bp`` file support)
@@ -208,7 +208,7 @@ CMake Option                 Default & Values                                   
 ``HiPACE_openpmd_mpi``       ON/OFF (default is set to value of ``HiPACE_MPI``)  Build openPMD with MPI support, although I/O is always serial
 ``HiPACE_openpmd_src``       *None*                                              Path to openPMD-api source directory (preferred if set)
 ``HiPACE_openpmd_repo``      ``https://github.com/openPMD/openPMD-api.git``      Repository URI to pull and build openPMD-api from
-``HiPACE_openpmd_branch``    ``0.16.0``                                          Repository branch for ``HiPACE_openpmd_repo``
+``HiPACE_openpmd_branch``    ``0.16.1``                                          Repository branch for ``HiPACE_openpmd_repo``
 ``HiPACE_openpmd_internal``  **ON**/OFF                                          Needs a pre-installed openPMD-api library if set to ``OFF``
 ``AMReX_LINEAR_SOLVERS``     ON/**OFF**                                          Compile AMReX multigrid solver.
 ===========================  ==================================================  =============================================================


### PR DESCRIPTION
Now that the CI test use cmake 4.0 which drops backwards compatibility for 3.0 we need to update openPMD api to the latest version and tweak the fftw compile on windows.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
