### PR TITLE
Fix grid external fields by adding Psi

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -162,26 +162,12 @@ General parameters
     If a parameter is present multiple times then the last occurrence will be used.
     Note that this will include some default AMReX parameters.
 
-* ``hipace.grid_external_E(x,y,z,t)`` (3 `float`) optional (default `0. 0. 0.`)
-    External electric field applied to the field grid as a function of x, y, z and t.
+* ``hipace.grid_external_fields(x,y,z,t)`` (5 `float`) optional (default `0. 0. 0. 0. 0.`)
+    External fields applied to the field grid as a function of x, y, z and t.
     This will affect both beam and plasma particles, as well as the field diagnostics.
-    The components represent Ex, Ey and Ez respectively.
-    Note that z refers to the location of the beam particle inside the moving frame of reference
-    (zeta) and t to the physical time of the current time step.
-
-* ``hipace.grid_external_B(x,y,z,t)`` (3 `float`) optional (default `0. 0. 0.`)
-    External magnetic field applied to the field grid as a function of x, y, z and t.
-    This will affect both beam and plasma particles, as well as the field diagnostics.
-    The components represent Bx, By and Bz respectively.
-    Note that z refers to the location of the beam particle inside the moving frame of reference
-    (zeta) and t to the physical time of the current time step.
-
-* ``hipace.grid_external_Psi(x,y,z,t)`` (`float`) optional (default `0.`)
-    External plasma wake potential :math:`\Psi = \phi - cA_z`
-    applied to the field grid as a function of x, y, z and t. Must be specified when using
-    ``hipace.grid_external_E(x,y,z,t)`` or ``hipace.grid_external_B(x,y,z,t)`` such that it is
-    consistand with :math:`\frac{d}{dx} \Psi = - (E_x - c B_y)` and
-    :math:`\frac{d}{dy} \Psi = - (E_y + c B_x)`.
+    The components represent Bx, By, Bz, Psi and Ez respectively.
+    The plasma wake potential :math:`\Psi = \phi - cA_z` must satisfy
+    :math:`\frac{d}{dx} \Psi = - (E_x - c B_y)` and :math:`\frac{d}{dy} \Psi = - (E_y + c B_x)`.
     Note that z refers to the location of the beam particle inside the moving frame of reference
     (zeta) and t to the physical time of the current time step.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -176,6 +176,15 @@ General parameters
     Note that z refers to the location of the beam particle inside the moving frame of reference
     (zeta) and t to the physical time of the current time step.
 
+* ``hipace.grid_external_Psi(x,y,z,t)`` (`float`) optional (default `0.`)
+    External plasma wake potential :math:`\Psi = \phi - cA_z`
+    applied to the field grid as a function of x, y, z and t. Must be specified when using
+    ``hipace.grid_external_E(x,y,z,t)`` or ``hipace.grid_external_B(x,y,z,t)`` such that it is
+    consistand with :math:`\frac{d}{dx} \Psi = - (E_x - c B_y)` and
+    :math:`\frac{d}{dy} \Psi = - (E_y + c B_x)`.
+    Note that z refers to the location of the beam particle inside the moving frame of reference
+    (zeta) and t to the physical time of the current time step.
+
 Geometry
 --------
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -326,10 +326,10 @@ public:
 
     /** Whether grid external fields should be used for this beam */
     bool m_use_grid_external_fields = false;
-    /** Grid external field functions for Ex Ey Ez Bx By Bz Psi*/
-    amrex::GpuArray<amrex::ParserExecutor<4>, 7> m_grid_external_fields;
+    /** Grid external field functions for Bx By Bz Psi Ez*/
+    amrex::GpuArray<amrex::ParserExecutor<4>, 5> m_grid_external_fields;
     /** Owns data for m_grid_external_fields */
-    amrex::Array<amrex::Parser, 7> m_grid_external_fields_parser;
+    amrex::Array<amrex::Parser, 5> m_grid_external_fields_parser;
 
 private:
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -326,10 +326,10 @@ public:
 
     /** Whether grid external fields should be used for this beam */
     bool m_use_grid_external_fields = false;
-    /** Grid external field functions for Ex Ey Ez Bx By Bz */
-    amrex::GpuArray<amrex::ParserExecutor<4>, 6> m_grid_external_fields;
+    /** Grid external field functions for Ex Ey Ez Bx By Bz Psi*/
+    amrex::GpuArray<amrex::ParserExecutor<4>, 7> m_grid_external_fields;
     /** Owns data for m_grid_external_fields */
-    amrex::Array<amrex::Parser, 6> m_grid_external_fields_parser;
+    amrex::Array<amrex::Parser, 7> m_grid_external_fields_parser;
 
 private:
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -246,31 +246,12 @@ Hipace::Hipace () :
     }
 
     // external fields applied to the grid
