### PR TITLE
FFTPoissonSolver: make destructor = default

### DIFF
--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.H
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.H
@@ -31,7 +31,7 @@ public:
     FFTPoissonSolver () = default;
 
     /** Abstract class needs a virtual destructor */
-    virtual ~FFTPoissonSolver () = 0;
+    virtual ~FFTPoissonSolver () = default;
 
     /**
      * Solve Poisson equation. The source term must be stored in the staging area m_stagingArea prior to this call.

--- a/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolver.cpp
@@ -7,9 +7,6 @@
  */
 #include "FFTPoissonSolver.H"
 
-FFTPoissonSolver::~FFTPoissonSolver ()
-{}
-
 amrex::MultiFab&
 FFTPoissonSolver::StagingArea ()
 {


### PR DESCRIPTION
Hi! I've noticed that you don't yet use clang-tidy in CI. @AlexanderSinn , in case you are interested in setting up something similar to what we did with WarpX, I've started running clang-tidy locally on my machine. This PR fixes what it found for the rule:
- [modernize-use-equals-default](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html)

- [X] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [X] **Tested** (describe the tests in the PR description)
- [x] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
