### PR TITLE
WrapFFTW.cpp : remove unused VendorCreatePlanR2C3D and VendorCreatePlanC2R3D

### DIFF
--- a/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
+++ b/src/fields/fft_poisson_solver/fft/WrapFFTW.cpp
@@ -17,13 +17,9 @@
 namespace AnyFFT
 {
 #ifdef AMREX_USE_FLOAT
-    const auto VendorCreatePlanR2C3D = fftwf_plan_dft_r2c_3d;
-    const auto VendorCreatePlanC2R3D = fftwf_plan_dft_c2r_3d;
     const auto VendorCreatePlanR2C2D = fftwf_plan_dft_r2c_2d;
     const auto VendorCreatePlanC2R2D = fftwf_plan_dft_c2r_2d;
 #else
-    const auto VendorCreatePlanR2C3D = fftw_plan_dft_r2c_3d;
-    const auto VendorCreatePlanC2R3D = fftw_plan_dft_c2r_3d;
     const auto VendorCreatePlanR2C2D = fftw_plan_dft_r2c_2d;
     const auto VendorCreatePlanC2R2D = fftw_plan_dft_c2r_2d;
 #endif


### PR DESCRIPTION
This PR removes a couple of unused functions from WrapFFTW.cpp (found with clang-tidy).

- [X] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [X] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
