### PR TITLE
Add centralized output_folder option

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1175,7 +1175,7 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``0``)
     Period of the plasma in-situ diagnostics. `0` means no plasma in-situ diagnostics.
 
-* ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/plasma_insitu"``)
+* ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/insitu"``)
     Path of the plasma in-situ output. Must not be the same as `hipace.file_prefix`.
 
 * ``<plasma name> or plasmas.insitu_radius`` (`float`) optional (default ``infinity``)
@@ -1185,13 +1185,13 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``fields.insitu_period`` (`int`) optional (default ``0``)
     Period of the field in-situ diagnostics. `0` means no field in-situ diagnostics.
 
-* ``fields.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/field_insitu"``)
+* ``fields.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/insitu"``)
     Path of the field in-situ output. Must not be the same as `hipace.file_prefix`.
 
 * ``lasers.insitu_period`` (`int`) optional (default ``0``)
     Period of the laser in-situ diagnostics. `0` means no laser in-situ diagnostics.
 
-* ``lasers.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/laser_insitu"``)
+* ``lasers.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/insitu"``)
     Path of the laser in-situ output. Must not be the same as `hipace.file_prefix`.
 
 Additional physics

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1021,7 +1021,11 @@ in-situ diagnostics allow for fast analysis of large beams or the plasma particl
     Output period for standard beam and field diagnostics. Field or beam specific diagnostics can overwrite this parameter.
     No output is given for ``diagnostic.output_period = 0``.
 
-* ``hipace.file_prefix`` (`string`) optional (default `diags/hdf5/`)
+* ``hipace.output_folder`` (`string`) optional (default ``"diags"``)
+    Set the output path of diagnostic data. By default all types of diagnostics will output
+    into subfolders of this folder.
+
+* ``hipace.file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/hdf5/"``)
     Path of the output.
 
 * ``hipace.openpmd_backend`` (`string`) optional (default `h5`)
@@ -1161,7 +1165,7 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``<beam name> or beams.insitu_period`` (`int`) optional (default ``0``)
     Period of the beam in-situ diagnostics. `0` means no beam in-situ diagnostics.
 
-* ``<beam name> or beams.insitu_file_prefix`` (`string`) optional (default ``"diags/insitu"``)
+* ``<beam name> or beams.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/insitu"``)
     Path of the beam in-situ output. Must not be the same as `hipace.file_prefix`.
 
 * ``<beam name> or beams.insitu_radius`` (`float`) optional (default ``infinity``)
@@ -1171,7 +1175,7 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``<plasma name> or plasmas.insitu_period`` (`int`) optional (default ``0``)
     Period of the plasma in-situ diagnostics. `0` means no plasma in-situ diagnostics.
 
-* ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"plasma_diags/insitu"``)
+* ``<plasma name> or plasmas.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/plasma_insitu"``)
     Path of the plasma in-situ output. Must not be the same as `hipace.file_prefix`.
 
 * ``<plasma name> or plasmas.insitu_radius`` (`float`) optional (default ``infinity``)
@@ -1181,13 +1185,13 @@ Use ``hipace/tools/read_insitu_diagnostics.py`` to read the files using this for
 * ``fields.insitu_period`` (`int`) optional (default ``0``)
     Period of the field in-situ diagnostics. `0` means no field in-situ diagnostics.
 
-* ``fields.insitu_file_prefix`` (`string`) optional (default ``"diags/field_insitu"``)
+* ``fields.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/field_insitu"``)
     Path of the field in-situ output. Must not be the same as `hipace.file_prefix`.
 
 * ``lasers.insitu_period`` (`int`) optional (default ``0``)
     Period of the laser in-situ diagnostics. `0` means no laser in-situ diagnostics.
 
-* ``lasers.insitu_file_prefix`` (`string`) optional (default ``"diags/laser_insitu"``)
+* ``lasers.insitu_file_prefix`` (`string`) optional (default ``"<hipace.output_folder>/laser_insitu"``)
     Path of the laser in-situ output. Must not be the same as `hipace.file_prefix`.
 
 Additional physics

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -192,6 +192,8 @@ public:
     inline static Hipace* m_instance = nullptr;
     /** Whether to use normalized units */
     inline static bool m_normalized_units = false;
+    /** Default location for diagnostics output */
+    inline static std::string m_output_folder = "diags";
     /** All field data (3D array, slices) and field methods */
     Fields m_fields;
     /** Contains all beam species */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -52,6 +52,7 @@ Hipace_early_init::Hipace_early_init (Hipace* instance)
     queryWithParser(pph, "depos_derivative_type", m_depos_derivative_type);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_depos_order_xy != 0 || m_depos_derivative_type != 0,
                             "Analytic derivative with depos_order=0 would vanish");
