### PR TITLE
Add option for transverse plasma profile

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -432,11 +432,16 @@ When both are specified, the per-species value is used.
 
 * ``<plasma name>.density_table_file`` (`string`) optional (default "")
     Alternative to ``<plasma name>.density(x,y,z)``. Specify the name of a text file containing
-    multiple densities for different positions. File syntax: ``<position> <density function>`` for
+    multiple densities for different longitudinal positions. File syntax: ``<position> <density function>`` for
     every line. If a line doesn't start with a position it is ignored (comments can be made
     with `#`). `<density function>` is evaluated like ``<plasma name>.density(x,y,z)``. The simulation
     position :math:`time \cdot c` is rounded up to the nearest `<position>` in the file to get it's
     `<density function>` which is used for that time step.
+
+* ``<plasma name>.transverse_profile(x,y)`` (`string`) optional (default `"1."`)
+    Transverse profile of the plasma.
+    This can be combined with density function or file, the result is then multiplied by ``transverse_profile`` when initializing the plasma.
+    A typical use case is to set the longitudinal profile with ``density_table_file`` and the transverse with ``transverse_profile`` for the full 3D profile, provided these are separable.
 
 * ``<plasma name> or plasmas.ppc`` (2 `integer`)
     The number of plasma particles per cell in x and y.

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -161,6 +161,8 @@ public:
 
     amrex::Parser m_parser; /**< owns data for m_density_func */
     amrex::ParserExecutor<3> m_density_func; /**< Density function for the plasma */
+    amrex::Parser m_transverse_parser; /**< owns data for m_density_func */
+    amrex::ParserExecutor<2> m_transverse_profile; /**< Density function for the plasma */
     amrex::Real m_min_density {0.}; /**< minimal density at which particles are injected */
     bool m_use_density_table; /**< if a density value table was specified */
     /** plasma density value table, key: position=c*time, value=density function string */

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -101,6 +101,10 @@ PlasmaParticleContainer::ReadParameters ()
     bool density_func_specified = queryWithParserAlt(pp, "density(x,y,z)", density_func_str, pp_alt);
     m_density_func = makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"});
 
+    std::string transverse_profile_str = "1.";
+    queryWithParserAlt(pp, "transverse_profile(x,y)", transverse_profile_str, pp_alt);
+    m_transverse_profile = makeFunctionWithParser<2>(transverse_profile_str, m_transverse_parser, {"x", "y"});
+
     queryWithParserAlt(pp, "min_density", m_min_density, pp_alt);
 
     std::string density_table_file_name{};

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -102,6 +102,7 @@ InitParticles (const amrex::RealVect& a_u_std,
         const amrex::Real c_light = get_phys_const().c;
         UpdateDensityFunction(c_light * Hipace::m_physical_time);
         auto density_func = m_density_func;
+        auto transverse_profile = m_transverse_profile;
         const amrex::Real c_t = c_light * Hipace::m_physical_time;
         const amrex::Real min_density = m_min_density;
 
@@ -176,7 +177,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                         y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                         rsq > radius_sq ||
                         rsq < a_hollow_core_radius*a_hollow_core_radius ||
-                        density_func(x, y, c_t) <= min_density) continue;
+                        density_func(x, y, c_t) * transverse_profile(x, y) <= min_density) continue;
 
                     num_particles_cell += 1;
                 }
@@ -230,7 +231,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                     rsq > radius_sq ||
                     rsq < a_hollow_core_radius*a_hollow_core_radius ||
-                    density_func(x, y, c_t) <= min_density) return;
+                    density_func(x, y, c_t) * transverse_profile(x, y) <= min_density) return;
 
                 int ix = i - lo.x;
                 int iy = j - lo.y;
@@ -290,7 +291,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                     y >= a_bounds.hi(1) || y < a_bounds.lo(1) ||
                     rsq > radius_sq ||
                     rsq < a_hollow_core_radius*a_hollow_core_radius ||
-                    density_func(x, y, c_t) <= min_density) return;
+                    density_func(x, y, c_t) * transverse_profile(x, y) <= min_density) return;
 
                 amrex::Real u[3] = {0.,0.,0.};
                 ParticleUtil::get_gaussian_random_momentum(u, a_u_mean, a_u_std, engine);
@@ -303,14 +304,14 @@ InitParticles (const amrex::RealVect& a_u_std,
                 if (use_fine_patch) {
                     const int fine_loc = arr_fine(i, j, comp_a);
                     if (fine_loc == 0) {
-                        ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * scale_fac_lev[0];
+                        ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * transverse_profile(x, y) * scale_fac_lev[0];
                     } else if (fine_loc <= fine_transition_cells + 1) {
-                        ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * scale_fac_lev[1];
+                        ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * transverse_profile(x, y) * scale_fac_lev[1];
                     } else {
-                        ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * scale_fac_lev[2];
+                        ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * transverse_profile(x, y) * scale_fac_lev[2];
                     }
                 } else {
-                    ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * scale_fac_lev[0];
+                    ptd.rdata(PlasmaIdx::w)[pidx] = density_func(x, y, c_t) * transverse_profile(x, y) * scale_fac_lev[0];
                 }
 
                 ptd.rdata(PlasmaIdx::ux)[pidx] = u[0] * c_light;


### PR DESCRIPTION
This allows to combine a longitudinal profile from file with an analytical transverse profile, provided the two are separable.