### PR TITLE
Fix some fpe_trap issues

### DIFF
--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -143,7 +143,8 @@ InitBeamFixedPPC3D ()
     const amrex::Real y_mean = m_position_mean[1];
     const amrex::Real z_min = m_zmin;
     const amrex::Real z_max = m_zmax;
-    const amrex::Real radius = m_radius;
+    const amrex::Real radius_sq = m_radius == std::numeric_limits<amrex::Real>::max() ?
+        std::numeric_limits<amrex::Real>::max() : m_radius * m_radius;
     const amrex::Real min_density = m_min_density;
     const amrex::GpuArray<int, 3> rand_ppc {m_random_ppc[0], m_random_ppc[1], m_random_ppc[2]};
 
@@ -174,7 +175,7 @@ InitBeamFixedPPC3D ()
                     // If particles are evenly spaced, discard particles
                     // individually if they are out of bounds
                     if (z >= z_max || z < z_min ||
-                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > radius*radius) {
+                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > radius_sq) {
                             continue;
                         }
                 } else {
@@ -184,7 +185,7 @@ InitBeamFixedPPC3D ()
                     amrex::Real yc = plo[1]+j*dx[1];
                     amrex::Real zc = plo[2]+k*dx[2];
                     if (zc >= z_max || zc < z_min ||
-                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > radius*radius) {
+                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > radius_sq) {
                             continue;
                         }
                 }
@@ -226,7 +227,8 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
     const amrex::Real y_mean = m_position_mean[1];
     const amrex::Real z_min = m_zmin;
     const amrex::Real z_max = m_zmax;
-    const amrex::Real radius = m_radius;
+    const amrex::Real radius_sq = m_radius == std::numeric_limits<amrex::Real>::max() ?
+        std::numeric_limits<amrex::Real>::max() : m_radius * m_radius;
     const amrex::Real min_density = m_min_density;
     const amrex::GpuArray<int, 3> rand_ppc {m_random_ppc[0], m_random_ppc[1], m_random_ppc[2]};
 
@@ -262,7 +264,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
                     // If particles are evenly spaced, discard particles
                     // individually if they are out of bounds
                     if (z >= z_max || z < z_min ||
-                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > radius*radius) {
+                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > radius_sq) {
                             continue;
                         }
                 } else {
@@ -272,7 +274,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
                     amrex::Real yc = plo[1]+j*dx[1];
                     amrex::Real zc = plo[2]+islice*dx[2];
                     if (zc >= z_max || zc < z_min ||
-                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > radius*radius) {
+                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > radius_sq) {
                             continue;
                         }
                 }
@@ -321,7 +323,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
                     // If particles are evenly spaced, discard particles
                     // individually if they are out of bounds
                     if (z >= z_max || z < z_min ||
-                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > radius*radius) {
+                        ((x-x_mean)*(x-x_mean)+(y-y_mean)*(y-y_mean)) > radius_sq) {
                             continue;
                         }
                 } else {
@@ -331,7 +333,7 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
                     amrex::Real yc = plo[1]+j*dx[1];
                     amrex::Real zc = plo[2]+islice*dx[2];
                     if (zc >= z_max || zc < z_min ||
-                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > radius*radius) {
+                        ((xc-x_mean)*(xc-x_mean)+(yc-y_mean)*(yc-y_mean)) > radius_sq) {
                             continue;
                         }
                 }
@@ -426,7 +428,8 @@ InitBeamFixedWeightSlice (int slice, int which_slice)
     const amrex::Real z_mean = can ? 0.5_rt * (z_min + z_max) : m_pos_mean_z;
     const amrex::RealVect pos_std = m_position_std;
     const amrex::Real z_foc = m_z_foc;
-    const amrex::Real radius = m_radius;
+    const amrex::Real radius_sq = m_radius == std::numeric_limits<amrex::Real>::max() ?
+        std::numeric_limits<amrex::Real>::max() : m_radius * m_radius;
     auto pos_mean_x = m_pos_mean_x_func;
     auto pos_mean_y = m_pos_mean_y_func;
     const amrex::Real weight = m_total_charge / (m_num_particles * m_charge);
@@ -445,7 +448,7 @@ InitBeamFixedWeightSlice (int slice, int which_slice)
             get_momentum(u[0], u[1], u[2], engine, z_central - z_mean, duz_per_uz0_dzeta);
 
             bool is_valid = true;