+    queryWithParser(pph, "output_folder", Hipace::m_output_folder);
 
     amrex::ParmParse pp_amr("amr");
     int max_level = 0;

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -104,7 +104,11 @@ OpenPMDWriter::ReadParameters ()
         m_file_prefix = Hipace::m_output_folder + "/json";
     }
     // overwrite output path by choice of the user
-    queryWithParser(pp, "file_prefix", m_file_prefix);
+    const bool set_file_prefix = queryWithParser(pp, "file_prefix", m_file_prefix);
+    if (set_file_prefix) {
+        amrex::Print() <<
+            "It is recommended to use hipace.output_folder instead of hipace.file_prefix\n";
+    }
 
     // temporary workaround until openPMD-viewer gets fixed
     amrex::ParmParse ppd("diagnostic");

--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -97,11 +97,11 @@ OpenPMDWriter::ReadParameters ()
 
     // set default output path according to backend
     if (m_openpmd_backend == "h5") {
-        m_file_prefix = "diags/hdf5";
+        m_file_prefix = Hipace::m_output_folder + "/hdf5";
     } else if (m_openpmd_backend == "bp") {
-        m_file_prefix = "diags/adios2";
+        m_file_prefix = Hipace::m_output_folder + "/adios2";
     } else if (m_openpmd_backend == "json") {
-        m_file_prefix = "diags/json";
+        m_file_prefix = Hipace::m_output_folder + "/json";
     }
     // overwrite output path by choice of the user
     queryWithParser(pp, "file_prefix", m_file_prefix);

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -484,7 +484,7 @@ private:
     /** Sum of all per-slice real field properties */
     amrex::Vector<amrex::Real> m_insitu_sum_rdata;
     /** Prefix/path for the output files */
-    std::string m_insitu_file_prefix = "diags/field_insitu";
+    std::string m_insitu_file_prefix = "";
 };
 
 /** Helper struct to check whether a point is within a valid domain. */

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -41,6 +41,7 @@ Fields::ReadParameters (const int nlev)
 #endif
     queryWithParser(ppf, "poisson_solver", m_poisson_solver_str);
     queryWithParser(ppf, "insitu_period", m_insitu_period);
+    m_insitu_file_prefix = Hipace::m_output_folder + "/field_insitu";
     queryWithParser(ppf, "insitu_file_prefix", m_insitu_file_prefix);
     queryWithParser(ppf, "do_symmetrize", m_do_symmetrize);
     DeprecatedInput("fields", "extended_solve",

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -42,7 +42,11 @@ Fields::ReadParameters (const int nlev)
     queryWithParser(ppf, "poisson_solver", m_poisson_solver_str);
     queryWithParser(ppf, "insitu_period", m_insitu_period);
     m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
-    queryWithParser(ppf, "insitu_file_prefix", m_insitu_file_prefix);
+    const bool set_file_prefix = queryWithParser(ppf, "insitu_file_prefix", m_insitu_file_prefix);
+    if (set_file_prefix) {
+        amrex::Print() <<
+            "It is recommended to use hipace.output_folder instead of fields.insitu_file_prefix\n";
+    }
     queryWithParser(ppf, "do_symmetrize", m_do_symmetrize);
     DeprecatedInput("fields", "extended_solve",
                     "boundary.particle_lo and boundary.particle_hi", "", true);

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -41,7 +41,7 @@ Fields::ReadParameters (const int nlev)
 #endif
     queryWithParser(ppf, "poisson_solver", m_poisson_solver_str);
     queryWithParser(ppf, "insitu_period", m_insitu_period);
-    m_insitu_file_prefix = Hipace::m_output_folder + "/field_insitu";
+    m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
     queryWithParser(ppf, "insitu_file_prefix", m_insitu_file_prefix);
     queryWithParser(ppf, "do_symmetrize", m_do_symmetrize);
     DeprecatedInput("fields", "extended_solve",

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -252,7 +252,7 @@ private:
     /** All per-slice complex laser properties */
     amrex::Vector<amrex::GpuComplex<amrex::Real>> m_insitu_cdata;
     /** Prefix/path for the output files */
-    std::string m_insitu_file_prefix = "diags/laser_insitu";
+    std::string m_insitu_file_prefix = "";
 };
 
 #endif // MULTILASER_H_

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -55,7 +55,7 @@ MultiLaser::ReadParameters ()
     }
 
     queryWithParser(pp, "insitu_period", m_insitu_period);
