### PR TITLE
Add in-situ term for laser energy in Energy conservation equation

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1117,7 +1117,7 @@ For the field in-situ diagnostics, the following quantities are calculated per s
 These quantities can be used to calculate the energy stored in the fields.
 
 For the laser in-situ diagnostics, the following quantities are calculated per slice and stored:
-``max(|a|^2), [|a|^2], [|a|^2*x], [|a|^2*x*x], [|a|^2*y], [|a|^2*y*y], axis(a)``.
+``max(|a|^2), [|a|^2], [|a|^2*x], [|a|^2*x*x], [|a|^2*y], [|a|^2*y*y], axis(a), [chi*d_z|a|^2]``.
 Thereby, ``max(|a|^2)`` is the highest value of ``|a|^2`` in the current slice
 and ``axis(a)`` gives the complex value of the laser envelope, in the center of every slice.
 

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -239,7 +239,7 @@ private:
 
     // Data for in-situ diagnostics:
     /** Number of real laser properties for in-situ per-slice reduced diagnostics. */
-    static constexpr int m_insitu_nrp = 6;
+    static constexpr int m_insitu_nrp = 7;
     /** Number of real complex properties for in-situ per-slice reduced diagnostics. */
     static constexpr int m_insitu_ncp = 1;
     /** How often the insitu laser diagnostics should be computed and written

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -952,7 +952,8 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
     const amrex::Real poff_y = GetPosOffset(1, m_laser_geom_3D, m_laser_geom_3D.Domain());
     const amrex::Real dx = m_laser_geom_3D.CellSize(0);
     const amrex::Real dy = m_laser_geom_3D.CellSize(1);
-    const amrex::Real dxdydz = dx * dy * m_laser_geom_3D.CellSize(2);
+    const amrex::Real dz = m_laser_geom_3D.CellSize(2);
+    const amrex::Real dxdydz = dx * dy * dz;
 
     const int xmid_lo = m_laser_geom_3D.Domain().smallEnd(0) + (m_laser_geom_3D.Domain().length(0) - 1) / 2;
     const int xmid_hi = m_laser_geom_3D.Domain().smallEnd(0) + (m_laser_geom_3D.Domain().length(0)) / 2;
@@ -975,7 +976,17 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
                 const amrex::Real areal = arr(i,j, n00j00_r);
                 const amrex::Real aimag = arr(i,j, n00j00_i);
                 const amrex::Real aabssq = abssq(areal, aimag);
-
+                const amrex::Real chidzabssq = arr(i,j, chi) * (
+                     - abssq(arr(i,j, n00j00_r), arr(i,j, n00j00_i))
+                     + abssq(arr(i,j, n00jp1_r), arr(i,j, n00jp1_i))
+                    ) / dz;
+                // Should be the following, unfortunately n00jp2 is being used for something
+                // else there and is therefore incorrect. Would be great to use that still.
+                // const amrex::Real chidzabssq = arr(i,j, chi) * (
+                //     - 3._rt * abssq(arr(i,j, n00j00_r), arr(i,j, n00j00_i))
+                //     + 4._rt * abssq(arr(i,j, n00jp1_r), arr(i,j, n00jp1_i))
+                //     -         abssq(arr(i,j, n00jp2_r), arr(i,j, n00jp2_i))
+                //     ) / (2._rt * dz);
                 const amrex::Real x = i * dx + poff_x;
                 const amrex::Real y = j * dy + poff_y;
 
@@ -989,7 +1000,8 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
                     aabssq*x*x,     // 3    [|a|^2*x*x]
                     aabssq*y,       // 4    [|a|^2*y]
                     aabssq*y*y,     // 5    [|a|^2*y*y]
-                    aaxis           // 6    axis(a)
+                    chidzabssq,     // 6    [chi*d_z|a|^2]
+                    aaxis           // 7    axis(a)
                 };
             });
     }
@@ -1055,6 +1067,7 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, int max_step, amrex::
         {"[|a|^2*x*x]"    , &m_insitu_rdata[3*nslices], nslices},
         {"[|a|^2*y]"      , &m_insitu_rdata[4*nslices], nslices},
         {"[|a|^2*y*y]"    , &m_insitu_rdata[5*nslices], nslices},
+        {"[chi*d_z|a|^2]" , &m_insitu_rdata[6*nslices], nslices},
         {"axis(a)"        , &m_insitu_cdata[0], nslices},
         {"integrated", {
             {"max(|a|^2)"     , &m_insitu_sum_rdata[0]},
@@ -1062,7 +1075,8 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, int max_step, amrex::
             {"[|a|^2*x]"      , &m_insitu_sum_rdata[2]},
             {"[|a|^2*x*x]"    , &m_insitu_sum_rdata[3]},
             {"[|a|^2*y]"      , &m_insitu_sum_rdata[4]},
-            {"[|a|^2*y*y]"    , &m_insitu_sum_rdata[5]}
+            {"[|a|^2*y*y]"    , &m_insitu_sum_rdata[5]},
+            {"[chi*d_z|a|^2]" , &m_insitu_sum_rdata[6]}
         }}
     };
 

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -976,17 +976,11 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
                 const amrex::Real areal = arr(i,j, n00j00_r);
                 const amrex::Real aimag = arr(i,j, n00j00_i);
                 const amrex::Real aabssq = abssq(areal, aimag);
+                // At this point, n00jp2 actually contains the data of n00jm1
                 const amrex::Real chidzabssq = arr(i,j, chi) * (
-                     - abssq(arr(i,j, n00j00_r), arr(i,j, n00j00_i))
+                     - abssq(arr(i,j, n00jp2_r), arr(i,j, n00jp2_i))
                      + abssq(arr(i,j, n00jp1_r), arr(i,j, n00jp1_i))
-                    ) / dz;
-                // Should be the following, unfortunately n00jp2 is being used for something
-                // else there and is therefore incorrect. Would be great to use that still.
-                // const amrex::Real chidzabssq = arr(i,j, chi) * (
-                //     - 3._rt * abssq(arr(i,j, n00j00_r), arr(i,j, n00j00_i))
-                //     + 4._rt * abssq(arr(i,j, n00jp1_r), arr(i,j, n00jp1_i))
-                //     -         abssq(arr(i,j, n00jp2_r), arr(i,j, n00jp2_i))
-                //     ) / (2._rt * dz);
+                    ) / ( 2._rt * dz );
                 const amrex::Real x = i * dx + poff_x;
                 const amrex::Real y = j * dy + poff_y;
 

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -953,6 +953,7 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
     const amrex::Real dx = m_laser_geom_3D.CellSize(0);
     const amrex::Real dy = m_laser_geom_3D.CellSize(1);
     const amrex::Real dz = m_laser_geom_3D.CellSize(2);
+    const amrex::Real dz2i = 1./(2. * dz);
     const amrex::Real dxdydz = dx * dy * dz;
 
     const int xmid_lo = m_laser_geom_3D.Domain().smallEnd(0) + (m_laser_geom_3D.Domain().length(0) - 1) / 2;
@@ -980,7 +981,7 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
                 const amrex::Real chidzabssq = arr(i,j, chi) * (
                      - abssq(arr(i,j, n00jp2_r), arr(i,j, n00jp2_i))
                      + abssq(arr(i,j, n00jp1_r), arr(i,j, n00jp1_i))
-                    ) / ( 2._rt * dz );
+                    ) * dz2i;
                 const amrex::Real x = i * dx + poff_x;
                 const amrex::Real y = j * dy + poff_y;
 


### PR DESCRIPTION
This PR adds the calculation of laser term in energy conservation eq. 4 of Golovanov PRL 2023. It gives the following result in a laser-driven example with a beam. The total gets closer and closer to 0 as transverse resolution in particular is increased. The results are shown on 2 different plots as the scales are quite different, but the total shown in bottom plot accounts for the 4 terms.
<img width="2400" height="1200" alt="energies" src="https://github.com/user-attachments/assets/acc29c93-7761-4225-a954-6b4e6e9a42bf" />

# Post-processing
```py
import numpy as np
import numpy as np
import matplotlib.pyplot as plt
import scipy.constants as scc
from openpmd_viewer import OpenPMDTimeSeries
import sys
import re
sys.path.append('../../../src/hipace/tools')
import read_insitu_diagnostics as diag

# 128 128 2048 1ppc 1e6beam
# 128 128 4096 1ppc 1e6beam gives same result
# 256 256 2048 1ppc 1e7beam reduces error and noise A LOT!

path = "./diags/insitu/"
all_data_fields = diag.read_file(path + "reduced_field*")
all_data_plasma = diag.read_file(path + "reduced_plasma*")
all_data_laser = diag.read_file(path + "reduced_laser*")
dzeta = (all_data_fields[0]["z_hi"] - all_data_fields[0]["z_lo"]) / all_data_fields[0]["n_slices"]

iteration = 0

psi_field = 0.5 / dzeta * (scc.e/scc.m_e/scc.c**2)**2 * (
               all_data_fields["[ExmBy^2]"][iteration] +
               all_data_fields["[EypBx^2]"][iteration] + 
               all_data_fields["[Ez^2]"][iteration] + 
    scc.c**2 * all_data_fields["[Bz^2]"][iteration])

psi_plasma = 1/dzeta * scc.e**2 / scc.m_e / scc.epsilon_0 / scc.c**2 * all_data_plasma["[(ga-1)*(1-vz)]"][iteration]

s_beam = - 1/dzeta * (scc.e/scc.m_e/scc.c**2)**2 / scc.epsilon_0 * all_data_fields["[Ez*jz_beam]"][iteration] / scc.c

s_laser = - 1/dzeta * 0.25 * all_data_laser["[chi*d_z|a|^2]"][iteration]

dz_psi_field = np.gradient(psi_field, dzeta)
dz_psi_plasma = np.gradient(psi_plasma, dzeta)

color=0.0
# Take colors at regular intervals spanning the colormap.
plt.rcParams.update({'font.size': 8})
plt.figure(figsize=(8,4))
plt.subplot(211)
plt.plot(1e6*diag.z_axis(all_data_fields), s_laser, label='s_laser', color=plt.colormaps['plasma'](color)); color+=.3
plt.plot(1e6*diag.z_axis(all_data_fields), dz_psi_plasma, label='dz psi_plasma', color=plt.colormaps['plasma'](color)); color+=.3
plt.grid()
plt.legend()
plt.ylabel('energies (random units)')
plt.ylim(-1e6, 1e6)
plt.subplot(212)
plt.plot(1e6*diag.z_axis(all_data_fields), dz_psi_field, label='dz psi_field', color=plt.colormaps['plasma'](color)); color+=.3
plt.plot(1e6*diag.z_axis(all_data_fields), s_beam, label='s_beam', color=plt.colormaps['plasma'](color)); color+=.3
plt.plot(1e6*diag.z_axis(all_data_fields), s_beam+s_laser+dz_psi_plasma+dz_psi_field, 'k--', label='total')
plt.grid()
plt.ylim(-1e4, 1e4)
plt.legend()
plt.xlabel('z (um)')
plt.ylabel('energies (random units)')
plt.tight_layout()
plt.savefig('energies.png', dpi=300)
plt.savefig('energies.pdf')
```
# Inputs
```
max_step = 0
amr.n_cell = 256 256 2048

my_constants.kp_inv = clight/wp
my_constants.kp = wp/clight
my_constants.wp = sqrt( ne * q_e^2/(m_e *epsilon0) )
my_constants.ne = 1.0505e23
my_constants.Rm = 3*kp_inv
my_constants.Lramp = 6.e-3

hipace.verbose = 1
hipace.dt = 10.*kp_inv/clight
diagnostic.output_period = 10

amr.max_level = 0

boundary.field = Dirichlet
boundary.particle = Periodic
geometry.prob_lo     = -18*kp_inv   -18*kp_inv   -7.5*kp_inv
geometry.prob_hi     =  18*kp_inv    18*kp_inv    1.5*kp_inv

lasers.names = laser
lasers.lambda0 = 800e-9
lasers.solver_type = multigrid
lasers.MG_tolerance_rel = 1e-6
laser.a0 = 1.
laser.position_mean = 0. 0. 0
laser.w0 = 3*kp_inv
laser.L0 = 0.5*kp_inv

plasmas.names = plasma
plasma.density(x,y,z) = "ne"
plasma.ppc = 1 1
plasma.element = electron
plasma.radius = 23.*kp_inv

beams.names = beam
beam.position_mean = 0. 0. -5*kp_inv
beam.position_std = 2.e-6 2.e-6 5.e-6
beam.injection_type = fixed_weight
beam.num_particles = 10000000
beam.total_charge = 50e-12
beam.u_mean = 0. 0. 2000.
beam.u_std = 2. 2. 20.

diagnostic.diag_type = xz
hipace.file_prefix = diags/hdf5
beams.insitu_file_prefix = diags/insitu
lasers.insitu_file_prefix = diags/insitu
fields.insitu_file_prefix = diags/insitu
plasmas.insitu_file_prefix = diags/insitu
fields.insitu_period = 1
lasers.insitu_period = 1
plasmas.insitu_period = 1
beams.insitu_period = 1
```