### PR TITLE
Resize Beam Diagnostic buffer

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1182,15 +1182,13 @@ Hipace::WriteDiagnostics (const int step)
 {
 #ifdef HIPACE_USE_OPENPMD
     if (m_diags.hasAnyFieldOutput(step, m_max_step, m_physical_time, m_max_time)) {
-        m_openpmd_writer.WriteDiagnostics(m_diags.getFieldData(), m_multi_beam,
-                        m_multi_laser, m_physical_time, step, getDiagBeamNames(),
-                        m_3D_geom, OpenPMDWriterCallType::fields);
+        m_openpmd_writer.WriteFieldDiagnostics(m_diags.getFieldData(),
+            m_multi_laser, m_physical_time, step);
     }
 
     if (m_diags.hasBeamOutput(step, m_max_step, m_physical_time, m_max_time)) {
-        m_openpmd_writer.WriteDiagnostics(m_diags.getFieldData(), m_multi_beam,
-                        m_multi_laser, m_physical_time, step, getDiagBeamNames(),
-                        m_3D_geom, OpenPMDWriterCallType::beams);
+        m_openpmd_writer.WriteBeamDiagnostics(m_multi_beam, m_physical_time, step,
+            getDiagBeamNames(), m_3D_geom);
     }
 #else
     amrex::ignore_unused(step);

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -26,9 +26,6 @@
 #   include <openPMD/openPMD.hpp>
 #endif
 
-/** \brief Whether the beam, the field data is written, or if it is just flushing the stored data */
-enum struct OpenPMDWriterCallType { beams, fields };
-
 #ifdef HIPACE_USE_OPENPMD
 /** \brief class handling the IO with openPMD */
 class OpenPMDWriter
@@ -102,8 +99,8 @@ private:
     /** vector of length nbeams with the numbers of particles already written to file */
     amrex::Vector<uint64_t> m_offset;
 
-    std::vector<std::vector<std::shared_ptr<uint64_t>>> m_uint64_beam_data {};
-    std::vector<std::vector<std::shared_ptr<amrex::ParticleReal>>> m_real_beam_data {};
+    std::vector<std::vector<amrex::PinnedVector<uint64_t>>> m_uint64_beam_data {};
+    std::vector<std::vector<amrex::PinnedVector<amrex::ParticleReal>>> m_real_beam_data {};
 
 public:
     /** Constructor */
@@ -120,22 +117,29 @@ public:
      */
     void InitBeamData (MultiBeam& beams, const amrex::Vector< std::string > beamnames);
 
-    /** \brief writing openPMD data
+    /** \brief writing openPMD beam data
      *
-     * \param[in] field_diag field diagnostic data
-     * \param[in] a_multi_beams multi beam container which is written to openPMD file
+     * \param[in] a_multi_beam multi beam container which is written to openPMD file
      * \param[in] physical_time Physical time of the currenerationt it.
      * \param[in] output_step current iteration to be written to file
      * \param[in] beamnames list of the names of the beam to be written to file
      * \param[in] geom3D 3D Geometry of the simulation, to get the cell size etc.
-     * \param[in] call_type whether the beams or the fields should be written to file
      */
-    void WriteDiagnostics (
-        const amrex::Vector<FieldDiagnosticData>& field_diag, MultiBeam& a_multi_beam,
-        const MultiLaser& a_multi_laser, const amrex::Real physical_time, const int output_step,
+    void WriteBeamDiagnostics (
+        MultiBeam& a_multi_beam, const amrex::Real physical_time, const int output_step,
         const amrex::Vector< std::string > beamnames,
-        amrex::Vector<amrex::Geometry> const& geom3D,
-        const OpenPMDWriterCallType call_type);
+        amrex::Vector<amrex::Geometry> const& geom3D);
+
+    /** \brief writing openPMD field data
+     *
+     * \param[in] field_diag field diagnostic data
+     * \param[in] a_multi_laser multi laser to get lambda0
+     * \param[in] physical_time Physical time of the currenerationt it.
+     * \param[in] output_step current iteration to be written to file
+     */
+    void WriteFieldDiagnostics (
+        const amrex::Vector<FieldDiagnosticData>& field_diag,
+        const MultiLaser& a_multi_laser, const amrex::Real physical_time, const int output_step);
 
     /** \brief Copy beam data into IO buffer
      *

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -99,8 +99,8 @@ private:
     /** vector of length nbeams with the numbers of particles already written to file */
     amrex::Vector<uint64_t> m_offset;
 
-    std::vector<std::vector<amrex::PinnedVector<uint64_t>>> m_uint64_beam_data {};
-    std::vector<std::vector<amrex::PinnedVector<amrex::ParticleReal>>> m_real_beam_data {};
+    std::vector<std::vector<amrex::Gpu::PinnedVector<uint64_t>>> m_uint64_beam_data {};
+    std::vector<std::vector<amrex::Gpu::PinnedVector<amrex::ParticleReal>>> m_real_beam_data {};
 
 public:
     /** Constructor */

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -60,23 +60,28 @@ OpenPMDWriter::InitDiagnostics ()
 }
 
 void
