### PR TITLE
Only include openPMD.hpp in .cpp files that need it

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -29,10 +29,6 @@
 #  include <AMReX_MLMG.H>
 #endif
 
-#ifdef HIPACE_USE_OPENPMD
-#   include <openPMD/openPMD.hpp>
-#endif
-
 #include <memory>
 
 namespace hpmg { class MultiGrid; }

--- a/src/diagnostics/OpenPMDWriter.H
+++ b/src/diagnostics/OpenPMDWriter.H
@@ -22,9 +22,11 @@
 #include <cstdint>
 #include <vector>
 
-#ifdef HIPACE_USE_OPENPMD
-#   include <openPMD/openPMD.hpp>
-#endif
+namespace openPMD {
+    class Series;
+    class Iteration;
+    class ParticleSpecies;
+}
 
 #ifdef HIPACE_USE_OPENPMD
 /** \brief class handling the IO with openPMD */
@@ -58,7 +60,7 @@ private:
      * \param[in] geom Geometry of the simulation, to get the cell size etc.
      * \param[in] beamnames list of the names of the beam to be written to file
      */
-    void WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration iteration,
+    void WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration& iteration,
                                 const amrex::Geometry& geom,
                                 const amrex::Vector< std::string > beamnames);
 
@@ -69,7 +71,7 @@ private:
      * \param[in,out] iteration openPMD iteration to which the data is written
      */
     void WriteFieldData (const FieldDiagnosticData& fd, const MultiLaser& a_multi_laser,
-                         openPMD::Iteration iteration);
+                         openPMD::Iteration& iteration);
 
     /** Named Beam SoA attributes per particle as defined in BeamIdx
      */
@@ -105,6 +107,8 @@ private:
 public:
     /** Constructor */
     explicit OpenPMDWriter ();
+
+    ~OpenPMDWriter ();
 
     /** \brief Initialize diagnostics (collective operation)
      */

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -15,6 +15,71 @@
 
 #ifdef HIPACE_USE_OPENPMD
 
+#include <openPMD/openPMD.hpp>
+
+namespace utils {
+    std::pair< std::string, std::string >
+    name2openPMD ( std::string const& fullName )
+    {
+        std::string record_name = fullName;
+        std::string component_name = openPMD::RecordComponent::SCALAR;
+        std::size_t startComp = fullName.find_last_of("_");
+
+        if( startComp != std::string::npos ) {  // non-scalar
+            record_name = fullName.substr(0, startComp);
+            component_name = fullName.substr(startComp + 1u);
+        }
+        return make_pair(record_name, component_name);
+    }
+
+    /** Get the openPMD physical dimensionality of a record
+     *
+     * @param record_name name of the openPMD record
+     * @return map with base quantities and power scaling
+     */
+    std::map< openPMD::UnitDimension, double >
+    getUnitDimension ( std::string const & record_name )
+    {
+
+        if( record_name == "position" ) return {
+            {openPMD::UnitDimension::L,  1.}
+        };
+        else if( record_name == "positionOffset" ) return {
+            {openPMD::UnitDimension::L,  1.}
+        };
+        else if( record_name == "momentum" ) return {
+            {openPMD::UnitDimension::L,  1.},
+            {openPMD::UnitDimension::M,  1.},
+            {openPMD::UnitDimension::T, -1.}
+        };
+        else if( record_name == "charge" ) return {
+            {openPMD::UnitDimension::T,  1.},
+            {openPMD::UnitDimension::I,  1.}
+        };
+        else if( record_name == "mass" ) return {
+            {openPMD::UnitDimension::M,  1.}
+        };
+        else if( record_name == "E" ) return {
+            {openPMD::UnitDimension::L,  1.},
+            {openPMD::UnitDimension::M,  1.},
+            {openPMD::UnitDimension::T, -3.},
+            {openPMD::UnitDimension::I, -1.},
+        };
+        else if( record_name == "B" ) return {
+            {openPMD::UnitDimension::M,  1.},
+            {openPMD::UnitDimension::I, -1.},
+            {openPMD::UnitDimension::T, -2.}
+        };
+        else if( record_name == "spin" ) return {
+            {openPMD::UnitDimension::L,  2.},
+            {openPMD::UnitDimension::M,  1.},
+            {openPMD::UnitDimension::T, -1.}
+        };
+        else return {};
+    }
+}
+
+
 OpenPMDWriter::OpenPMDWriter ()
 {
     amrex::ParmParse pp("hipace");
@@ -45,6 +110,8 @@ OpenPMDWriter::OpenPMDWriter ()
     amrex::ParmParse ppd("diagnostic");
     queryWithParser(ppd, "openpmd_viewer_u_workaround", m_openpmd_viewer_workaround);
 }
+
+OpenPMDWriter::~OpenPMDWriter() {}
 
 void
 OpenPMDWriter::InitDiagnostics ()
