### PR TITLE
Fix min max issue with cuda 11.8

### DIFF
--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -120,7 +120,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                     const amrex::Real x = plo[0] + (i + 0.5_rt + x_offset)*dx[0];
                     const amrex::Real y = plo[1] + (j + 0.5_rt + y_offset)*dx[1];
                     const int fine_val = static_cast<int>(std::round(fine_patch_func(x, y)));
-                    arr_fine(i, j, comp_a) = std::min(max_lev, std::max(0, fine_val))
+                    arr_fine(i, j, comp_a) = std::min(max_lev+0, std::max(0, fine_val))
                                              * (fine_transition_cells + 1);
                 });
 


### PR DESCRIPTION
There seems to be a compiler bug with cuda 11.8 that resulted in the wrong result being returned from `std::min`:
```C++
constexpr int max_lev = 2;
...
const int fine_val = 0;
std::min(max_lev, std::max(0, fine_val)) == 2;
```
It is fixed by addint `+0` to `max_lev `.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