-    amrex::Array<std::string, 3> field_str = {"0", "0", "0"};
-    m_use_grid_external_fields = queryWithParser(pph, "grid_external_E(x,y,z,t)", field_str);
-    m_grid_external_fields[0] = makeFunctionWithParser<4>(field_str[0],
-        m_grid_external_fields_parser[0], {"x", "y", "z", "t"});
-    m_grid_external_fields[1] = makeFunctionWithParser<4>(field_str[1],
-        m_grid_external_fields_parser[1], {"x", "y", "z", "t"});
-    m_grid_external_fields[2] = makeFunctionWithParser<4>(field_str[2],
-        m_grid_external_fields_parser[2], {"x", "y", "z", "t"});
-    field_str = {"0", "0", "0"};
-    m_use_grid_external_fields = queryWithParser(pph, "grid_external_B(x,y,z,t)", field_str)
-        || m_use_grid_external_fields;
-    m_grid_external_fields[3] = makeFunctionWithParser<4>(field_str[0],
-        m_grid_external_fields_parser[3], {"x", "y", "z", "t"});
-    m_grid_external_fields[4] = makeFunctionWithParser<4>(field_str[1],
-        m_grid_external_fields_parser[4], {"x", "y", "z", "t"});
-    m_grid_external_fields[5] = makeFunctionWithParser<4>(field_str[2],
-        m_grid_external_fields_parser[5], {"x", "y", "z", "t"});
-    std::string psi_str = "0";
-    bool psi_is_specified = queryWithParser(pph, "grid_external_Psi(x,y,z,t)", psi_str);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(psi_is_specified == m_use_grid_external_fields,
-        "Must specify 'grid_external_Psi(x,y,z,t)' when using "
-        "'grid_external_E(x,y,z,t)' or 'grid_external_B(x,y,z,t)'! Psi is defined by: "
-        "d/dx Psi = - (Ex - c*By) and d/dy Psi = - (Ey + c*Bx)");
-    m_grid_external_fields[6] = makeFunctionWithParser<4>(psi_str,
-        m_grid_external_fields_parser[6], {"x", "y", "z", "t"});
+    amrex::Array<std::string, 5> field_str = {"0", "0", "0", "0", "0"};
+    m_use_grid_external_fields = queryWithParser(pph, "grid_external_fields(x,y,z,t)", field_str);
+    for (int i = 0; i < 5; ++i) {
+        m_grid_external_fields[i] = makeFunctionWithParser<4>(field_str[i],
+            m_grid_external_fields_parser[i], {"x", "y", "z", "t"});
+    }
 }
 
 void
@@ -1124,21 +1105,23 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
     const amrex::Real dy = m_3D_geom[lev].CellSize(Direction::y);
     const amrex::Real dz = m_3D_geom[lev].CellSize(Direction::z);
 
+    const amrex::Real dx_inv = m_3D_geom[lev].InvCellSize(Direction::x);
+    const amrex::Real dy_inv = m_3D_geom[lev].InvCellSize(Direction::y);
+
     const amrex::Real poff_x = GetPosOffset(0, m_3D_geom[lev], m_3D_geom[lev].Domain());
     const amrex::Real poff_y = GetPosOffset(1, m_3D_geom[lev], m_3D_geom[lev].Domain());
     const amrex::Real poff_z = GetPosOffset(2, m_3D_geom[lev], m_3D_geom[lev].Domain());
 
     auto external_fields = m_grid_external_fields;
 
-    const int ExmBy = Comps[WhichSlice::This]["ExmBy"];
-    const int EypBx = Comps[WhichSlice::This]["EypBx"];
-    const int Ez = Comps[WhichSlice::This]["Ez"];
     const int Bx = Comps[WhichSlice::This]["By"];
     const int By = Comps[WhichSlice::This]["Bx"];
     const int Bz = Comps[WhichSlice::This]["Bz"];
     const int Psi = Comps[WhichSlice::This]["Psi"];
+    const int ExmBy = Comps[WhichSlice::This]["ExmBy"];
+    const int EypBx = Comps[WhichSlice::This]["EypBx"];
+    const int Ez = Comps[WhichSlice::This]["Ez"];
 
-    const amrex::Real clight = m_phys_const.c;
     const amrex::Real time = m_physical_time;
 
     amrex::MultiFab& slicemf = m_fields.getSlices(lev);