-    m_insitu_file_prefix = Hipace::m_output_folder + "/laser_insitu";
+    m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
     queryWithParser(pp, "insitu_file_prefix", m_insitu_file_prefix);
 }
 

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -55,6 +55,7 @@ MultiLaser::ReadParameters ()
     }
 
     queryWithParser(pp, "insitu_period", m_insitu_period);
+    m_insitu_file_prefix = Hipace::m_output_folder + "/laser_insitu";
     queryWithParser(pp, "insitu_file_prefix", m_insitu_file_prefix);
 }
 

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -56,7 +56,11 @@ MultiLaser::ReadParameters ()
 
     queryWithParser(pp, "insitu_period", m_insitu_period);
     m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
-    queryWithParser(pp, "insitu_file_prefix", m_insitu_file_prefix);
+    const bool set_file_prefix = queryWithParser(pp, "insitu_file_prefix", m_insitu_file_prefix);
+    if (set_file_prefix) {
+        amrex::Print() <<
+            "It is recommended to use hipace.output_folder instead of lasers.insitu_file_prefix\n";
+    }
 }
 
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -334,7 +334,7 @@ private:
     /** Sum of all per-slice int beam properties */
     amrex::Vector<int> m_insitu_sum_idata;
     /** Prefix/path for the output files */
-    std::string m_insitu_file_prefix = "diags/insitu";
+    std::string m_insitu_file_prefix = "";
 
     // spin insitu:
 

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -60,6 +60,7 @@ BeamParticleContainer::ReadParameters ()
     queryWithParserAlt(pp, "do_push", m_do_push, pp_alt);
     queryWithParserAlt(pp, "do_radiation_reaction", m_do_radiation_reaction, pp_alt);
     queryWithParserAlt(pp, "insitu_period", m_insitu_period, pp_alt);
+    m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
     queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
     queryWithParserAlt(pp, "insitu_radius", m_insitu_radius, pp_alt);
     queryWithParser(pp, "n_subcycles", m_n_subcycles);

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -61,7 +61,12 @@ BeamParticleContainer::ReadParameters ()
     queryWithParserAlt(pp, "do_radiation_reaction", m_do_radiation_reaction, pp_alt);
     queryWithParserAlt(pp, "insitu_period", m_insitu_period, pp_alt);
     m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
-    queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
+    const bool set_file_prefix =
+        queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
+    if (set_file_prefix) {
+        amrex::Print() <<
+            "It is recommended to use hipace.output_folder instead of beams.insitu_file_prefix\n";
+    }
     queryWithParserAlt(pp, "insitu_radius", m_insitu_radius, pp_alt);
     queryWithParser(pp, "n_subcycles", m_n_subcycles);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_n_subcycles >= 1, "n_subcycles must be >= 1");

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -245,7 +245,7 @@ private:
     /** Sum of all per-slice int plasma properties */
     amrex::Vector<int> m_insitu_sum_idata;
     /** Prefix/path for the output files */
-    std::string m_insitu_file_prefix = "diags/plasma_insitu";
+    std::string m_insitu_file_prefix = "";
 };
 
 /** \brief Iterator over boxes in a particle container */

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -156,7 +156,12 @@ PlasmaParticleContainer::ReadParameters ()
     m_reorder_idx_type = amrex::IntVect(idx_array[0], idx_array[1], 0);
     queryWithParserAlt(pp, "insitu_period", m_insitu_period, pp_alt);
     m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
-    queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
+    const bool set_file_prefix =
+        queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
+    if (set_file_prefix) {
+        amrex::Print() <<
+            "It is recommended to use hipace.output_folder instead of plasmas.insitu_file_prefix\n";
+    }
     queryWithParserAlt(pp, "prevent_centered_particle", m_prevent_centered_particle, pp_alt);
     queryWithParserAlt(pp, "do_push", m_do_push, pp_alt);
 }

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -155,7 +155,7 @@ PlasmaParticleContainer::ReadParameters ()
     queryWithParserAlt(pp, "reorder_idx_type", idx_array, pp_alt);
     m_reorder_idx_type = amrex::IntVect(idx_array[0], idx_array[1], 0);
     queryWithParserAlt(pp, "insitu_period", m_insitu_period, pp_alt);
-    m_insitu_file_prefix = Hipace::m_output_folder + "/plasma_insitu";
+    m_insitu_file_prefix = Hipace::m_output_folder + "/insitu";
     queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
     queryWithParserAlt(pp, "prevent_centered_particle", m_prevent_centered_particle, pp_alt);
     queryWithParserAlt(pp, "do_push", m_do_push, pp_alt);

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -155,6 +155,7 @@ PlasmaParticleContainer::ReadParameters ()
     queryWithParserAlt(pp, "reorder_idx_type", idx_array, pp_alt);
     m_reorder_idx_type = amrex::IntVect(idx_array[0], idx_array[1], 0);
     queryWithParserAlt(pp, "insitu_period", m_insitu_period, pp_alt);
