### PR TITLE
Initialize beam from list in input file

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -581,7 +581,7 @@ which are valid only for certain beam types, are introduced further below under
 
 * ``<beam name>.injection_type`` (`string`)
     The injection type for the particle beam. Currently available are ``fixed_weight_pdf``, ``fixed_weight``, ``fixed_ppc``,
-    and ``from_file``.
+    ``from_file`` and ``from_list``.
     ``fixed_weight_pdf`` generates a beam with a fixed number of particles with a constant weight where
     the transverse profile is Gaussian and the longitudinal profile is arbitrary according to a
     user-specified probability density function. It is more general and faster, and uses
@@ -590,6 +590,7 @@ which are valid only for certain beam types, are introduced further below under
     ``fixed_ppc`` generates a beam with a fixed number of particles per cell and
     varying weights. It can be either a Gaussian or a flattop beam.
     ``from_file`` reads a beam from openPMD files.
+    ``from_list`` reads a beam from arrays provided directly in the input script.
 
 * ``<beam name>.element`` (`string`) optional (default `electron`)
     The Physical Element of the plasma. Sets charge, mass and, if available,
@@ -855,6 +856,27 @@ Option: ``from_file``
 * ``<beam name> or beams.initialize_on_cpu`` (`bool`) optional (default `0`)
     Whether to initialize the beam on the CPU instead of the GPU.
     Initializing the beam on the CPU can be much slower but is necessary if the full beam does not fit into GPU memory.
+
+Option: ``from_list``
+^^^^^^^^^^^^^^^^^^^^^
+
+* ``<beam name>.num_particles`` (`int`)
+    Number of particles to generate the beam. If this is equal to zero,
+    then the other parameters can be omitted.
+
+* ``<beam name>.init_pos_x``, ``<beam name>.init_pos_y`` and ``<beam name>.init_pos_z`` (`float`)
+    List of initial x-, y- and z-positions for all beam particles.
+
+* ``<beam name>.init_ux``, ``<beam name>.init_uy`` and ``<beam name>.init_uz`` (`float`)
+    List of initial normalized momentum (:math:`= \gamma \beta = \frac{p}{m c}`)
+    in x, y and z for all beam particles.
+
+* ``<beam name>.init_weight`` (`float`)
+    List of macro-particle weight for all beam particles.
+    A value of one corresponds to one physical particle.
+
+* ``<beam name>.init_sx``, ``<beam name>.init_sy`` and ``<beam name>.init_sz`` (`float`)
+    If spin-tracking is enabled, list of initial x-, y- and z-spin for all beam particles.
 
 SALAME algorithm
 ^^^^^^^^^^^^^^^^

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -122,6 +122,9 @@ public:
                                   const bool species_specified);
 #endif
 
+    /** Initialize a beam from a list in the input script */
+    void InitBeamFromList3D ();
+
     /** Compute reduced beam diagnostics of current slice, store in member variable
      * \param[in] islice current slice, on which diags are computed.
      */
@@ -317,6 +320,10 @@ private:
     amrex::Array<std::string, AMREX_SPACEDIM> m_file_coordinates_xyz;
     int m_num_iteration {0}; /**< the iteration of the openPMD beam */
     std::string m_species_name; /**< the name of the particle species in the beam file */
+
+    // from list
+
+    amrex::Long m_num_particles_list; /**< Number of particles in input list */
 
     // insitu:
 

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -89,14 +89,14 @@ BeamParticleContainer::ReadParameters ()
         {"x", "y", "z", "t"});
     m_external_fields[5] = makeFunctionWithParser<4>(field_str[2], m_external_fields_parser[5],
         {"x", "y", "z", "t"});