-OpenPMDWriter::WriteDiagnostics (
-    const amrex::Vector<FieldDiagnosticData>& field_diag, MultiBeam& a_multi_beam,
-    const MultiLaser& a_multi_laser, const amrex::Real physical_time, const int output_step,
+OpenPMDWriter::WriteBeamDiagnostics (
+    MultiBeam& a_multi_beam, const amrex::Real physical_time, const int output_step,
     const amrex::Vector< std::string > beamnames,
-    amrex::Vector<amrex::Geometry> const& geom3D,
-    const OpenPMDWriterCallType call_type)
+    amrex::Vector<amrex::Geometry> const& geom3D)
 {
     openPMD::Iteration iteration = m_outputSeries->iterations[output_step];
     iteration.setTime(physical_time);
 
-    if (call_type == OpenPMDWriterCallType::beams ) {
-        WriteBeamParticleData(a_multi_beam, iteration, geom3D[0], beamnames);
-    } else if (call_type == OpenPMDWriterCallType::fields) {
-        for (const auto& fd : field_diag) {
-            if (fd.m_has_field) {
-                WriteFieldData(fd, a_multi_laser, iteration);
-            }
+    WriteBeamParticleData(a_multi_beam, iteration, geom3D[0], beamnames);
+}
+
+void
+OpenPMDWriter::WriteFieldDiagnostics (
+    const amrex::Vector<FieldDiagnosticData>& field_diag,
+    const MultiLaser& a_multi_laser, const amrex::Real physical_time, const int output_step)
+{
+    openPMD::Iteration iteration = m_outputSeries->iterations[output_step];
+    iteration.setTime(physical_time);
+
+    for (const auto& fd : field_diag) {
+        if (fd.m_has_field) {
+            WriteFieldData(fd, a_multi_laser, iteration);
         }
     }
 }
@@ -176,13 +181,7 @@ OpenPMDWriter::InitBeamData (MultiBeam& beams, const amrex::Vector< std::string 
         m_uint64_beam_data[ibeam].resize(m_int_names.size());
 
         for (std::size_t idx=0; idx<m_uint64_beam_data[ibeam].size(); idx++) {
-            m_uint64_beam_data[ibeam][idx].reset(
-                reinterpret_cast<uint64_t*>(
-                    amrex::The_Pinned_Arena()->alloc(sizeof(uint64_t)*np_total)
-                ),
-                [](uint64_t *p){
-                    amrex::The_Pinned_Arena()->free(reinterpret_cast<void*>(p));
-                });
+            m_uint64_beam_data[ibeam][idx].resize(np_total);
         }
 
         if (beams.getBeam(ibeam).m_do_spin_tracking) {
@@ -192,13 +191,7 @@ OpenPMDWriter::InitBeamData (MultiBeam& beams, const amrex::Vector< std::string 
         }
 
         for (std::size_t idx=0; idx<m_real_beam_data[ibeam].size(); idx++) {
-            m_real_beam_data[ibeam][idx].reset(
-                reinterpret_cast<amrex::ParticleReal*>(
-                    amrex::The_Pinned_Arena()->alloc(sizeof(amrex::ParticleReal)*np_total)
-                ),
-                [](amrex::ParticleReal *p){
-                    amrex::The_Pinned_Arena()->free(reinterpret_cast<void*>(p));
-                });
+            m_real_beam_data[ibeam][idx].resize(np_total);
         }
 
         // if first slice of loop over slices, reset offset
@@ -245,7 +238,7 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
         }
 
         for (std::size_t idx=0; idx<m_uint64_beam_data[ibeam].size(); idx++) {
-            uint64_t * const uint64_data = m_uint64_beam_data[ibeam][idx].get();
+            uint64_t * const uint64_data = m_uint64_beam_data[ibeam][idx].data();
 
             for (uint64_t i=0; i<np_total; ++i) {
                 uint64_t id = uint64_data[i];
@@ -259,7 +252,7 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
             auto& currRecord = beam_species[record_name];
             auto& currRecordComp = currRecord[component_name];
             // not read until the data is flushed
-            currRecordComp.storeChunk(m_uint64_beam_data[ibeam][idx], {0ull}, {np_total});
+            currRecordComp.storeChunkRaw(m_uint64_beam_data[ibeam][idx].data(), {0ull}, {np_total});
         }
 
         for (std::size_t idx=0; idx<m_real_beam_data[ibeam].size(); idx++) {
@@ -268,7 +261,7 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
             auto& currRecord = beam_species[record_name];
             auto& currRecordComp = currRecord[component_name];
             // not read until the data is flushed
-            currRecordComp.storeChunk(m_real_beam_data[ibeam][idx], {0ull}, {np_total});
+            currRecordComp.storeChunkRaw(m_real_beam_data[ibeam][idx].data(), {0ull}, {np_total});
         }
     }
 }
@@ -293,10 +286,16 @@ OpenPMDWriter::CopyBeams (MultiBeam& beams, const amrex::Vector< std::string > b
             auto& soa = beam.getBeamSlice(WhichBeamSlice::This).GetStructOfArrays();
 
             for (std::size_t idx=0; idx<m_uint64_beam_data[ibeam].size(); idx++) {
+                const auto old_size = m_uint64_beam_data[ibeam][idx].size();
+                if (old_size < m_offset[ibeam] + np) {
+                    m_uint64_beam_data[ibeam][idx].resize(
+                        std::max<uint64_t>(5*old_size/4, m_offset[ibeam] + np)
+                    );
+                }
                 amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost,
                     soa.GetIdCPUData().begin(),
                     soa.GetIdCPUData().begin() + np,
-                    m_uint64_beam_data[ibeam][idx].get() + m_offset[ibeam]);
+                    m_uint64_beam_data[ibeam][idx].data() + m_offset[ibeam]);
             }
 
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -304,10 +303,16 @@ OpenPMDWriter::CopyBeams (MultiBeam& beams, const amrex::Vector< std::string > b
                 "List of real names in openPMD Writer class does not match the beam");
 
             for (std::size_t idx=0; idx<m_real_beam_data[ibeam].size(); idx++) {
+                const auto old_size = m_real_beam_data[ibeam][idx].size();
+                if (old_size < m_offset[ibeam] + np) {
+                    m_real_beam_data[ibeam][idx].resize(
+                        std::max<uint64_t>(5*old_size/4, m_offset[ibeam] + np)
+                    );
+                }
                 amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost,
                     soa.GetRealData(idx).begin(),
                     soa.GetRealData(idx).begin() + np,
-                    m_real_beam_data[ibeam][idx].get() + m_offset[ibeam]);
+                    m_real_beam_data[ibeam][idx].data() + m_offset[ibeam]);
             }
         }
 
