### PR TITLE
Use amrex::ToString instead of std::to_string

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -373,19 +373,18 @@ Hipace::MakeGeometry ()
                 patch_hi_lev[1] - patch_lo_lev[1]
             };
 
-            if (!(old_patch_len[0] > 0._rt && old_patch_len[1] > 0._rt &&
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                old_patch_len[0] > 0._rt && old_patch_len[1] > 0._rt &&
                 (std::abs((patch_len_lev[0] - old_patch_len[0]) / old_patch_len[0]) <= 0.05_rt) &&
-                (std::abs((patch_len_lev[1] - old_patch_len[1]) / old_patch_len[1]) <= 0.05_rt))) {
-
-                amrex::Abort(
-                    "The refined patch would need to be changed by more than 5% "
-                    "to fit the requested refinement ratio! "
-                    "The patch length from patch_lo and patch_hi is " +
-                    amrex::ToString(old_patch_len) +
-                    " but the ref ratio and number of cells would give " +
-                    amrex::ToString(patch_len_lev) +
-                    "!");
-            }
+                (std::abs((patch_len_lev[1] - old_patch_len[1]) / old_patch_len[1]) <= 0.05_rt),
+                "The refined patch would need to be changed by more than 5% "
+                "to fit the requested refinement ratio! "
+                "The patch length from patch_lo and patch_hi is " +
+                amrex::ToString(old_patch_len) +
+                " but the ref ratio and number of cells would give " +
+                amrex::ToString(patch_len_lev) +
+                "!"
+            );
 
             patch_lo_lev[0] = patch_center_lev[0] - patch_len_lev[0] * 0.5_rt;
             patch_lo_lev[1] = patch_center_lev[1] - patch_len_lev[1] * 0.5_rt;

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -381,9 +381,9 @@ Hipace::MakeGeometry ()
                     "The refined patch would need to be changed by more than 5% "
                     "to fit the requested refinement ratio! "
                     "The patch length from patch_lo and patch_hi is " +
-                    std::to_string(old_patch_len[0]) + " and " + std::to_string(old_patch_len[1]) +
+                    amrex::ToString(old_patch_len) +
                     " but the ref ratio and number of cells would give " +
