### PR TITLE
Replace `std::numeric_limits<>::infinity()` with `max()`

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -204,7 +204,7 @@ public:
     /** Number of time iterations */
     inline static int m_max_step = 0;
     /** Maximum simulation time */
-    inline static amrex::Real m_max_time = std::numeric_limits<amrex::Real>::infinity();
+    inline static amrex::Real m_max_time = std::numeric_limits<amrex::Real>::max();
     /** Physical time of the simulation. At the end of the time step, it is the physical time
      * at which the fields have been calculated. The beam is one step ahead. */
     inline static amrex::Real m_physical_time = 0.0;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -423,7 +423,7 @@ Hipace::Evolve ()
 
         m_physical_time = step == 0 ? m_initial_time : m_multi_buffer.get_time();
 
-        if (m_physical_time == std::numeric_limits<amrex::Real>::infinity()) {
+        if (m_physical_time == std::numeric_limits<amrex::Real>::max()) {
             if (step+1 <= m_max_step && !m_has_last_step) {
                 m_multi_buffer.put_time(m_physical_time);
             }
@@ -438,7 +438,7 @@ Hipace::Evolve ()
         if (m_physical_time == m_max_time) {
             m_has_last_step = true;
             m_dt = 0.;
-            next_time = std::numeric_limits<amrex::Real>::infinity();
+            next_time = std::numeric_limits<amrex::Real>::max();
         } else if ((m_physical_time + m_dt >= m_max_time && m_physical_time < m_max_time) ||
                    (m_physical_time + m_dt <= m_max_time && m_physical_time > m_max_time)) {
             m_dt = m_max_time - m_physical_time;

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -246,12 +246,12 @@ private:
     std::string m_injection_type;
     uint64_t m_id64 = 1; /**< 64 bit ID to initialize many particles without overflowing */
     /** Min longitudinal particle position of the beam */
-    amrex::Real m_zmin = -std::numeric_limits<amrex::Real>::infinity();
+    amrex::Real m_zmin = -std::numeric_limits<amrex::Real>::max();
     /** Max longitudinal particle position of the beam */
-    amrex::Real m_zmax = std::numeric_limits<amrex::Real>::infinity();
-    amrex::Real m_radius {std::numeric_limits<amrex::Real>::infinity()}; /**< Radius of the beam */
+    amrex::Real m_zmax = std::numeric_limits<amrex::Real>::max();
+    amrex::Real m_radius {std::numeric_limits<amrex::Real>::max()}; /**< Radius of the beam */
     /** radius of the beam insitu diagnostics */
-    amrex::Real m_insitu_radius {std::numeric_limits<amrex::Real>::infinity()};
+    amrex::Real m_insitu_radius {std::numeric_limits<amrex::Real>::max()};
     GetInitialMomentum m_get_momentum {}; /**< momentum profile of the beam */
     /** After how many slices the particles are reordered. 0: off */
     int m_reorder_period = 0;

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -151,8 +151,8 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
             queryWithParser(pp, "zmin", m_zmin);
             queryWithParser(pp, "zmax", m_zmax);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE( !m_do_salame ||
-                (m_zmin != -std::numeric_limits<amrex::Real>::infinity() &&
-                 m_zmax !=  std::numeric_limits<amrex::Real>::infinity()),
+                (m_zmin != -std::numeric_limits<amrex::Real>::max() &&
+                 m_zmax !=  std::numeric_limits<amrex::Real>::max()),
                 "For the SALAME algorithm it is mandatory to either use a 'can' profile or "
                 "'zmin' and 'zmax' with a gaussian profile");
         } else {

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -172,9 +172,9 @@ public:
     /** maximum weighting factor gamma/(Psi +1) before particle is regarded as violating
      *  the quasi-static approximation and is removed */
     amrex::Real m_max_qsa_weighting_factor {35.};
-    amrex::Real m_radius {std::numeric_limits<amrex::Real>::infinity()}; /**< radius of the plasma */
+    amrex::Real m_radius {std::numeric_limits<amrex::Real>::max()}; /**< radius of the plasma */
     /** radius of the plasma insitu diagnostics */
-    amrex::Real m_insitu_radius {std::numeric_limits<amrex::Real>::infinity()};
+    amrex::Real m_insitu_radius {std::numeric_limits<amrex::Real>::max()};
     amrex::Real m_hollow_core_radius {0.}; /**< hollow core radius of the plasma */
     bool m_use_fine_patch = false;
     int m_fine_transition_cells = 5;

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -67,7 +67,7 @@ InitParticles (const amrex::RealVect& a_u_std,
     {
         amrex::Box tile_box  = mfi.tilebox(box_nodal, box_grow);
 
-        if (a_radius != std::numeric_limits<amrex::Real>::infinity()) {
+        if (a_radius != std::numeric_limits<amrex::Real>::max()) {
             amrex::IntVect lo_limit {
                 static_cast<int>(std::round((-a_radius - plo[0])/dx[0] - 2)),
                 static_cast<int>(std::round((-a_radius - plo[1])/dx[1] - 2)),

--- a/src/utils/AdaptiveTimeStep.H
+++ b/src/utils/AdaptiveTimeStep.H
@@ -24,7 +24,7 @@ private:
     /** Number of time steps per betatron period for the adaptive time step */
     amrex::Real m_nt_per_betatron = 20.;
     /** Upper bound of the time step. Avoid gigantic time step(s) when beam starts near vacuum */
-    amrex::Real m_dt_max = std::numeric_limits<amrex::Real>::infinity();
+    amrex::Real m_dt_max = std::numeric_limits<amrex::Real>::max();
     /** uz*mass/charge of the slowest particles */
     amrex::Real m_min_uz_mq = std::numeric_limits<amrex::Real>::max();
     /** Threshold beam momentum, below which the time step is not decreased */

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -140,7 +140,7 @@ AdaptiveTimeStep::GatherMinUzSlice (MultiBeam& beams, const bool initial)
             [=] AMREX_GPU_DEVICE (unsigned long long ip) noexcept -> ReduceTuple
             {
                 if (amrex::ConstParticleIDWrapper(idcpup[ip]) < 0) return {
-                    0._rt, 0._rt, 0._rt, std::numeric_limits<amrex::Real>::infinity()
+                    0._rt, 0._rt, 0._rt, std::numeric_limits<amrex::Real>::max()
                 };
                 return {
                     wp[ip],


### PR DESCRIPTION
If we want to use https://github.com/AMReX-Codes/amrex/pull/4545 to enable fast math on all platforms we can't use infinity due to the `-ffinite-math-only` flag.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
