### PR TITLE
Fix shadow issue in AddGridExternalFields

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -1093,15 +1093,15 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
                 const amrex::Real y = j * dy + poff_y;
                 const amrex::Real z = islice * dz + poff_z;
 
-                const amrex::Real Bx = external_fields[0](x, y, z, time);
-                const amrex::Real By = external_fields[1](x, y, z, time);
-                const amrex::Real Bz = external_fields[2](x, y, z, time);
+                const amrex::Real Bxp = external_fields[0](x, y, z, time);
+                const amrex::Real Byp = external_fields[1](x, y, z, time);
+                const amrex::Real Bzp = external_fields[2](x, y, z, time);
 
-                arr(i, j, ExmBy) -= clight * By;
-                arr(i, j, EypBx) += clight * Bx;
-                arr(i, j, Bx) += Bx;
-                arr(i, j, By) += By;
-                arr(i, j, Bz) += Bz;
+                arr(i, j, ExmBy) -= clight * Byp;
+                arr(i, j, EypBx) += clight * Bxp;
+                arr(i, j, Bx) += Bxp;
+                arr(i, j, By) += Byp;
+                arr(i, j, Bz) += Bzp;
             });
     }
 }


### PR DESCRIPTION
Previously `arr(i, j, Bx)` would have used the value of the Bx field converted to int as the field index which was wrong.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