-    if (m_injection_type == "fixed_ppc" || m_injection_type == "from_file"){
+    if (m_injection_type != "fixed_weight"){
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_duz_per_uz0_dzeta == 0.,
         "Tilted beams and correlated energy spreads are only implemented for fixed weight beams");
     }
     queryWithParserAlt(pp, "initialize_on_cpu", m_initialize_on_cpu, pp_alt);
     queryWithParserAlt(pp, "do_spin_tracking", m_do_spin_tracking, pp_alt);
     if (m_do_spin_tracking) {
-        if (m_injection_type != "from_file") {
+        if (m_injection_type != "from_file" && m_injection_type != "from_list") {
             getWithParserAlt(pp, "initial_spin", m_initial_spin, pp_alt);
         }
         queryWithParserAlt(pp, "spin_anom", m_spin_anom, pp_alt);
@@ -282,7 +282,8 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         }
     } else {
 
-        amrex::Abort("Unknown beam injection type. Must be fixed_ppc, fixed_weight or from_file\n");
+        amrex::Abort("Unknown beam injection type. Must be fixed_ppc, fixed_weight, from_file"
+            " or from_list\n");
 
     }
 

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -271,6 +271,15 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
         amrex::Abort("beam particle injection via external_file requires openPMD support: "
                      "Add HiPACE_OPENPMD=ON when compiling HiPACE++.\n");
 #endif  // HIPACE_USE_OPENPMD
+    } else if (m_injection_type == "from_list") {
+        getWithParser(pp, "num_particles", m_num_particles_list);
+        m_total_num_particles = m_num_particles_list;
+        InitBeamFromList3D();
+        if (Hipace::HeadRank()) {
+            m_init_sorter.sortParticlesByBox(
+                getBeamInitSlice().GetStructOfArrays().GetRealData(BeamIdx::z).dataPtr(),
+                getBeamInitSlice().size(), m_initialize_on_cpu, geom);
+        }
     } else {
 
         amrex::Abort("Unknown beam injection type. Must be fixed_ppc, fixed_weight or from_file\n");
@@ -354,7 +363,7 @@ BeamParticleContainer::initializeSlice (int slice, int which_slice) {
         InitBeamFixedWeightSlice(slice, which_slice);
     } else if (m_injection_type == "fixed_weight_pdf") {
         InitBeamFixedWeightPDFSlice(slice, which_slice);
-    } else {
+    } else { // from_file and from_list
         HIPACE_PROFILE("BeamParticleContainer::initializeSlice()");
         const int num_particles = m_init_sorter.m_box_counts_cpu[slice];
 
@@ -389,7 +398,7 @@ BeamParticleContainer::initializeSlice (int slice, int which_slice) {
         );
     }
 
-    if (m_do_spin_tracking && m_injection_type != "from_file") {
+    if (m_do_spin_tracking && m_injection_type != "from_file" && m_injection_type != "from_list" ) {
         HIPACE_PROFILE("BeamParticleContainer::initializeSpin()");
         auto ptd = getBeamSlice(which_slice).getParticleTileData();
 

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -744,10 +744,10 @@ InitBeamFromList3D ()
         AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_sz.size()) == m_num_particles_list);
     }
 
-    const amrex::Real *p_x = init_x.dataPtr(), *p_y = init_x.dataPtr(), *p_z = init_x.dataPtr();
-    const amrex::Real *p_ux = init_x.dataPtr(), *p_uy = init_x.dataPtr(), *p_uz = init_x.dataPtr();
-    const amrex::Real *p_w = init_x.dataPtr();
-    const amrex::Real *p_sx = init_x.dataPtr(), *p_sy = init_x.dataPtr(), *p_sz = init_x.dataPtr();
+    const amrex::Real *p_x=init_x.dataPtr(), *p_y=init_y.dataPtr(), *p_z=init_z.dataPtr();
+    const amrex::Real *p_ux=init_ux.dataPtr(), *p_uy=init_uy.dataPtr(), *p_uz=init_uz.dataPtr();
+    const amrex::Real *p_w=init_w.dataPtr();
+    const amrex::Real *p_sx=init_sx.dataPtr(), *p_sy=init_sy.dataPtr(), *p_sz=init_sz.dataPtr();
 
     auto& particle_tile = getBeamInitSlice();
     auto old_size = particle_tile.size();

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -731,17 +731,17 @@ InitBeamFromList3D ()
         getWithParser(pp, "init_sz", init_sz);
     }
 
