### PR TITLE
Pass AMReX Arena to getBeamInitSlice().define()

### DIFF
--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -102,9 +102,10 @@ BeamParticleContainer::ReadParameters ()
             // Use 3 real and 0 int runtime components
             beam_tile.define(3, 0);
         }
-        getBeamInitSlice().define(3, 0, nullptr, nullptr,
-            m_initialize_on_cpu ? amrex::The_Pinned_Arena() : amrex::The_Arena());
     }
+
+    getBeamInitSlice().define(m_do_spin_tracking ? 3 : 0, 0, nullptr, nullptr,
+        m_initialize_on_cpu ? amrex::The_Pinned_Arena() : amrex::The_Arena());
 }
 
 amrex::Real

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -102,17 +102,7 @@ BeamParticleContainer::ReadParameters ()
             // Use 3 real and 0 int runtime components
             beam_tile.define(3, 0);
         }
-        getBeamInitSlice().define(3, 0);
-    }
-    auto& soa = getBeamInitSlice().GetStructOfArrays();
-    soa.GetIdCPUData().setArena(
-        m_initialize_on_cpu ? amrex::The_Pinned_Arena() : amrex::The_Arena());
-    for (int rcomp = 0; rcomp < soa.NumRealComps(); ++rcomp) {
-        soa.GetRealData(rcomp).setArena(
-            m_initialize_on_cpu ? amrex::The_Pinned_Arena() : amrex::The_Arena());
-    }
-    for (int icomp = 0; icomp < soa.NumIntComps(); ++icomp) {
-        soa.GetIntData(icomp).setArena(
+        getBeamInitSlice().define(3, 0, nullptr, nullptr,
             m_initialize_on_cpu ? amrex::The_Pinned_Arena() : amrex::The_Arena());
     }
 }


### PR DESCRIPTION
See https://github.com/AMReX-Codes/amrex/pull/4603

Now it's required to pass an Arena to define when using a PolymorphicArenaAllocator

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
