### PR TITLE
Add max_open_requests option to MultiBuffer

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -104,7 +104,7 @@ General parameters
     laser slice to avoid a deadlock, i.e.
     ``comms_buffer.max_size_GiB * nranks > beam_size + laser_size``.
 
-* ``comms_buffer.max_open_requests`` (`int`) optional (default `inf`)
+* ``comms_buffer.max_open_requests`` (`int`) optional (default `1000`)
     How many MPI requests may be open at the same time. Note that this is counted separately
     for each of the four different kinds of requests used. Must be set to at least two.
     Limiting the number of open requests is useful for simulations with many zeta slices

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -104,6 +104,13 @@ General parameters
     laser slice to avoid a deadlock, i.e.
     ``comms_buffer.max_size_GiB * nranks > beam_size + laser_size``.
 
+* ``comms_buffer.max_open_requests`` (`int`) optional (default `inf`)
+    How many MPI requests may be open at the same time. Note that this is counted separately
+    for each of the four different kinds of requests used. Must be set to at least two.
+    Limiting the number of open requests is useful for simulations with many zeta slices
+    (`>10000`) to reduce work for the MPI implementation.
+    Note that setting the limit too low may result in a deadlock.
+
 * ``comms_buffer.max_leading_slices`` (`int`) optional (default `inf`)
     How many slices of beam particles can be received and stored in advance.
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -650,14 +650,6 @@ Hipace::Evolve ()
 void
 Hipace::SolveOneSlice (int islice, int step)
 {
-#ifdef AMREX_USE_MPI
-    {
-        // Call a MPI function so that the MPI implementation has a chance to
-        // run tasks necessary to make progress with asynchronous communications.
-        int flag = 0;
-        MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag, MPI_STATUS_IGNORE);
-    }
-#endif
     HIPACE_PROFILE("Hipace::SolveOneSlice()");
 
     int current_N_level = 1;

--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -123,6 +123,7 @@ private:
     int m_max_trailing_slices = std::numeric_limits<int>::max();
     std::size_t m_current_buffer_size = 0;
     std::size_t m_max_buffer_size = std::numeric_limits<std::size_t>::max();
+    int m_max_open_requests = std::numeric_limits<int>::max();
 
     // parameters to send physical time
     amrex::Real m_time_send_buffer = 0.;
@@ -132,6 +133,14 @@ private:
     // slice index of where to continue making async progress
     std::array<int, comm_progress::nprogress> m_async_metadata_slice {};
     std::array<int, comm_progress::nprogress> m_async_data_slice {};
+
+    // calculate distance of a and b in the periodic range [0,m_nslices) with
+    // a barrier at current_slice
+    int periodic_distance (int current_slice, int a, int b) const;
+
+    // calculate min of a and b in the periodic range [0,m_nslices) with
+    // a barrier at current_slice
+    int periodic_min (int current_slice, int a, int b) const;
 
     // send some dummy messages so MPI can pre-register the memory
     void pre_register_memory ();
@@ -145,7 +154,10 @@ private:
     void free_buffer (int slice);
 
     // function containing main progress loop to deal with asynchronous MPI requests
-    void make_progress (int slice, bool is_blocking, int current_slice);
+    void make_progress (int slice, bool is_blocking_recv, int current_slice);
+
+    // call make_progress until the current slice is received
+    void progress_loop (int slice, bool is_blocking_recv);
 
     // write MultiBeam sizes into the metadata array
     void write_metadata (int slice, MultiBeam& beams, MultiLaser& laser, int beam_slice);

--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -156,8 +156,8 @@ private:
     // function containing main progress loop to deal with asynchronous MPI requests
     void make_progress (int slice, bool is_blocking_recv, int current_slice);
 
-    // call make_progress until the current slice is received
-    void progress_loop (int slice, bool is_blocking_recv);
+    // call make_progress asynchronously on strategic slices
+    void async_progress (int slice);
 
     // write MultiBeam sizes into the metadata array
     void write_metadata (int slice, MultiBeam& beams, MultiLaser& laser, int beam_slice);

--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -123,7 +123,7 @@ private:
     int m_max_trailing_slices = std::numeric_limits<int>::max();
     std::size_t m_current_buffer_size = 0;
     std::size_t m_max_buffer_size = std::numeric_limits<std::size_t>::max();
