### PR TITLE
OpenPMDWriter.cpp & HpMultiGrid.H : enforce clang-tidy rule bugprone-branch-clone

### DIFF
--- a/src/diagnostics/OpenPMDWriter.cpp
+++ b/src/diagnostics/OpenPMDWriter.cpp
@@ -41,10 +41,8 @@ namespace utils {
     getUnitDimension ( std::string const & record_name )
     {
 
-        if( record_name == "position" ) return {
-            {openPMD::UnitDimension::L,  1.}
-        };
-        else if( record_name == "positionOffset" ) return {
+        if( (record_name == "position") ||
+            (record_name == "positionOffset")) return {
             {openPMD::UnitDimension::L,  1.}
         };
         else if( record_name == "momentum" ) return {

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -195,9 +195,12 @@ public:
      */
     static constexpr int get_num_comps_acf (int system_type) {
         switch (system_type) {
-            case 1: return 1;
-            case 2: return 2;
-            case 3: return 0;
+            case 1:
+                return 1;
+            case 2:
+                return 2;
+            case 3:
+                return 0;
         }
         return 0;
     }

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -180,9 +180,11 @@ public:
      */
     static constexpr int get_num_comps (int system_type) {
         switch (system_type) {
-            case 1: return 2;
-            case 2: return 2;
-            case 3: return 1;
+            case 1:
+            case 2:
+                return 2;
+            case 3:
+                return 1;
         }
         return 0;
     }


### PR DESCRIPTION
This PR is a follow-up of https://github.com/Hi-PACE/hipace/pull/1302 . 
By using the tool proposed in https://github.com/Hi-PACE/hipace/pull/1303 I ran `clang-tidy` on the code. This PR fixes the issues found with the rule:
- [bugprone-branch-clone](https://rocm.docs.amd.com/projects/llvm-project/en/develop/LLVM/clang-tools/html/clang-tidy/checks/bugprone/branch-clone.html)

Is this something that you would like to enforce in `HiPACE++` ? In my opinion, most of the checks of the `bugprone-*` family are quite useful (in WarpX we decided to enable most of them)...

These are the only issues found with the following rules:
```
    bugprone-argument-comment,
    bugprone-assert-side-effect,
    bugprone-assignment-in-if-condition,
    bugprone-bad-signal-to-kill-thread,
    bugprone-bitwise-pointer-cast,
    bugprone-bool-pointer-implicit-conversion,
    bugprone-branch-clone,
    bugprone-casting-through-void,
    bugprone-chained-comparison,
    bugprone-compare-pointer-to-member-virtual-function,
    bugprone-copy-constructor-init,
    bugprone-crtp-constructor-accessibility,
    bugprone-dangling-handle,
    bugprone-dynamic-static-initializers,
    cppcoreguidelines-avoid-goto
```


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [x] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