-            if (z_central < z_min || z_central > z_max || x*x + y*y > radius*radius) {
+            if (z_central < z_min || z_central > z_max || x*x + y*y > radius_sq) {
                 is_valid = false;
             }
 
@@ -621,7 +624,8 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
         const bool do_symmetrize = m_do_symmetrize;
         const bool peak_density_is_specified = m_peak_density_is_specified;
         const amrex::Real z_foc = m_z_foc;
-        const amrex::Real radius = m_radius;
+        const amrex::Real radius_sq = m_radius == std::numeric_limits<amrex::Real>::max() ?
+            std::numeric_limits<amrex::Real>::max() : m_radius * m_radius;
         const amrex::Real weight = m_total_weight / m_num_particles;
         const auto pos_func = m_pdf_pos_func;
         const auto u_func = m_pdf_u_func;
@@ -669,7 +673,7 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
                 do {
                     x = amrex::RandomNormal(0, x_std, engine);
                     y = amrex::RandomNormal(0, y_std, engine);
-                    is_valid = x*x + y*y <= radius*radius;
+                    is_valid = x*x + y*y <= radius_sq;
                 } while (!peak_density_is_specified && !is_valid);
 
                 const amrex::Real ux = amrex::RandomNormal(u_func[0](z), u_func[3](z), engine);

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -93,6 +93,9 @@ InitParticles (const amrex::RealVect& a_u_std,
             tile_box &= amrex::Box(lo_limit, hi_limit, box_nodal);
         }
 
+        const amrex::Real radius_sq = a_radius == std::numeric_limits<amrex::Real>::max() ?
+            std::numeric_limits<amrex::Real>::max() : a_radius * a_radius;
+
         const auto lo = amrex::lbound(tile_box);
         const auto hi = amrex::ubound(tile_box);
 
@@ -171,7 +174,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                     const amrex::Real rsq = x*x + y*y;
                     if (x >= a_bounds.hi(0) || x < a_bounds.lo(0) ||
                         y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
-                        rsq > a_radius*a_radius ||
+                        rsq > radius_sq ||
                         rsq < a_hollow_core_radius*a_hollow_core_radius ||
                         density_func(x, y, c_t) <= min_density) continue;
 
@@ -225,7 +228,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                 const amrex::Real rsq = x*x + y*y;
                 if (x >= a_bounds.hi(0) || x < a_bounds.lo(0) ||
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
-                    rsq > a_radius*a_radius ||
+                    rsq > radius_sq ||
                     rsq < a_hollow_core_radius*a_hollow_core_radius ||
                     density_func(x, y, c_t) <= min_density) return;
 
@@ -285,7 +288,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                 const amrex::Real rsq = x*x + y*y;
                 if (x >= a_bounds.hi(0) || x < a_bounds.lo(0) ||
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
-                    rsq > a_radius*a_radius ||
+                    rsq > radius_sq ||
                     rsq < a_hollow_core_radius*a_hollow_core_radius ||
                     density_func(x, y, c_t) <= min_density) return;
 

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -113,10 +113,10 @@ AdvanceBeamParticlesSlice (
 
     // calcuation of E0 in SI units for denormalization
     // using wp_inv to avoid multiplication in kernel
-    const amrex::Real wp_inv = normalized_units ? std::sqrt(PhysConstSI::ep0 * PhysConstSI::m_e/
+    const amrex::Real wp_inv = normalized_units && radiation_reaction ? std::sqrt(PhysConstSI::ep0 * PhysConstSI::m_e/
                                      ( static_cast<double>(background_density_SI) *
                                      PhysConstSI::q_e*PhysConstSI::q_e )  ) : 1;
-    const amrex::Real E0 = Hipace::m_normalized_units ?
+    const amrex::Real E0 = Hipace::m_normalized_units && radiation_reaction ?
                            PhysConstSI::m_e * PhysConstSI::c / wp_inv / PhysConstSI::q_e : 1;
 
     // don't include slipped particles in count as they were already pushed


### PR DESCRIPTION
This PR fixes a few places that cause crashes when using
```
amrex.fpe_trap_invalid = 1
amrex.fpe_trap_zero = 1
amrex.fpe_trap_overflow = 1
```
Note that capturing the `radius_sq = std::numeric_limits<amrex::Real>::max()` in ParallelFor, even without using it, still causes crashes when running on GPU.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