-                    std::to_string(patch_len_lev[0]) + " and " + std::to_string(patch_len_lev[1]) +
+                    amrex::ToString(patch_len_lev) +
                     "!");
             }
 

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -268,11 +268,11 @@ Diagnostic::Initialize (int nlev, bool use_laser) {
 
     // check that all components are at least used by one of the diagnostics
     for (auto& [key, val] : is_global_comp_used) {
-        if (!val) {
-            amrex::Abort("Unknown or unused component in diagnostic.field_data.\n'" +
-                         key + "' does not belong to any diagnostic.names!\n" +
-                         all_comps_error_str.str());
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(val,
+            "Unknown or unused component in diagnostic.field_data.\n'" +
+            key + "' does not belong to any diagnostic.names!\n" +
+            all_comps_error_str.str()
+        );
     }
 
     // if there are multiple diagnostic objects with the same m_base_geom_type (colliding component
@@ -306,10 +306,12 @@ Diagnostic::Initialize (int nlev, bool use_laser) {
                 m_output_beam_names.clear();
                 break;
             }
-            if(std::find(all_beam_names.begin(), all_beam_names.end(), beam_name) ==  all_beam_names.end() ) {
-                amrex::Abort("Unknown beam name: " + beam_name + "\nmust be " +
-                "a subset of beams.names or 'none'");
-            }
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                std::find(all_beam_names.begin(), all_beam_names.end(), beam_name)
+                    != all_beam_names.end(),
+                "Unknown beam name: " + beam_name + "\nmust be " +
+                "a subset of beams.names: " + amrex::ToString(all_beam_names) + ", 'all' or 'none'"
+            );
         }
     }
 

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -30,14 +30,11 @@ struct WhichSlice {
 
 struct assert_map : std::map<std::string, int> {
     int operator[] (const std::string& str) const {
-        if (count(str)==0) {
-            amrex::ErrorStream() << "Component '"+str+"' is not allocated\nFields allocated:";
-            for (auto& [alloc_str, num] : *this) {
-                amrex::ErrorStream() << " '" << alloc_str << "' (" << num << "),";
-            }
-            amrex::ErrorStream() << "\n";
-            AMREX_ALWAYS_ASSERT(count(str)!=0);
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            count(str) != 0,
+             "Component '" + str + "' is not allocated\n"
+             "Fields allocated: " + amrex::ToString(*this) + "\n"
+        );
         return at(str);
     }
 

--- a/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapCuFFT.cpp
@@ -57,9 +57,9 @@ std::string cufftErrorToString (const cufftResult& err) {
 }
 
 void assert_cufft_status (std::string const& name, const cufftResult& status) {
-    if (status != CUFFT_SUCCESS) {
-        amrex::Abort(name + " failed! Error: " + cufftErrorToString(status));
-    }
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(status == CUFFT_SUCCESS,
+        name + " failed! Error: " + cufftErrorToString(status)
+    );
 }
 
 std::size_t AnyFFT::Initialize (FFTType type, int nx, int ny) {

--- a/src/fields/fft_poisson_solver/fft/WrapRocFFT.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapRocFFT.cpp
@@ -63,9 +63,9 @@ std::string rocfftErrorToString (const rocfft_status& err) {
 }
 
 void assert_rocfft_status (std::string const& name, const rocfft_status& status) {
-    if (status != rocfft_status_success) {
-        amrex::Abort(name + " failed! Error: " + rocfftErrorToString(status));
-    }
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(status == rocfft_status_success,
+        name + " failed! Error: " + rocfftErrorToString(status)
+    );
 }
 
 std::size_t AnyFFT::Initialize (FFTType type, int nx, int ny) {

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -77,34 +77,38 @@ Laser::GetEnvelopeFromFileHelper (amrex::Geometry laser_geom_3D) {
         // Check what kind of Datatype is used in the Laser file
         auto series = openPMD::Series( m_input_file_path , openPMD::Access::READ_ONLY );
 
-        if(!series.iterations.contains(m_file_num_iteration)) {
-            amrex::Abort("Could not find iteration " + std::to_string(m_file_num_iteration) +
-                         " in file " + m_input_file_path + "\n");
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            series.iterations.contains(m_file_num_iteration),
+            "Could not find iteration " + std::to_string(m_file_num_iteration) +
+            " in file " + m_input_file_path + "\n"
+        );
 
         auto iteration = series.iterations[m_file_num_iteration];
 
-        if(!iteration.meshes.contains(m_file_envelope_name)) {
-            amrex::Abort("Could not find mesh '" + m_file_envelope_name + "' in file "
-                + m_input_file_path + "\n");
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            iteration.meshes.contains(m_file_envelope_name),
+            "Could not find mesh '" + m_file_envelope_name + "' in file "
+            + m_input_file_path + "\n"
+        );
 
         auto mesh = iteration.meshes[m_file_envelope_name];
 
-        if (!mesh.containsAttribute("angularFrequency")) {
-            amrex::Abort("Could not find Attribute 'angularFrequency' of iteration "
-                + std::to_string(m_file_num_iteration) + " in file "
-                + m_input_file_path + "\n");
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            mesh.containsAttribute("angularFrequency"),
+            "Could not find Attribute 'angularFrequency' of iteration "
+            + std::to_string(m_file_num_iteration) + " in file "
+            + m_input_file_path + "\n"
+        );
 
         m_lambda0_from_file = 2.*MathConst::pi*PhysConstSI::c
             / mesh.getAttribute("angularFrequency").get<double>();
 
-        if(!mesh.contains(openPMD::RecordComponent::SCALAR)) {
-            amrex::Abort("Could not find component '" +
-                std::string(openPMD::RecordComponent::SCALAR) +
-                "' in file " + m_input_file_path + "\n");
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            mesh.contains(openPMD::RecordComponent::SCALAR),
+            "Could not find component '" +
+            std::string(openPMD::RecordComponent::SCALAR) +
+            "' in file " + m_input_file_path + "\n"
+        );
 
         input_type = mesh[openPMD::RecordComponent::SCALAR].getDatatype();
     }

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -849,8 +849,11 @@ MultiLaser::InitLaserSlice (const int islice, const int comp)
                     arr(i, j, k, comp + 1 ) += arr_ff(i, j, islice, 1 );
                 }
                 );
-                AMREX_ASSERT_WITH_MESSAGE(laser.m_lambda0_from_file == m_lambda0 && m_lambda0 != 0,
-                "The central wavelength of laser from openPMD file and other lasers must be identical");
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    laser.m_lambda0_from_file == m_lambda0 && m_lambda0 != 0,
+                    "The central wavelength of laser from openPMD file and "
+                    "other lasers must be identical"
+                );
             }
             if (laser.m_laser_init_type == "parser") {
                 auto profile_real = laser.m_profile_real;

--- a/src/mg_solver/HpMultiGrid.cpp
+++ b/src/mg_solver/HpMultiGrid.cpp
@@ -1396,24 +1396,22 @@ MultiGrid::solve_doit (FArrayBox& a_sol, FArrayBox const& a_rhs,
                                    << norminf << ", " << norminf/max_norm << "\n";
                 }
                 break;
-            } else if (norminf > Real(1.e20)*max_norm) {
-                if (verbose > 0) {
-                    amrex::Print() << "hpmg: Failing to converge after " << iter+1 << " iterations."
-                                   << " resid, resid/" << norm_name << " = "
-                                   << norminf << ", " << norminf/max_norm << "\n";
-                  }
-                  amrex::Abort("hpmg failing so lets stop here");
             }