-    AMREX_ALWAYS_ASSERT(amrex::Long{init_x.size()} == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(amrex::Long{init_y.size()} == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(amrex::Long{init_z.size()} == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(amrex::Long{init_ux.size()} == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(amrex::Long{init_uy.size()} == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(amrex::Long{init_uz.size()} == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(amrex::Long{init_w.size()} == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_x.size()) == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_y.size()) == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_z.size()) == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_ux.size()) == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_uy.size()) == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_uz.size()) == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_w.size()) == m_num_particles_list);
     if (do_spin_tracking) {
-        AMREX_ALWAYS_ASSERT(amrex::Long{init_sx.size()} == m_num_particles_list);
-        AMREX_ALWAYS_ASSERT(amrex::Long{init_sy.size()} == m_num_particles_list);
-        AMREX_ALWAYS_ASSERT(amrex::Long{init_sz.size()} == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_sx.size()) == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_sy.size()) == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(init_sz.size()) == m_num_particles_list);
     }
 
     const amrex::Real *p_x = init_x.dataPtr(), *p_y = init_x.dataPtr(), *p_z = init_x.dataPtr();

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -24,7 +24,6 @@
 
 namespace
 {
-#ifdef HIPACE_USE_OPENPMD
     /** \brief Adds a single beam particle
      *
      * \param[in,out] ptd real and int beam data
@@ -71,7 +70,6 @@ namespace
         ptd.idcpu(ip) = pid + ip;
         ptd.id(ip).make_valid();
     }
-#endif // HIPACE_USE_OPENPMD
 
     /** \brief Adds a single beam particle into the per-slice BeamTile
      *
@@ -703,6 +701,79 @@ InitBeamFixedWeightPDFSlice (int slice, int which_slice)
 
         loc_index += num_to_add;
     }
+}
+
+void
+BeamParticleContainer::
+InitBeamFromList3D ()
+{
+    HIPACE_PROFILE("BeamParticleContainer::InitBeamFromList3D()");
+    using namespace amrex::literals;
+
+    if (!Hipace::HeadRank() || m_num_particles_list == 0) { return; }
+
+    const bool do_spin_tracking = m_do_spin_tracking;
+
+    amrex::Gpu::PinnedVector<amrex::Real> init_x, init_y, init_z, init_ux, init_uy, init_uz, init_w;
+    amrex::Gpu::PinnedVector<amrex::Real> init_sx, init_sy, init_sz;
+
+    amrex::ParmParse pp(m_name);
+    getWithParser(pp, "init_pos_x", init_x);
+    getWithParser(pp, "init_pos_y", init_y);
+    getWithParser(pp, "init_pos_z", init_z);
+    getWithParser(pp, "init_ux", init_ux);
+    getWithParser(pp, "init_uy", init_uy);
+    getWithParser(pp, "init_uz", init_uz);
+    getWithParser(pp, "init_weight", init_w);
+    if (do_spin_tracking) {
+        getWithParser(pp, "init_sx", init_sx);
+        getWithParser(pp, "init_sy", init_sy);
+        getWithParser(pp, "init_sz", init_sz);
+    }
+
+    AMREX_ALWAYS_ASSERT(init_x.size() == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(init_y.size() == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(init_z.size() == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(init_ux.size() == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(init_uy.size() == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(init_uz.size() == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(init_w.size() == m_num_particles_list);
+    if (do_spin_tracking) {
+        AMREX_ALWAYS_ASSERT(init_sx.size() == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(init_sy.size() == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(init_sz.size() == m_num_particles_list);
+    }
+
+    const amrex::Real *p_x = init_x.dataPtr(), *p_y = init_x.dataPtr(), *p_z = init_x.dataPtr();
+    const amrex::Real *p_ux = init_x.dataPtr(), *p_uy = init_x.dataPtr(), *p_uz = init_x.dataPtr();
+    const amrex::Real *p_w = init_x.dataPtr();
+    const amrex::Real *p_sx = init_x.dataPtr(), *p_sy = init_x.dataPtr(), *p_sz = init_x.dataPtr();
+
+    auto& particle_tile = getBeamInitSlice();
+    auto old_size = particle_tile.size();
+    auto new_size = old_size + m_num_particles_list;
+    particle_tile.resize(new_size);
+
+    const auto ptd = particle_tile.getParticleTileData();
+    const auto enforceBC = EnforceBC();
+    const amrex::Real clight = get_phys_const().c;
+
+    const uint64_t pid = m_id64;
+    m_id64 += m_num_particles_list;
+
+    amrex::ParallelFor(amrex::Long(m_num_particles_list),
+        [=] AMREX_GPU_DEVICE (const amrex::Long i) {
+            AddOneBeamParticle(ptd,
+                p_x[i], p_y[i], p_z[i],
+                p_ux[i], p_uy[i], p_uz[i],
+                do_spin_tracking ? p_sx[i] : 0.,
+                do_spin_tracking ? p_sy[i] : 0.,
+                do_spin_tracking ? p_sz[i] : 0.,
+                p_w[i],
+                pid, i, clight, enforceBC, do_spin_tracking);
+        });
+
+    amrex::Gpu::streamSynchronize();
 }
 
 #ifdef HIPACE_USE_OPENPMD

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -731,17 +731,17 @@ InitBeamFromList3D ()
         getWithParser(pp, "init_sz", init_sz);
     }
 
-    AMREX_ALWAYS_ASSERT(init_x.size() == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(init_y.size() == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(init_z.size() == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(init_ux.size() == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(init_uy.size() == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(init_uz.size() == m_num_particles_list);
-    AMREX_ALWAYS_ASSERT(init_w.size() == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(amrex::Long{init_x.size()} == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(amrex::Long{init_y.size()} == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(amrex::Long{init_z.size()} == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(amrex::Long{init_ux.size()} == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(amrex::Long{init_uy.size()} == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(amrex::Long{init_uz.size()} == m_num_particles_list);
+    AMREX_ALWAYS_ASSERT(amrex::Long{init_w.size()} == m_num_particles_list);
     if (do_spin_tracking) {
-        AMREX_ALWAYS_ASSERT(init_sx.size() == m_num_particles_list);
-        AMREX_ALWAYS_ASSERT(init_sy.size() == m_num_particles_list);
-        AMREX_ALWAYS_ASSERT(init_sz.size() == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(amrex::Long{init_sx.size()} == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(amrex::Long{init_sy.size()} == m_num_particles_list);
+        AMREX_ALWAYS_ASSERT(amrex::Long{init_sz.size()} == m_num_particles_list);
     }
 
     const amrex::Real *p_x = init_x.dataPtr(), *p_y = init_x.dataPtr(), *p_z = init_x.dataPtr();

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -266,6 +266,17 @@ namespace Parser
         }
     }
 
+    template<class T, class Allocator>
+    inline void
+    fillWithParserArr (const amrex::ParmParse& pp, std::vector<std::string> const& str_arr,
+                       amrex::PODVector<T, Allocator>& val_arr) {
+        auto const n = str_arr.size();
+        val_arr.resize(n);
+        for (auto i=0ul ; i != n ; ++i) {
+            fillWithParser(pp, str_arr[i], val_arr[i]);
+        }
+    }
+
     template<class T, std::size_t size>
     inline void
     fillWithParserArr (const amrex::ParmParse& pp, std::vector<std::string> const& str_arr,

--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -14,6 +14,7 @@
 #include <AMReX_Parser.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_IntVect.H>
+#include <AMReX_PODVector.H>
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
The from_list injection type allows to set the coordinates of individual particles directly from the input script:
```
beams.names = beam
beam.injection_type = from_list
beam.num_particles = 15
beam.init_pos_x =  -1.5 1.5 2  -2   1  -1  -1.5 1.5 0   1  -1  -2   2  -3   3
beam.init_pos_y =   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
beam.init_pos_z =  -2  -2  -1  -1  -1  -1 -0.5 -0.5 -7 -7  -7  -6  -6  -5  -5
beam.init_ux =      0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
beam.init_uy =      0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
beam.init_uz =      200 200 200 200 200 200 200 200 200 200 200 200 200 200 200
beam.init_weight =  1   1   1   1   1   1   1   1   1   1   1   1   1   1   1
```
Result:
<img width="1415" height="1169" alt="image" src="https://github.com/user-attachments/assets/58f8f79f-2d74-43da-875a-1a233ca09477" />

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
