### PR TITLE
Add in-situ diagnostic to get_started input files

### DIFF
--- a/docs/source/run/get_started.rst
+++ b/docs/source/run/get_started.rst
@@ -27,7 +27,7 @@ Then you can use the `openPMD-viewer <https://github.com/openPMD/openPMD-viewer>
    import numpy as np
    import matplotlib.pyplot as plt
    from openpmd_viewer import OpenPMDTimeSeries
-   # from hipace tools
+   # from tools/
    import read_insitu_diagnostics as diag
    # Read the simulation data
    ts = OpenPMDTimeSeries('./diags/hdf5/')

--- a/docs/source/run/get_started.rst
+++ b/docs/source/run/get_started.rst
@@ -27,12 +27,22 @@ Then you can use the `openPMD-viewer <https://github.com/openPMD/openPMD-viewer>
    import numpy as np
    import matplotlib.pyplot as plt
    from openpmd_viewer import OpenPMDTimeSeries
+   # from hipace tools
+   import read_insitu_diagnostics as diag
    # Read the simulation data
    ts = OpenPMDTimeSeries('./diags/hdf5/')
    # Get beam and field data at iteration 20
    iteration = 20
    x, z = ts.get_particle(species='beam', iteration=iteration, var_list=['x', 'z'])
    F, m = ts.get_field(field='Ez', iteration=iteration)
+   # Read in-situ diagnostics
+   all_data = diag.read_file('./diags/insitu/reduced_beam.*.txt')
+   print('Available beam diagnostics:', all_data.dtype.names)
+   # Example plot
+   plt.figure(figsize=(7,7), dpi=150)
+   plt.plot(all_data["time"], all_data["average"]["[x]"])
+   plt.savefig('./avg_x.png')
+
 
 Also please have a look at the production runs for beam-driven and laser-driven wakefield:
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1038,6 +1038,7 @@ Diagnostic parameters
 
 There are different types of diagnostics in HiPACE++. The standard diagnostics are compliant with the openPMD standard. The
 in-situ diagnostics allow for fast analysis of large beams or the plasma particles.
+Please make sure to always clear or rename the output folder before running a new simulation to avoid mixing data from different runs.
 
 * ``diagnostic.output_period`` (`integer`) optional (default `0`)
     Output period for standard beam and field diagnostics. Field or beam specific diagnostics can overwrite this parameter.

--- a/examples/get_started/inputs_lwfa
+++ b/examples/get_started/inputs_lwfa
@@ -36,4 +36,7 @@ plasma.ppc = 1 1
 plasma.element = electron
 plasma.radius = 23.*kp_inv
 
+lasers.insitu_period = 10
+plasmas.insitu_period = 10
+
 diagnostic.diag_type = xz

--- a/examples/get_started/inputs_normalized
+++ b/examples/get_started/inputs_normalized
@@ -6,13 +6,13 @@ amr.max_level = 0                       # level of mesh refinement. Currently, o
 #### General simulation settings
 ################################
 max_step = 20                           # max time step. 0 computes the fields of the initial beam
-diagnostic.output_period = 1                # output period. Last step is always written
+diagnostic.output_period = 1            # output period. Last step is always written
 hipace.normalized_units = 1             # unit system: SI units: 0, normalized units: 1
 hipace.dt = 4.4                         # Time step
 
 ### Simulation domain
 ################################
-boundary.field = Dirichlet             # boundary condition for fields
+boundary.field = Dirichlet              # boundary condition for fields
 boundary.particle = Periodic            # boundary condition for particles
 geometry.prob_lo     = -8.   -8.   -6   # physical domain: dimension must be provided
 geometry.prob_hi     =  8.    8.    6   # in the respective unit system
@@ -38,3 +38,4 @@ plasma.ppc = 1 1                        # particles per cell in x,y
 ### Diagnostics
 ################################
 diagnostic.diag_type = xz               # 2D xz slice output. Options: xyz, xz, yz
+beams.insitu_period = 1                 # in-situ diagnostic period for beam(s)

--- a/examples/get_started/inputs_pwfa
+++ b/examples/get_started/inputs_pwfa
@@ -1,5 +1,5 @@
 max_step = 300
-amr.n_cell = 512 512 512
+amr.n_cell = 1024 1024 1024
 
 amr.max_level = 0
 

--- a/examples/get_started/inputs_pwfa
+++ b/examples/get_started/inputs_pwfa
@@ -1,5 +1,5 @@
 max_step = 300
-amr.n_cell = 1024 1024 1024
+amr.n_cell = 512 512 512
 
 amr.max_level = 0
 
@@ -48,5 +48,8 @@ ion.density(x,y,z) = 2.e22
 ion.ppc = 1 1
 ion.u_mean = 0.0 0.0 0.
 ion.element = H
+
+fields.insitu_period = 1
+beams.insitu_period = 1
 
 diagnostic.diag_type = xz


### PR DESCRIPTION
Addressing issue #1186 
Added in-situ diagnostics to the different get_started example input files
Added a few lines in the get_started landing page in the python example on how to read the outputs
Added a line in the input parameters/diagnostic page about clearing the output directory before running a new simulation
