### PR TITLE
Remove CONDA from CUDA Local CI

### DIFF
--- a/.github/workflows/cudaLocal.yml
+++ b/.github/workflows/cudaLocal.yml
@@ -45,4 +45,6 @@ jobs:
     - name: Run Tests
       run: |
         source $HOME/profile.hipace
+        python3 -m pip install --upgrade pip --user
+        python3 -m pip install --upgrade matplotlib numpy scipy openpmd-viewer openpmd-api lasy --user
         ctest --test-dir build --output-on-failure

--- a/.github/workflows/cudaLocal.yml
+++ b/.github/workflows/cudaLocal.yml
@@ -46,4 +46,5 @@ jobs:
       run: |
         source $HOME/profile.hipace
         conda activate openpmd
+        conda update --all
         ctest --test-dir build --output-on-failure

--- a/.github/workflows/cudaLocal.yml
+++ b/.github/workflows/cudaLocal.yml
@@ -45,6 +45,4 @@ jobs:
     - name: Run Tests
       run: |
         source $HOME/profile.hipace
-        conda activate openpmd
-        conda update --all
         ctest --test-dir build --output-on-failure


### PR DESCRIPTION
It looks like conda doesn't work anymore to install new packages or update existing ones. This PR switches to using pip.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
