### PR TITLE
Fix laser from file hanging with MPI

### DIFF
--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -851,15 +851,6 @@ MultiLaser::InitLaserSlice (const int islice, const int comp)
                 );
                 AMREX_ASSERT_WITH_MESSAGE(laser.m_lambda0_from_file == m_lambda0 && m_lambda0 != 0,
                 "The central wavelength of laser from openPMD file and other lasers must be identical");
-                m_lambda0 = laser.m_lambda0_from_file;
-                 #ifdef AMREX_USE_MPI
-                // need to communicate m_lambda0 as it is read in from the input file only by the head rank
-                MPI_Bcast(&m_lambda0,
-                1,
-                amrex::ParallelDescriptor::Mpi_typemap<decltype(m_lambda0)>::type(),
-                Hipace::HeadRankID(),
-                amrex::ParallelDescriptor::Communicator());
-                #endif
             }
             if (laser.m_laser_init_type == "parser") {
                 auto profile_real = laser.m_profile_real;


### PR DESCRIPTION
PR #1157 added a something equivalent to this in InitLaserSlice():
``` C++
if (Hipace::HeadRank()) {
    MPI_Bcast(&m_lambda0,
        1,
        amrex::ParallelDescriptor::Mpi_typemap<decltype(m_lambda0)>::type(),
        Hipace::HeadRankID(),
        amrex::ParallelDescriptor::Communicator());
}
```
This hangs because the head rank is waiting for the other ranks to receive m_lambda0, but they never call MPI_Bcast and won't receive it. Some MPI implementations may not hang here due to using an internal buffer.

Since lambda0 is required to be set in the input and its asserted that that is the same as the one from the file, the MPI_Bcast can be removed without replacement.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