-    int m_max_open_requests = std::numeric_limits<int>::max();
+    int m_max_open_requests = 1000;
 
     // parameters to send physical time
     amrex::Real m_time_send_buffer = 0.;

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -10,6 +10,19 @@
 #include "HipaceProfilerWrapper.H"
 #include "Parser.H"
 
+int MultiBuffer::periodic_distance (int current_slice, int a, int b) const {
+    if (a <= current_slice) {
+        a += m_nslices;
+    }
+    if (b <= current_slice) {
+        b += m_nslices;
+    }
+    return b - a;
+}
+
+int MultiBuffer::periodic_min (int current_slice, int a, int b) const {
+    return periodic_distance(current_slice, a, b) < 0 ? b : a;
+}
 
 std::size_t MultiBuffer::get_metadata_size () {
     // 0: buffer size
@@ -76,6 +89,7 @@ void MultiBuffer::initialize (int nslices, MultiBeam& beams, MultiLaser& laser) 
     queryWithParser(pp, "on_gpu", m_buffer_on_gpu);
     queryWithParser(pp, "max_leading_slices", m_max_leading_slices);
     queryWithParser(pp, "max_trailing_slices", m_max_trailing_slices);
+    queryWithParser(pp, "max_open_requests", m_max_open_requests);
 #ifdef AMREX_USE_GPU
     queryWithParser(pp, "async_memcpy", m_async_memcpy);
     if (m_buffer_on_gpu)
@@ -164,9 +178,7 @@ void MultiBuffer::initialize (int nslices, MultiBeam& beams, MultiLaser& laser) 
     }
 
     // open initial receives