+
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                converged || (norminf <= Real(1.e20)*max_norm),
+                "hpmg: Failing to converge after " + amrex::ToString(iter+1)  + " iterations."
+                " resid, resid/" + norm_name + " = " + amrex::ToString(norminf) + ", " +
+                amrex::ToString(norminf/max_norm) + "\n"
+            );
         }
 
-        if (!converged) {
-            if (verbose > 0) {
-                amrex::Print() << "hpmg: Failed to converge after " << nummaxiter << " iterations."
-                               << " resid, resid/" << norm_name << " = "
-                               << norminf << ", " << norminf/max_norm << "\n";
-            }
-            amrex::Abort("hpmg failed");
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            converged,
+             "hpmg: Failed to converge after " + amrex::ToString(nummaxiter) + " iterations."
+             " resid, resid/" + norm_name + " = " + amrex::ToString(norminf) + ", " +
+             amrex::ToString(norminf/max_norm) + "\n"
+        );
     }
 
     // copy the cor array into the sol array used for the final output

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -721,10 +721,11 @@ InitBeamFromFileHelper (const std::string input_file,
         // Check what kind of Datatype is used in beam file
         auto series = openPMD::Series( input_file , openPMD::Access::READ_ONLY );
 
-        if(!series.iterations.contains(num_iteration)) {
-            amrex::Abort("Could not find iteration " + std::to_string(num_iteration) +
-                                                        " in file " + input_file + "\n");
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            series.iterations.contains(num_iteration),
+            "Could not find iteration " + std::to_string(num_iteration) +
+            " in file " + input_file + "\n"
+        );
         species_known = series.iterations[num_iteration].particles.contains(species_name);
 
         for( auto const& particle_type : series.iterations[num_iteration].particles ) {

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -204,17 +204,17 @@ PlasmaParticleContainer::InitData (const amrex::Vector<amrex::Geometry>& geom3d)
                 // if((x-xc)^2/lenx^2 + (y-yc)^2/leny^2, lev, ...)
                 fine_patch_str =
                     "if((x-(" +
-                    std::to_string(0.5*(geom3d[lev].ProbHi(0) + geom3d[lev].ProbLo(0))) +
+                    amrex::ToString(0.5*(geom3d[lev].ProbHi(0) + geom3d[lev].ProbLo(0))) +
                     "))^2/(" +
-                    std::to_string(0.5 * Hipace::GetInstance().m_plasma_fine_patch[lev][0] *
-                                geom3d[lev].ProbLength(0)) +
+                    amrex::ToString(0.5 * Hipace::GetInstance().m_plasma_fine_patch[lev][0] *
+                                    geom3d[lev].ProbLength(0)) +
                     ")^2 + (y-(" +
-                    std::to_string(0.5*(geom3d[lev].ProbHi(1) + geom3d[lev].ProbLo(1))) +
+                    amrex::ToString(0.5*(geom3d[lev].ProbHi(1) + geom3d[lev].ProbLo(1))) +
                     "))^2/(" +
-                    std::to_string(0.5 * Hipace::GetInstance().m_plasma_fine_patch[lev][1] *
-                                geom3d[lev].ProbLength(1)) +
+                    amrex::ToString(0.5 * Hipace::GetInstance().m_plasma_fine_patch[lev][1] *
+                                    geom3d[lev].ProbLength(1)) +
                     ")^2 < 1, " +
-                    std::to_string(lev) +
+                    amrex::ToString(lev) +
                     ", " +
                     fine_patch_str +
                     ")";

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -128,8 +128,8 @@ void MultiBuffer::initialize (int nslices, MultiBeam& beams, MultiLaser& laser) 
             amrex::Abort("comms_buffer.max_size_GiB must be large enough to fit "
                          "all the data needed for all beams and the laser "
                          "between all ranks if there are more timesteps than ranks!\n"
-                         "Data needed: " + std::to_string(1.05*size_estimate) + " GiB\n"
-                         "Space available: " + std::to_string(max_size_GiB*n_ranks) + " GiB\n");
+                         "Data needed: " + amrex::ToString(1.05*size_estimate) + " GiB\n"
+                         "Space available: " + amrex::ToString(max_size_GiB*n_ranks) + " GiB\n");
         }
     }
 

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -123,14 +123,15 @@ void MultiBuffer::initialize (int nslices, MultiBeam& beams, MultiLaser& laser) 
         }
 
         size_estimate /= 1024*1024*1024;