+    m_insitu_file_prefix = Hipace::m_output_folder + "/plasma_insitu";
     queryWithParserAlt(pp, "insitu_file_prefix", m_insitu_file_prefix, pp_alt);
     queryWithParserAlt(pp, "prevent_centered_particle", m_prevent_centered_particle, pp_alt);
     queryWithParserAlt(pp, "do_push", m_do_push, pp_alt);


### PR DESCRIPTION
This PR adds an option to set the default folder location for all types of diagnostics by setting a default for all `...file_prefix` options. This is backwards compatible due to the choice of `"diags"` as the default `hipace.output_folder`.
```bash
hipace.output_folder = "diags/new/test1"
```
```
sinnalex@uan02:/diags/new/test1> ls -R
.:
field_insitu  hdf5  insitu  plasma_insitu

./field_insitu:
reduced_fields.0000.txt  reduced_fields.0004.txt  reduced_fields.0008.txt  reduced_fields.0012.txt
reduced_fields.0001.txt  reduced_fields.0005.txt  reduced_fields.0009.txt  reduced_fields.0013.txt
reduced_fields.0002.txt  reduced_fields.0006.txt  reduced_fields.0010.txt  reduced_fields.0014.txt
reduced_fields.0003.txt  reduced_fields.0007.txt  reduced_fields.0011.txt  reduced_fields.0015.txt

./hdf5:
openpmd_000000.h5  openpmd_000015.h5

./insitu:
reduced_driver.0000.txt  reduced_driver_ghost.0000.txt  reduced_witness.0000.txt
reduced_driver.0001.txt  reduced_driver_ghost.0001.txt  reduced_witness.0001.txt
reduced_driver.0002.txt  reduced_driver_ghost.0002.txt  reduced_witness.0002.txt
reduced_driver.0003.txt  reduced_driver_ghost.0003.txt  reduced_witness.0003.txt
reduced_driver.0004.txt  reduced_driver_ghost.0004.txt  reduced_witness.0004.txt
reduced_driver.0005.txt  reduced_driver_ghost.0005.txt  reduced_witness.0005.txt
reduced_driver.0006.txt  reduced_driver_ghost.0006.txt  reduced_witness.0006.txt
reduced_driver.0007.txt  reduced_driver_ghost.0007.txt  reduced_witness.0007.txt
reduced_driver.0008.txt  reduced_driver_ghost.0008.txt  reduced_witness.0008.txt
reduced_driver.0009.txt  reduced_driver_ghost.0009.txt  reduced_witness.0009.txt
reduced_driver.0010.txt  reduced_driver_ghost.0010.txt  reduced_witness.0010.txt
reduced_driver.0011.txt  reduced_driver_ghost.0011.txt  reduced_witness.0011.txt
reduced_driver.0012.txt  reduced_driver_ghost.0012.txt  reduced_witness.0012.txt
reduced_driver.0013.txt  reduced_driver_ghost.0013.txt  reduced_witness.0013.txt
reduced_driver.0014.txt  reduced_driver_ghost.0014.txt  reduced_witness.0014.txt
reduced_driver.0015.txt  reduced_driver_ghost.0015.txt  reduced_witness.0015.txt

./plasma_insitu:
reduced_electron.0000.txt  reduced_electron.0008.txt  reduced_ion.0000.txt  reduced_ion.0008.txt
reduced_electron.0001.txt  reduced_electron.0009.txt  reduced_ion.0001.txt  reduced_ion.0009.txt
reduced_electron.0002.txt  reduced_electron.0010.txt  reduced_ion.0002.txt  reduced_ion.0010.txt
reduced_electron.0003.txt  reduced_electron.0011.txt  reduced_ion.0003.txt  reduced_ion.0011.txt
reduced_electron.0004.txt  reduced_electron.0012.txt  reduced_ion.0004.txt  reduced_ion.0012.txt
reduced_electron.0005.txt  reduced_electron.0013.txt  reduced_ion.0005.txt  reduced_ion.0013.txt
reduced_electron.0006.txt  reduced_electron.0014.txt  reduced_ion.0006.txt  reduced_ion.0014.txt
reduced_electron.0007.txt  reduced_electron.0015.txt  reduced_ion.0007.txt  reduced_ion.0015.txt
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