@@ -88,7 +155,7 @@ OpenPMDWriter::WriteFieldDiagnostics (
 
 void
 OpenPMDWriter::WriteFieldData (
-    const FieldDiagnosticData& fd, const MultiLaser& a_multi_laser, openPMD::Iteration iteration)
+    const FieldDiagnosticData& fd, const MultiLaser& a_multi_laser, openPMD::Iteration& iteration)
 {
     HIPACE_PROFILE("OpenPMDWriter::WriteFieldData()");
 
@@ -200,7 +267,7 @@ OpenPMDWriter::InitBeamData (MultiBeam& beams, const amrex::Vector< std::string 
 }
 
 void
-OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration iteration,
+OpenPMDWriter::WriteBeamParticleData (MultiBeam& beams, openPMD::Iteration& iteration,
                                       const amrex::Geometry& geom,
                                       const amrex::Vector< std::string > beamnames)
 {

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -15,6 +15,10 @@
 #include <AMReX_ParmParse.H>
 #include "particles/particles_utils/ShapeFactors.H"
 
+#ifdef HIPACE_USE_OPENPMD
+#include <openPMD/openPMD.hpp>
+#endif
+
 Laser::Laser (std::string name,  amrex::Geometry laser_geom_3D)
 {
     m_name = name;

--- a/src/utils/IOUtil.H
+++ b/src/utils/IOUtil.H
@@ -17,10 +17,6 @@
 #include <iostream>
 #include <vector>
 
-#ifdef HIPACE_USE_OPENPMD
-#include <openPMD/openPMD.hpp>
-#endif
-
 namespace utils
 {
     /** Get the Relative Cell Position of Values in an MultiFab
@@ -60,19 +56,6 @@ namespace utils
      */
      bool doDiagnostics (int output_period, int output_step, int max_step,
                     amrex::Real output_time, amrex::Real max_time);
-
-#ifdef HIPACE_USE_OPENPMD
-    std::pair< std::string, std::string >
-    name2openPMD ( std::string const& fullName );
-
-    /** Get the openPMD physical dimensionality of a record
-     *
-     * @param record_name name of the openPMD record
-     * @return map with base quantities and power scaling
-     */
-    std::map< openPMD::UnitDimension, double >
-    getUnitDimension ( std::string const & record_name );
-#endif
 
     struct format_time {
         double seconds = 0;

--- a/src/utils/IOUtil.cpp
+++ b/src/utils/IOUtil.cpp
@@ -81,68 +81,6 @@ utils::doDiagnostics (int output_period, int output_step, int max_step,
         (output_step % output_period == 0) );
 }
 
-#ifdef HIPACE_USE_OPENPMD
-std::pair< std::string, std::string >
-utils::name2openPMD ( std::string const& fullName )
-{
-    std::string record_name = fullName;
-    std::string component_name = openPMD::RecordComponent::SCALAR;
-    std::size_t startComp = fullName.find_last_of("_");
-
-    if( startComp != std::string::npos ) {  // non-scalar
-        record_name = fullName.substr(0, startComp);
-        component_name = fullName.substr(startComp + 1u);
-    }
-    return make_pair(record_name, component_name);
-}
-
-/** Get the openPMD physical dimensionality of a record
- *
- * @param record_name name of the openPMD record
- * @return map with base quantities and power scaling
- */
-std::map< openPMD::UnitDimension, double >
-utils::getUnitDimension ( std::string const & record_name )
-{
-
-    if( record_name == "position" ) return {
-        {openPMD::UnitDimension::L,  1.}
-    };
-    else if( record_name == "positionOffset" ) return {
-        {openPMD::UnitDimension::L,  1.}
-    };
-    else if( record_name == "momentum" ) return {
-        {openPMD::UnitDimension::L,  1.},
-        {openPMD::UnitDimension::M,  1.},
-        {openPMD::UnitDimension::T, -1.}
-    };
-    else if( record_name == "charge" ) return {
-        {openPMD::UnitDimension::T,  1.},
-        {openPMD::UnitDimension::I,  1.}
-    };
-    else if( record_name == "mass" ) return {
-        {openPMD::UnitDimension::M,  1.}
-    };
-    else if( record_name == "E" ) return {
-        {openPMD::UnitDimension::L,  1.},
-        {openPMD::UnitDimension::M,  1.},
-        {openPMD::UnitDimension::T, -3.},
-        {openPMD::UnitDimension::I, -1.},
-    };
-    else if( record_name == "B" ) return {
-        {openPMD::UnitDimension::M,  1.},
-        {openPMD::UnitDimension::I, -1.},
-        {openPMD::UnitDimension::T, -2.}
-    };
-    else if( record_name == "spin" ) return {
-        {openPMD::UnitDimension::L,  2.},
-        {openPMD::UnitDimension::M,  1.},
-        {openPMD::UnitDimension::T, -1.}
-    };
-    else return {};
-}
-#endif
-
 std::ostream& operator<<(std::ostream& os, utils::format_time ft) {
     long long seconds = static_cast<long long>(std::floor(ft.seconds));
 


### PR DESCRIPTION
Adding `#include <openPMD/openPMD.hpp>` to a cpp file slows down compilation a bit due to the giant std::variant of all datatypes used by openPMD.

Using 50 threads, this speeds up compilation by 14% (about 10 seconds).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