@@ -1157,23 +1140,29 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
             {
                 const amrex::Real x = i * dx + poff_x;
                 const amrex::Real y = j * dy + poff_y;
+                const amrex::Real xlo = (i-1) * dx + poff_x;
+                const amrex::Real ylo = (j-1) * dy + poff_y;
+                const amrex::Real xhi = (i+1) * dx + poff_x;
+                const amrex::Real yhi = (j+1) * dy + poff_y;
                 const amrex::Real z = islice * dz + poff_z;
 
-                const amrex::Real Exp = external_fields[0](x, y, z, time);
-                const amrex::Real Eyp = external_fields[1](x, y, z, time);
-                const amrex::Real Ezp = external_fields[2](x, y, z, time);
-                const amrex::Real Bxp = external_fields[3](x, y, z, time);
-                const amrex::Real Byp = external_fields[4](x, y, z, time);
-                const amrex::Real Bzp = external_fields[5](x, y, z, time);
-                const amrex::Real Psip = external_fields[6](x, y, z, time);
+                const amrex::Real Bxp = external_fields[0](x, y, z, time);
+                const amrex::Real Byp = external_fields[1](x, y, z, time);
+                const amrex::Real Bzp = external_fields[2](x, y, z, time);
+                const amrex::Real Psip = external_fields[3](x, y, z, time);
+                const amrex::Real Psipxlo = external_fields[3](xlo, y, z, time);
+                const amrex::Real Psipxhi = external_fields[3](xhi, y, z, time);
+                const amrex::Real Psipylo = external_fields[3](x, ylo, z, time);
+                const amrex::Real Psipyhi = external_fields[3](x, yhi, z, time);
+                const amrex::Real Ezp = external_fields[4](x, y, z, time);
 
-                arr(i, j, ExmBy) += Exp - clight * Byp;
-                arr(i, j, EypBx) += Eyp + clight * Bxp;
-                arr(i, j, Ez) += Ezp;
                 arr(i, j, Bx) += Bxp;
                 arr(i, j, By) += Byp;
                 arr(i, j, Bz) += Bzp;
                 arr(i, j, Psi) += Psip;
+                arr(i, j, ExmBy) += - (Psipxhi - Psipxlo) * dx_inv;
+                arr(i, j, EypBx) += - (Psipyhi - Psipylo) * dy_inv;
+                arr(i, j, Ez) += Ezp;
             });
     }
 }

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -263,6 +263,14 @@ Hipace::Hipace () :
         m_grid_external_fields_parser[4], {"x", "y", "z", "t"});
     m_grid_external_fields[5] = makeFunctionWithParser<4>(field_str[2],
         m_grid_external_fields_parser[5], {"x", "y", "z", "t"});
+    std::string psi_str = "0";
+    bool psi_is_specified = queryWithParser(pph, "grid_external_Psi(x,y,z,t)", psi_str);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(psi_is_specified == m_use_grid_external_fields,
+        "Must specify 'grid_external_Psi(x,y,z,t)' when using "
+        "'grid_external_E(x,y,z,t)' or 'grid_external_B(x,y,z,t)'! Psi is defined by: "
+        "d/dx Psi = - (Ex - c*By) and d/dy Psi = - (Ey + c*Bx)");
+    m_grid_external_fields[6] = makeFunctionWithParser<4>(psi_str,
+        m_grid_external_fields_parser[6], {"x", "y", "z", "t"});
 }
 
 void
@@ -1128,6 +1136,7 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
     const int Bx = Comps[WhichSlice::This]["By"];
     const int By = Comps[WhichSlice::This]["Bx"];
     const int Bz = Comps[WhichSlice::This]["Bz"];
+    const int Psi = Comps[WhichSlice::This]["Psi"];
 
     const amrex::Real clight = m_phys_const.c;
     const amrex::Real time = m_physical_time;
@@ -1156,6 +1165,7 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
                 const amrex::Real Bxp = external_fields[3](x, y, z, time);
                 const amrex::Real Byp = external_fields[4](x, y, z, time);
                 const amrex::Real Bzp = external_fields[5](x, y, z, time);
+                const amrex::Real Psip = external_fields[6](x, y, z, time);
 
                 arr(i, j, ExmBy) += Exp - clight * Byp;
                 arr(i, j, EypBx) += Eyp + clight * Bxp;
@@ -1163,6 +1173,7 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
                 arr(i, j, Bx) += Bxp;
                 arr(i, j, By) += Byp;
                 arr(i, j, Bz) += Bzp;
+                arr(i, j, Psi) += Psip;
             });
     }
 }

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -252,6 +252,8 @@ Hipace::Hipace () :
         m_grid_external_fields[i] = makeFunctionWithParser<4>(field_str[i],
             m_grid_external_fields_parser[i], {"x", "y", "z", "t"});
     }
+    DeprecatedInput("hipace", "grid_external_E(x,y,z,t)", "grid_external_fields(x,y,z,t)");
+    DeprecatedInput("hipace", "grid_external_B(x,y,z,t)", "grid_external_fields(x,y,z,t)");
 }
 
 void


### PR DESCRIPTION
Previously the grid external fields would have updated ExmBy and EypBx, however the beam and plasma particles actually gather the Psi field and calculate ExmBy and EypBx by taking the transverse derivative on the fly. So the Psi field also needs to be updated when using external fields.

This PR changes the interface to

```
hipace.grid_external_fields(x,y,z,t) = "Bx" "By" "Bz" "Psi" "Ez" 
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
