### PR TITLE
try fix macos CI by uninstalling cmake

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,6 +83,8 @@ jobs:
 
         set -e
 
+        brew uninstall cmake
+
         brew tap openpmd/openpmd
         brew install openpmd-api --only-dependencies --force
         brew install openpmd-api

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,8 +83,10 @@ jobs:
 
         set -e
 
+        brew uninstall cmake
+
         brew tap openpmd/openpmd
-        brew install openpmd-api --only-dependencies
+        brew install openpmd-api --only-dependencies --force
         brew install openpmd-api
         brew link openpmd-api
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,10 +83,8 @@ jobs:
 
         set -e
 
-        brew uninstall cmake
-
         brew tap openpmd/openpmd
-        brew install openpmd-api --only-dependencies --force
+        brew install openpmd-api --only-dependencies
         brew install openpmd-api
         brew link openpmd-api
 


### PR DESCRIPTION
Fix this issue: https://github.com/Hi-PACE/hipace/actions/runs/17405622923/job/49412578933?pr=1280

Uninstalling cmake before openpmd installes it again seems to work (for now...).

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