@@ -431,12 +436,13 @@ OpenPMDWriter::SetupRealProperties (openPMD::ParticleSpecies& currSpecies,
 void OpenPMDWriter::flush ()
 {
     amrex::Gpu::streamSynchronize();
-    m_uint64_beam_data.resize(0);
-    m_real_beam_data.resize(0);
     if (m_outputSeries) {
         HIPACE_PROFILE("OpenPMDWriter::flush()");
         m_outputSeries->flush();
     }
+    // need to keep these alive until after the flush
+    m_uint64_beam_data.resize(0);
+    m_real_beam_data.resize(0);
     m_outputSeries.reset();
 }
 

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -225,7 +225,6 @@ OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration itera
         }
 
         // initialize beam IO on first slice
-        AMREX_ALWAYS_ASSERT(m_offset[ibeam] <= beam.getTotalNumParticles());
         const uint64_t np_total = m_offset[ibeam];
 
         SetupPos(beam_species, beam, np_total, geom);

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -289,7 +289,7 @@ OpenPMDWriter::CopyBeams (MultiBeam& beams, const amrex::Vector< std::string > b
                 const auto old_size = m_uint64_beam_data[ibeam][idx].size();
                 if (old_size < m_offset[ibeam] + np) {
                     m_uint64_beam_data[ibeam][idx].resize(
-                        std::max<uint64_t>(5*old_size/4, m_offset[ibeam] + np)
+                        std::max<uint64_t>(old_size+old_size/4, m_offset[ibeam] + np)
                     );
                 }
                 amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost,
@@ -306,7 +306,7 @@ OpenPMDWriter::CopyBeams (MultiBeam& beams, const amrex::Vector< std::string > b
                 const auto old_size = m_real_beam_data[ibeam][idx].size();
                 if (old_size < m_offset[ibeam] + np) {
                     m_real_beam_data[ibeam][idx].resize(
-                        std::max<uint64_t>(5*old_size/4, m_offset[ibeam] + np)
+                        std::max<uint64_t>(old_size+old_size/4, m_offset[ibeam] + np)
                     );
                 }
                 amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost,


### PR DESCRIPTION
When beam particles are injected from the plasma, the total number is not known from the start (an all ranks) so the diagnostic buffers need to be resized to avoid segfaults.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
