### PR TITLE
Use copyAsync instead of dtoh_memcpy_async

### DIFF
--- a/src/particles/sorting/BoxSort.cpp
+++ b/src/particles/sorting/BoxSort.cpp
@@ -60,19 +60,11 @@ void BoxSorter::sortParticlesByBox (const amrex::Real * z_array, const index_typ
             p_permutations[local_offset + p_box_offsets[dst_box]] = i;
         });
 
-#ifdef AMREX_USE_GPU
-    amrex::Gpu::dtoh_memcpy_async(m_box_counts_cpu.dataPtr(), box_counts.dataPtr(),
-                                  box_counts.size() * sizeof(index_type));
+    amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost, box_counts.begin(), box_counts.end(),
+        m_box_counts_cpu.begin());
 
-    amrex::Gpu::dtoh_memcpy_async(m_box_offsets_cpu.dataPtr(), box_offsets.dataPtr(),
-                                  box_offsets.size() * sizeof(index_type));
+    amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost, box_offsets.begin(), box_offsets.end(),
+        m_box_offsets_cpu.begin());
 
     amrex::Gpu::streamSynchronize();
-#else
-    std::memcpy(m_box_counts_cpu.dataPtr(), box_counts.dataPtr(),
-                box_counts.size() * sizeof(index_type));
-
-    std::memcpy(m_box_offsets_cpu.dataPtr(), box_offsets.dataPtr(),
-                box_offsets.size() * sizeof(index_type));
-#endif
 }


### PR DESCRIPTION
A bit cleaner as copyAsync also works when compiling for CPU.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
