### PR TITLE
Add option to output fewer beam particles

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -628,6 +628,12 @@ which are valid only for certain beam types, are introduced further below under
     The ideal index type is different for beam push and beam deposition so some experimentation
     may be required to find the overall fastest setting for a specific simulation.
 
+* ``<beam name> or beams.output_ratio`` (`int`) optional (default `1`)
+    Set the fraction of beam particles that should be written to the openPMD output.
+    For example, an output ratio of 100 will output every 100th beam particle.
+    This is implemented using the particle ID, which is set in ascending order at
+    the beginning of a simulation.
+
 Option: ``fixed_weight_pdf``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -244,8 +244,14 @@ OpenPMDWriter::InitBeamData (MultiBeam& beams, const amrex::Vector< std::string 
         std::string name = beams.get_name(ibeam);
         if(std::find(beamnames.begin(), beamnames.end(), name) ==  beamnames.end() ) continue;
 
+        auto& beam = beams.getBeam(ibeam);
+
         // initialize beam IO on first slice
-        const uint64_t np_total = beams.getBeam(ibeam).getTotalNumParticles();
+        uint64_t np_total = beam.getTotalNumParticles();
+
+        if (beam.m_output_ratio > 1) {
+            np_total = (np_total + beam.m_output_ratio - 1) / beam.m_output_ratio;
+        }
 
         m_uint64_beam_data[ibeam].resize(m_int_names.size());
 
@@ -253,7 +259,7 @@ OpenPMDWriter::InitBeamData (MultiBeam& beams, const amrex::Vector< std::string 
             m_uint64_beam_data[ibeam][idx].resize(np_total);
         }
 
-        if (beams.getBeam(ibeam).m_do_spin_tracking) {
+        if (beam.m_do_spin_tracking) {
             m_real_beam_data[ibeam].resize(m_real_names.size() + m_real_names_spin.size());
         } else {
             m_real_beam_data[ibeam].resize(m_real_names.size());
@@ -347,7 +353,17 @@ OpenPMDWriter::CopyBeams (MultiBeam& beams, const amrex::Vector< std::string > b
 
         auto& beam = beams.getBeam(ibeam);
 
-        const uint64_t np = beam.getNumParticles(WhichBeamSlice::This);
+        uint64_t np = beam.getNumParticles(WhichBeamSlice::This);
+
+        const int output_ratio = beam.m_output_ratio;
+
+        if (output_ratio > 1) {
+            np = amrex::partitionParticles(beam.getBeamSlice(WhichBeamSlice::This),
+                [=] AMREX_GPU_DEVICE (auto& ptd, int i) {
+                    return i < int(np) && ptd.idcpu(i) % output_ratio == 0;
+                }
+            );
+        }
 
         if (np != 0) {
             // copy data from GPU to IO buffer

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -238,6 +238,8 @@ public:
     amrex::RealVect m_initial_spin = {1, 0, 0,};
     /** The anomalous magnetic moment */
     amrex::Real m_spin_anom = 0.00115965218128;
+    /** ratio of beam particles that are written to the openPMD output */
+    int m_output_ratio = 1;
 private:
     std::string m_name; /**< name of the species */
     /** injection type, fixed_width or fixed_ppc */

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -69,6 +69,8 @@ BeamParticleContainer::ReadParameters ()
     amrex::Array<int, 2> idx_array
         {Hipace::m_depos_order_xy % 2, Hipace::m_depos_order_xy % 2};
     queryWithParserAlt(pp, "reorder_idx_type", idx_array, pp_alt);
+    queryWithParserAlt(pp, "output_ratio", m_output_ratio, pp_alt);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_output_ratio >= 1, "output_ratio must be >= 1");
     m_reorder_idx_type = amrex::IntVect(idx_array[0], idx_array[1], 0);
     amrex::Array<std::string, 3> field_str = {"0", "0", "0"};
     m_use_external_fields = queryWithParserAlt(pp, "external_E(x,y,z,t)", field_str, pp_alt);

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -608,6 +608,9 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
         resize(which_slice, num_to_add_full, 0);
     }
 
+    const uint64_t pid = m_id64;
+    m_id64 += m_do_symmetrize ? 4*num_to_add_full : num_to_add_full;
+
     unsigned int loc_index = 0;
     for (int r=m_pdf_ref_ratio-1; r>=0; --r) {
         const unsigned int num_to_add = m_num_particles_slice[slice*m_pdf_ref_ratio+r];
@@ -616,9 +619,6 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
         auto& particle_tile = getBeamSlice(which_slice);
         // Access particles' SoA
         const auto ptd = particle_tile.getParticleTileData();
-
-        const uint64_t pid = m_id64;
-        m_id64 += m_do_symmetrize ? 4*num_to_add : num_to_add;
 
         const amrex::Real clight = get_phys_const().c;
         const bool do_symmetrize = m_do_symmetrize;


### PR DESCRIPTION
```
beams.output_ratio = 100
```

Set the fraction of beam particles that should be written to the openPMD output. For example, an output ratio of 100 will output every 100th beam particle. This is implemented using the particle ID, which is set in ascending order at the beginning of a simulation.

This PR also fixes an issue where with fixed_weight_pdf some IDs would be repeated.


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