-        if (!((1.05*size_estimate < max_size_GiB*n_ranks)
-            || (Hipace::m_max_step < amrex::ParallelDescriptor::NProcs()))) {
-            amrex::Abort("comms_buffer.max_size_GiB must be large enough to fit "
-                         "all the data needed for all beams and the laser "
-                         "between all ranks if there are more timesteps than ranks!\n"
-                         "Data needed: " + amrex::ToString(1.05*size_estimate) + " GiB\n"
-                         "Space available: " + amrex::ToString(max_size_GiB*n_ranks) + " GiB\n");
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            (1.05*size_estimate < max_size_GiB*n_ranks)
+            || (Hipace::m_max_step < amrex::ParallelDescriptor::NProcs()),
+            "comms_buffer.max_size_GiB must be large enough to fit "
+            "all the data needed for all beams and the laser "
+            "between all ranks if there are more timesteps than ranks!\n"
+            "Data needed: " + amrex::ToString(1.05*size_estimate) + " GiB\n"
+            "Space available: " + amrex::ToString(max_size_GiB*n_ranks) + " GiB\n"
+        );
     }
 
     bool do_pre_register = false;

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -209,6 +209,7 @@ namespace Parser
                 double parse_val = 0.;
                 fillWithParser(pp, parse_string, parse_val);
                 std::stringstream ss{};