-    for (int i = m_nslices-1; i >= 0; --i) {
-        make_progress(i, false, m_nslices-1);
-    }
+    progress_loop(m_nslices-1, false);
 }
 
 void MultiBuffer::pre_register_memory () {
@@ -285,23 +297,16 @@ MultiBuffer::~MultiBuffer () {
 #endif
 }
 
-void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice) {
-    const bool is_first_slice_with_recv_data =
-        m_async_data_slice[comm_progress::receive_started] == slice;
-    const bool is_last_slice_with_send_data =
-        m_async_data_slice[comm_progress::sent] == slice;
-    const bool is_blocking_send = is_blocking ||
-        ((m_nslices + slice - current_slice) % m_nslices > m_max_trailing_slices) ||
-        (is_last_slice_with_send_data && (m_current_buffer_size > m_max_buffer_size));
-    const bool is_blocking_recv = is_blocking;
-    const bool skip_recv = !is_blocking_recv && (slice == current_slice ||
-        (m_nslices - slice + current_slice) % m_nslices > m_max_leading_slices);
+void MultiBuffer::make_progress (int slice, bool is_blocking_recv,
+                                 [[maybe_unused]] int current_slice) {
 
     if (m_is_serial) {
-        if (is_blocking) {
+        if (is_blocking_recv) {
             // send buffer to myself
-            AMREX_ALWAYS_ASSERT(m_datanodes[slice].m_metadata_progress == comm_progress::ready_to_send);
-            AMREX_ALWAYS_ASSERT(m_datanodes[slice].m_progress == comm_progress::ready_to_send);
+            AMREX_ALWAYS_ASSERT(m_datanodes[slice].m_metadata_progress ==
+                                comm_progress::ready_to_send);
+            AMREX_ALWAYS_ASSERT(m_datanodes[slice].m_progress ==
+                                comm_progress::ready_to_send);
             m_datanodes[slice].m_metadata_progress = comm_progress::received;
             m_datanodes[slice].m_progress = comm_progress::received;
         }
@@ -310,23 +315,45 @@ void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice)
 
 #ifdef AMREX_USE_MPI
 
+    const bool is_within_max_leading_slices = slice != current_slice &&
+        (m_nslices - slice + current_slice) % m_nslices <= m_max_leading_slices;
+    const bool is_within_max_trailing_slices =
+        (m_nslices + slice - current_slice) % m_nslices <= m_max_trailing_slices;
+
+    const bool is_blocking_send = is_blocking_recv ||
+        !is_within_max_trailing_slices ||
+        (m_async_data_slice[comm_progress::sent] == slice &&
+            m_current_buffer_size > m_max_buffer_size);
+
     if (m_datanodes[slice].m_metadata_progress == comm_progress::ready_to_send) {
-        MPI_Isend(
-            get_metadata_location(slice),
-            get_metadata_size(),
-            amrex::ParallelDescriptor::Mpi_typemap<std::size_t>::type(),
-            m_rank_send_to,
-            m_tag_metadata_start + slice,
-            m_comm,
-            &(m_datanodes[slice].m_metadata_request));
-        m_datanodes[slice].m_metadata_progress = comm_progress::send_started;
+
+        const bool allow_metadata_send = is_blocking_send ||
+            (periodic_distance(current_slice, slice,
+                m_async_metadata_slice[comm_progress::sent]) < m_max_open_requests);
+
+        if (allow_metadata_send) {
+            MPI_Isend(
+                get_metadata_location(slice),
+                get_metadata_size(),
+                amrex::ParallelDescriptor::Mpi_typemap<std::size_t>::type(),
+                m_rank_send_to,
+                m_tag_metadata_start + slice,
+                m_comm,
+                &(m_datanodes[slice].m_metadata_request));
+            m_datanodes[slice].m_metadata_progress = comm_progress::send_started;
+        }
     }
 
     if (m_datanodes[slice].m_progress == comm_progress::ready_to_send) {
+
+        const bool allow_data_send = is_blocking_send ||
+            (periodic_distance(current_slice, slice,
+                m_async_data_slice[comm_progress::sent]) < m_max_open_requests);
+
         if (m_datanodes[slice].m_buffer_size == 0) {
             // don't send empty buffer
             m_datanodes[slice].m_progress = comm_progress::sent;
-        } else {
+        } else if (allow_data_send) {
             MPI_Isend(
                 m_datanodes[slice].m_buffer,
                 m_datanodes[slice].m_buffer_size,
@@ -352,27 +379,37 @@ void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice)
         }
     }
 
-    if (m_datanodes[slice].m_metadata_progress == comm_progress::sent && !skip_recv) {
-        MPI_Irecv(
-            get_metadata_location(slice),
-            get_metadata_size(),
-            amrex::ParallelDescriptor::Mpi_typemap<std::size_t>::type(),
-            m_rank_receive_from,
-            m_tag_metadata_start + slice,
-            m_comm,
-            &(m_datanodes[slice].m_metadata_request));
-        m_datanodes[slice].m_metadata_progress = comm_progress::receive_started;
+    if (m_datanodes[slice].m_metadata_progress == comm_progress::sent) {
+
+        const bool allow_metadata_recv = is_blocking_recv ||
+            (is_within_max_leading_slices &&
+            (periodic_distance(current_slice, slice,
+                m_async_metadata_slice[comm_progress::received]) < m_max_open_requests));
+
+        if (allow_metadata_recv) {
+            MPI_Irecv(
+                get_metadata_location(slice),
+                get_metadata_size(),
+                amrex::ParallelDescriptor::Mpi_typemap<std::size_t>::type(),
+                m_rank_receive_from,
+                m_tag_metadata_start + slice,
+                m_comm,
+                &(m_datanodes[slice].m_metadata_request));
+            m_datanodes[slice].m_metadata_progress = comm_progress::receive_started;
+        }
     }
 
     if (m_datanodes[slice].m_metadata_progress == comm_progress::receive_started) {
         if (is_blocking_recv) {
             MPI_Wait(&(m_datanodes[slice].m_metadata_request), MPI_STATUS_IGNORE);
             m_datanodes[slice].m_metadata_progress = comm_progress::received;
+            m_datanodes[slice].m_buffer_size = get_metadata_location(slice)[0];
         } else {
             int is_complete = false;
             MPI_Test(&(m_datanodes[slice].m_metadata_request), &is_complete, MPI_STATUS_IGNORE);
             if (is_complete) {
                 m_datanodes[slice].m_metadata_progress = comm_progress::received;
+                m_datanodes[slice].m_buffer_size = get_metadata_location(slice)[0];
             }
         }
     }
@@ -395,29 +432,30 @@ void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice)
     if (m_datanodes[slice].m_progress == comm_progress::sent &&
         m_datanodes[slice].m_metadata_progress == comm_progress::received) {
 
-        AMREX_ALWAYS_ASSERT(m_datanodes[slice].m_location == memory_location::nowhere);
-
-        m_datanodes[slice].m_buffer_size = get_metadata_location(slice)[0];
+        // enforce that slices are received in order
+        const bool allow_data_recv = is_blocking_recv ||
+            (m_async_data_slice[comm_progress::receive_started] == slice &&
+            is_within_max_leading_slices &&
+            (m_current_buffer_size + m_datanodes[slice].m_buffer_size * sizeof(storage_type)
+                <= m_max_buffer_size) &&
+            (periodic_distance(current_slice, slice,
+                m_async_data_slice[comm_progress::received]) < m_max_open_requests));
 
         if (m_datanodes[slice].m_buffer_size == 0) {
             // don't receive empty buffer
             m_datanodes[slice].m_progress = comm_progress::received;
-        } else {
-            // enforce that slices are received in order
-            if (is_blocking_recv || (is_first_slice_with_recv_data &&
-                (m_current_buffer_size + m_datanodes[slice].m_buffer_size * sizeof(storage_type)
-                <= m_max_buffer_size))) {
-                allocate_buffer(slice);
-                MPI_Irecv(
-                    m_datanodes[slice].m_buffer,
-                    m_datanodes[slice].m_buffer_size,
-                    amrex::ParallelDescriptor::Mpi_typemap<storage_type>::type(),
-                    m_rank_receive_from,
-                    m_tag_buffer_start + slice,
-                    m_comm,
-                    &(m_datanodes[slice].m_request));
-                m_datanodes[slice].m_progress = comm_progress::receive_started;
-            }
+        } else if (allow_data_recv) {
+            AMREX_ALWAYS_ASSERT(m_datanodes[slice].m_location == memory_location::nowhere);
+            allocate_buffer(slice);
+            MPI_Irecv(
+                m_datanodes[slice].m_buffer,
+                m_datanodes[slice].m_buffer_size,
+                amrex::ParallelDescriptor::Mpi_typemap<storage_type>::type(),
+                m_rank_receive_from,
+                m_tag_buffer_start + slice,
+                m_comm,
+                &(m_datanodes[slice].m_request));
+            m_datanodes[slice].m_progress = comm_progress::receive_started;
         }
     }
 
@@ -440,6 +478,57 @@ void MultiBuffer::make_progress (int slice, bool is_blocking, int current_slice)
     }
 
 #endif
+}
+
+void MultiBuffer::progress_loop (int slice, bool is_blocking_recv) {
+
+    make_progress(slice, is_blocking_recv, slice);
+
+    if (is_blocking_recv) {
+        return;
+    }
+
+    // make asynchronous progress for metadata
+    // only check slices that have a chance of making progress
+    // first progress type starts at slice-1 or where it last stopped
+    m_async_metadata_slice[comm_progress::async_progress_end] =
+        slice == 0 ? m_nslices - 1 : slice - 1;
+    for (int p=comm_progress::async_progress_end-1; p>comm_progress::async_progress_begin; --p) {
+        m_async_metadata_slice[p] =
+            periodic_min(slice, m_async_metadata_slice[p], m_async_metadata_slice[p+1]);
+
+        // start at slice-1 (next slice), iterate backwards, loop around, stop at slice+1
+        for (int i = m_async_metadata_slice[p]; i!=slice; (i==0) ? i=m_nslices-1 : --i) {
+            m_async_metadata_slice[p] = i;
+            if (m_datanodes[i].m_metadata_progress < p) {
+                make_progress(i, false, slice);
+            }
+            if (m_datanodes[i].m_metadata_progress < p) {
+                break;
+            }
+        }
+    }
+
+    // make asynchronous progress for data
+    // only check slices that have a chance of making progress
+    // first progress type starts at slice-1 or where it last stopped
+    m_async_data_slice[comm_progress::async_progress_end] =
+        slice == 0 ? m_nslices - 1 : slice - 1;
+    for (int p=comm_progress::async_progress_end-1; p>comm_progress::async_progress_begin; --p) {
+        m_async_data_slice[p] =
+            periodic_min(slice, m_async_data_slice[p], m_async_data_slice[p+1]);
+
+        // start at slice-1 (next slice), iterate backwards, loop around, stop at slice+1
+        for (int i = m_async_data_slice[p]; i!=slice; (i==0) ? i=m_nslices-1 : --i) {
+            m_async_data_slice[p] = i;
+            if (m_datanodes[i].m_progress < p) {
+                make_progress(i, false, slice);
+            }
+            if (m_datanodes[i].m_progress < p) {
+                break;
+            }
+        }
+    }
 }
 
 void MultiBuffer::get_data (int slice, MultiBeam& beams, MultiLaser& laser, int beam_slice) {
@@ -534,79 +623,7 @@ void MultiBuffer::put_data (int slice, MultiBeam& beams, MultiLaser& laser, int 
         }
     }
 
-    make_progress(slice, false, slice);
-
-    // make asynchronous progress for metadata
-    // only check slices that have a chance of making progress
-    for (int p=comm_progress::async_progress_end-1; p>comm_progress::async_progress_begin; --p) {
-        if (p == comm_progress::async_progress_end-1) {
-            // first progress type starts at slice-1 or where it last stopped
-            if (m_async_metadata_slice[p] == slice) {
-                if (slice == 0) {
-                    m_async_metadata_slice[p] = m_nslices - 1;
-                } else {
-                    --m_async_metadata_slice[p];
-                }
-            }
-        } else {
-            // all other progress types start at the minimum of where they or
-            // the previous progress type last stopped
-            if ((m_async_metadata_slice[p+1] < slice) == (m_async_metadata_slice[p] <= slice)) {
-                if (m_async_metadata_slice[p+1] < m_async_metadata_slice[p]) {
-                    m_async_metadata_slice[p] = m_async_metadata_slice[p+1];
-                }
-            } else if (m_async_metadata_slice[p+1] > slice && m_async_metadata_slice[p] <= slice) {
-                m_async_metadata_slice[p] = m_async_metadata_slice[p+1];
-            }
-        }
-
-        // start at slice-1 (next slice), iterate backwards, loop around, stop at slice+1
-        for (int i = m_async_metadata_slice[p]; i!=slice; (i==0) ? i=m_nslices-1 : --i) {
-            m_async_metadata_slice[p] = i;
-            if (m_datanodes[i].m_metadata_progress < p) {
-                make_progress(i, false, slice);
-            }
-            if (m_datanodes[i].m_metadata_progress < p) {
-                break;
-            }
-        }
-    }
-
-    // make asynchronous progress for data
-    // only check slices that have a chance of making progress
-    for (int p=comm_progress::async_progress_end-1; p>comm_progress::async_progress_begin; --p) {
-        if (p == comm_progress::async_progress_end-1) {
-            // first progress type starts at slice-1 or where it last stopped
-            if (m_async_data_slice[p] == slice) {
-                if (slice == 0) {
-                    m_async_data_slice[p] = m_nslices - 1;
-                } else {
-                    --m_async_data_slice[p];
-                }
-            }
-        } else {
-            // all other progress types start at the minimum of where they or
-            // the previous progress type last stopped
-            if ((m_async_data_slice[p+1] < slice) == (m_async_data_slice[p] <= slice)) {
-                if (m_async_data_slice[p+1] < m_async_data_slice[p]) {
-                    m_async_data_slice[p] = m_async_data_slice[p+1];
-                }
-            } else if (m_async_data_slice[p+1] > slice && m_async_data_slice[p] <= slice) {
-                m_async_data_slice[p] = m_async_data_slice[p+1];
-            }
-        }
-
-        // start at slice-1 (next slice), iterate backwards, loop around, stop at slice+1
-        for (int i = m_async_data_slice[p]; i!=slice; (i==0) ? i=m_nslices-1 : --i) {
-            m_async_data_slice[p] = i;
-            if (m_datanodes[i].m_progress < p) {
-                make_progress(i, false, slice);
-            }
-            if (m_datanodes[i].m_progress < p) {
-                break;
-            }
-        }
-    }
+    progress_loop(slice, false);
 }
 
 amrex::Real MultiBuffer::get_time () {

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -403,13 +403,11 @@ void MultiBuffer::make_progress (int slice, bool is_blocking_recv,
         if (is_blocking_recv) {
             MPI_Wait(&(m_datanodes[slice].m_metadata_request), MPI_STATUS_IGNORE);
             m_datanodes[slice].m_metadata_progress = comm_progress::received;
-            m_datanodes[slice].m_buffer_size = get_metadata_location(slice)[0];
         } else {
             int is_complete = false;
             MPI_Test(&(m_datanodes[slice].m_metadata_request), &is_complete, MPI_STATUS_IGNORE);
             if (is_complete) {
                 m_datanodes[slice].m_metadata_progress = comm_progress::received;
-                m_datanodes[slice].m_buffer_size = get_metadata_location(slice)[0];
             }
         }
     }
@@ -431,6 +429,10 @@ void MultiBuffer::make_progress (int slice, bool is_blocking_recv,
 
     if (m_datanodes[slice].m_progress == comm_progress::sent &&
         m_datanodes[slice].m_metadata_progress == comm_progress::received) {
+
+        AMREX_ALWAYS_ASSERT(m_datanodes[slice].m_location == memory_location::nowhere);
+
+        m_datanodes[slice].m_buffer_size = get_metadata_location(slice)[0];
 
         // enforce that slices are received in order
         const bool allow_data_recv = is_blocking_recv ||

--- a/src/utils/MultiBuffer.cpp
+++ b/src/utils/MultiBuffer.cpp
@@ -90,6 +90,8 @@ void MultiBuffer::initialize (int nslices, MultiBeam& beams, MultiLaser& laser) 
     queryWithParser(pp, "max_leading_slices", m_max_leading_slices);
     queryWithParser(pp, "max_trailing_slices", m_max_trailing_slices);
     queryWithParser(pp, "max_open_requests", m_max_open_requests);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_open_requests >= 2,
+        "max_open_requests must be at least 2");
 #ifdef AMREX_USE_GPU
     queryWithParser(pp, "async_memcpy", m_async_memcpy);
     if (m_buffer_on_gpu)
@@ -178,7 +180,7 @@ void MultiBuffer::initialize (int nslices, MultiBeam& beams, MultiLaser& laser) 
     }
 
     // open initial receives
-    progress_loop(m_nslices-1, false);
+    async_progress(m_nslices-1);
 }
 
 void MultiBuffer::pre_register_memory () {
@@ -482,17 +484,14 @@ void MultiBuffer::make_progress (int slice, bool is_blocking_recv,
 #endif
 }
 
-void MultiBuffer::progress_loop (int slice, bool is_blocking_recv) {
+void MultiBuffer::async_progress (int slice) {
 
-    make_progress(slice, is_blocking_recv, slice);
+    make_progress(slice, false, slice);
 
-    if (is_blocking_recv) {
-        return;
-    }
-
-    // make asynchronous progress for metadata
+    // make asynchronous progress for data and metadata
     // only check slices that have a chance of making progress
     // first progress type starts at slice-1 or where it last stopped
+
     m_async_metadata_slice[comm_progress::async_progress_end] =
         slice == 0 ? m_nslices - 1 : slice - 1;
     for (int p=comm_progress::async_progress_end-1; p>comm_progress::async_progress_begin; --p) {
@@ -511,16 +510,12 @@ void MultiBuffer::progress_loop (int slice, bool is_blocking_recv) {
         }
     }
 
-    // make asynchronous progress for data
-    // only check slices that have a chance of making progress
-    // first progress type starts at slice-1 or where it last stopped
     m_async_data_slice[comm_progress::async_progress_end] =
         slice == 0 ? m_nslices - 1 : slice - 1;
     for (int p=comm_progress::async_progress_end-1; p>comm_progress::async_progress_begin; --p) {
         m_async_data_slice[p] =
             periodic_min(slice, m_async_data_slice[p], m_async_data_slice[p+1]);
 
-        // start at slice-1 (next slice), iterate backwards, loop around, stop at slice+1
         for (int i = m_async_data_slice[p]; i!=slice; (i==0) ? i=m_nslices-1 : --i) {
             m_async_data_slice[p] = i;
             if (m_datanodes[i].m_progress < p) {
@@ -625,7 +620,7 @@ void MultiBuffer::put_data (int slice, MultiBeam& beams, MultiLaser& laser, int 
         }
     }
 
-    progress_loop(slice, false);
+    async_progress(slice);
 }
 
 amrex::Real MultiBuffer::get_time () {


### PR DESCRIPTION
This PR adds the option to limit the number of open MPI requests:
```
comms_buffer.max_open_requests = 100
```
If a simulation has a lot of zeta slices (>10000), previously performance could drop due to the MPI implementation being inefficient with dealing with so many requests.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
