### PR TITLE
Update Ubuntu version of CI tests

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -20,7 +20,7 @@ jobs:
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_nvcc:
     name: NVCC 11.8 SP
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.draft == false
     env:
       CXXFLAGS: "-Werror"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -20,7 +20,7 @@ jobs:
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_nvcc:
     name: NVCC 11.8 SP
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     env:
       CXXFLAGS: "-Werror"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -20,7 +20,7 @@ jobs:
 #   https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/
   build_nvcc:
     name: NVCC 11.8 SP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     env:
       CXXFLAGS: "-Werror"

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -12,7 +12,7 @@ on: [push, pull_request]
 jobs:
   build_hip:
     name: HIP SP
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # -Werror
     env: {CXXFLAGS: "-Wno-deprecated-declarations -Wno-error=pass-failed"}
     steps:
@@ -20,7 +20,7 @@ jobs:
 
     - name: install dependencies
       shell: bash
-      run: .github/workflows/setup/hip.sh 6.3.2
+      run: .github/workflows/setup/hip.sh
 
     - name: CCache Cache
       uses: actions/cache@v4

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -12,7 +12,7 @@ on: [push, pull_request]
 jobs:
   build_hip:
     name: HIP SP
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     # -Werror
     env: {CXXFLAGS: "-Wno-deprecated-declarations -Wno-error=pass-failed"}
     steps:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -12,7 +12,7 @@ on: [push, pull_request]
 jobs:
   build_hip:
     name: HIP SP
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # -Werror
     env: {CXXFLAGS: "-Wno-deprecated-declarations -Wno-error=pass-failed"}
     steps:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -12,7 +12,7 @@ on: [push, pull_request]
 jobs:
   build_hip:
     name: HIP SP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # -Werror
     env: {CXXFLAGS: "-Wno-deprecated-declarations -Wno-error=pass-failed"}
     steps:

--- a/.github/workflows/setup/hip.sh
+++ b/.github/workflows/setup/hip.sh
@@ -36,7 +36,9 @@ sudo apt-key add rocm.gpg.key
 
 source /etc/os-release  # set UBUNTU_CODENAME: focal or jammy or ...
 
-echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${1-latest} ${UBUNTU_CODENAME} main" \
+VERSION=${1-6.3.2}
+
+echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${VERSION} ${UBUNTU_CODENAME} main" \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
   | sudo tee -a /etc/profile.d/rocm.sh
@@ -58,10 +60,10 @@ sudo apt-get install -y --no-install-recommends \
     libzstd-dev     \
     ninja-build     \
     openmpi-bin     \
-    rocm-dev        \
-    rocfft-dev      \
-    rocprim-dev     \
-    rocrand-dev
+    rocm-dev${VERSION}    \
+    rocfft-dev${VERSION}  \
+    rocprim-dev${VERSION} \
+    rocrand-dev${VERSION}
 
 # activate
 #

--- a/.github/workflows/setup/hip.sh
+++ b/.github/workflows/setup/hip.sh
@@ -42,6 +42,7 @@ echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/r
   | sudo tee -a /etc/profile.d/rocm.sh
 # we should not need to export HIP_PATH=/opt/rocm/hip with those installs
 
+sudo apt-get clean
 sudo apt-get update
 
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#installing-development-packages-for-cross-compilation
@@ -60,8 +61,7 @@ sudo apt-get install -y --no-install-recommends \
     rocm-dev        \
     rocfft-dev      \
     rocprim-dev     \
-    rocrand-dev     \
-    hiprand-dev
+    rocrand-dev
 
 # activate
 #

--- a/.github/workflows/setup/hip.sh
+++ b/.github/workflows/setup/hip.sh
@@ -63,7 +63,8 @@ sudo apt-get install -y --no-install-recommends \
     rocm-dev${VERSION}    \
     rocfft-dev${VERSION}  \
     rocprim-dev${VERSION} \
-    rocrand-dev${VERSION}
+    rocrand-dev${VERSION} \
+    hiprand-dev${VERSION}
 
 # activate
 #


### PR DESCRIPTION
ubuntu-20.04 does not work anymore.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