+                ss.precision(16);
                 ss << parse_val;
                 loc_str.replace(pos, pos_end-pos+1, ss.str());
             }

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -156,12 +156,10 @@ namespace Parser
         static std::set<std::string> recursive_symbols{};
         while ( (pos=loc_str.rfind("{")) != std::string::npos) {
             const auto pos_end = loc_str.find("}", pos);
-            if (pos_end == std::string::npos) {
-                amrex::ErrorStream() << "Bad format for input '"
-                                     << str
-                                     << "', unclosed brace!\n";
-                AMREX_ALWAYS_ASSERT(pos_end != std::string::npos);
-            }
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                pos_end != std::string::npos,
+                "Bad format for input '" + str +  "', unclosed brace!\n"
+            );
             auto pos_start_trim = pos + 1;
             auto pos_count_trim = pos_end - pos - 1;
             // remove leading and trailing spaces
@@ -182,14 +180,10 @@ namespace Parser
                        pp_my_constants.contains(parse_string.c_str())) {
                 // use my_constants directly (with recursive string parsing) if available
                 // also check in local and global namespaces, same as the amrex parser
-                if (recursive_symbols.count(parse_string) != 0) {
-                    amrex::ErrorStream() << "Expression '"
-                                         << str
-                                         << "' contains recursive symbol '"
-                                         << parse_string
-                                         << "'!\n";
-                    AMREX_ALWAYS_ASSERT(recursive_symbols.count(parse_string) == 0);
-                }
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    recursive_symbols.count(parse_string) == 0,
+                    "Expression '" + str + "' contains recursive symbol '" + parse_string + "'!\n"
+                );
                 std::string replacer;
                 if (amrex::ParmParse{}.contains(parse_string.c_str())) {
                     amrex::ParmParse{}.get(parse_string.c_str(), replacer);
@@ -277,13 +271,11 @@ namespace Parser
     fillWithParserArr (const amrex::ParmParse& pp, std::vector<std::string> const& str_arr,
                        std::array<T,size>& val_arr) {
         const auto n = str_arr.size();
-        if (n != size) {
-            for( auto const& str : str_arr) {
-                amrex::ErrorStream() << str << ' ';
-            }
-            amrex::ErrorStream() << "has wrong length " << n << " should be " << size << '\n';
-        }
-        AMREX_ALWAYS_ASSERT( n == size );
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            n == size,
+            amrex::ToString(str_arr) + "has wrong length " +
+            amrex::ToString(n) + " should be " + amrex::ToString(size) + "\n"
+        );
         for (auto i=0ul ; i != n ; ++i) {
             fillWithParser(pp, str_arr[i], val_arr[i]);
         }
@@ -293,14 +285,11 @@ namespace Parser
     fillWithParserArr (const amrex::ParmParse& pp, std::vector<std::string> const& str_arr,
                        amrex::RealVect& val_arr) {
         const auto n = str_arr.size();
-        if (n != AMREX_SPACEDIM) {
-            for( auto const& str : str_arr) {
-                amrex::ErrorStream() << str << ' ';
-            }
-            amrex::ErrorStream() << "has wrong length " << n
-                                 << " should be " << AMREX_SPACEDIM << '\n';
-        }
-        AMREX_ALWAYS_ASSERT( n == AMREX_SPACEDIM );
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            n == AMREX_SPACEDIM,
+            amrex::ToString(str_arr) + "has wrong length " +
+            amrex::ToString(n) + " should be " + amrex::ToString(AMREX_SPACEDIM) + "\n"
+        );
         for (auto i=0ul ; i != n ; ++i) {
             fillWithParser(pp, str_arr[i], val_arr[i]);
         }
@@ -310,14 +299,11 @@ namespace Parser
     fillWithParserArr (const amrex::ParmParse& pp, std::vector<std::string> const& str_arr,
                        amrex::IntVect& val_arr) {
         const auto n = str_arr.size();
-        if (n != AMREX_SPACEDIM) {
-            for( auto const& str : str_arr) {
-                amrex::ErrorStream() << str << ' ';
-            }
-            amrex::ErrorStream() << "has wrong length " << n
-                                 << " should be " << AMREX_SPACEDIM << '\n';
-        }
-        AMREX_ALWAYS_ASSERT( n == AMREX_SPACEDIM );
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            n == AMREX_SPACEDIM,
+            amrex::ToString(str_arr) + "has wrong length " +
+            amrex::ToString(n) + " should be " + amrex::ToString(AMREX_SPACEDIM) + "\n"
+        );
         for (auto i=0ul ; i != n ; ++i) {
             fillWithParser(pp, str_arr[i], val_arr[i]);
         }

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -273,7 +273,7 @@ namespace Parser
         const auto n = str_arr.size();
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             n == size,
-            amrex::ToString(str_arr) + "has wrong length " +
+            amrex::ToString(str_arr) + " has wrong length " +
             amrex::ToString(n) + " should be " + amrex::ToString(size) + "\n"
         );
         for (auto i=0ul ; i != n ; ++i) {
@@ -287,7 +287,7 @@ namespace Parser
         const auto n = str_arr.size();
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             n == AMREX_SPACEDIM,
-            amrex::ToString(str_arr) + "has wrong length " +
+            amrex::ToString(str_arr) + " has wrong length " +
             amrex::ToString(n) + " should be " + amrex::ToString(AMREX_SPACEDIM) + "\n"
         );
         for (auto i=0ul ; i != n ; ++i) {
@@ -301,7 +301,7 @@ namespace Parser
         const auto n = str_arr.size();
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             n == AMREX_SPACEDIM,
-            amrex::ToString(str_arr) + "has wrong length " +
+            amrex::ToString(str_arr) + " has wrong length " +
             amrex::ToString(n) + " should be " + amrex::ToString(AMREX_SPACEDIM) + "\n"
         );
         for (auto i=0ul ; i != n ; ++i) {

--- a/src/utils/Parser.cpp
+++ b/src/utils/Parser.cpp
@@ -30,17 +30,13 @@ namespace Parser {
 
             auto pos = s.find_first_of("=");
 
-            if (pos == std::string::npos) {
-                amrex::Abort(abort_str);
-            }
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != std::string::npos, abort_str);
 
             std::string varname = s.substr(0, pos);
             std::string expr = s.substr(pos + 1u);
             std::stringstream expr_ss{expr};
 
-            if (expr.size() < 1ul) {
-                amrex::Abort(abort_str);
-            }
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(expr.size() >= 1ul, abort_str);
 
             if (expr_ss.peek() == '[') {
                 double range_begin = 0., range_end = 0., num_points = 0.;
@@ -51,10 +47,11 @@ namespace Parser {
                         >> second_comma >> num_points
                         >> bracked_close;
 
-                if (bracket_open != '[' || first_comma != ',' ||
-                    second_comma != ',' || bracked_close != ']') {
-                    amrex::Abort(abort_str);
-                }
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    bracket_open == '[' && first_comma == ',' &&
+                    second_comma == ',' && bracked_close == ']',
+                    abort_str
+                );
                 local_variables_names.emplace_back(varname);
                 local_variables_bounds.emplace_back(range_begin, range_end,
                     static_cast<int>(std::round(num_points)));
@@ -64,11 +61,12 @@ namespace Parser {
                 pp.add(varname.c_str(), val);
             }
 
-            if (expr_ss.fail() ||
-                (static_cast<long>(expr_ss.tellg()) != static_cast<long>(expr.size()) &&
-                static_cast<long>(expr_ss.tellg()) != -1l)) {
-                amrex::Abort(abort_str);
-            }
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                !expr_ss.fail() &&
+                (static_cast<long>(expr_ss.tellg()) == static_cast<long>(expr.size()) ||
+                static_cast<long>(expr_ss.tellg()) == -1l),
+                abort_str
+            );
         }
 
         amrex::Parser func_parser{};


### PR DESCRIPTION
... and use `AMREX_ALWAYS_ASSERT_WITH_MESSAGE` instead of `if (...) {amrex::Abort(...)}`

`std::to_string` has very low precision for floating point values in some cases, `amrex::ToString` fixes this.

This uses recent amrex PRs https://github.com/AMReX-Codes/amrex/pull/4581 and https://github.com/AMReX-Codes/amrex/pull/4584 .


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
