### PR TITLE
HpMultiGrid.H: add default case to switch statements

### DIFF
--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -186,8 +186,9 @@ public:
             case 3:
                 return 1;
             default:
-                return 0;
+                amrex::Abort(std::to_string(system_type) + " is not a valid system_type!");
         }
+        return 0; //unreachable
     }
 
     /** \brief Return the number of acf components used for a given system type
@@ -201,9 +202,11 @@ public:
             case 2:
                 return 2;
             case 3:
-            default:
                 return 0;
+            default:
+                amrex::Abort(std::to_string(system_type) + " is not a valid system_type!");
         }
+        return 0; //unreachable
     }
 
     /** When applying Dirichlet boundary conditions, shift boundary value by offset number of cells */

--- a/src/mg_solver/HpMultiGrid.H
+++ b/src/mg_solver/HpMultiGrid.H
@@ -185,8 +185,9 @@ public:
                 return 2;
             case 3:
                 return 1;
+            default:
+                return 0;
         }
-        return 0;
     }
 
     /** \brief Return the number of acf components used for a given system type
@@ -200,9 +201,9 @@ public:
             case 2:
                 return 2;
             case 3:
+            default:
                 return 0;
         }
-        return 0;
     }
 
     /** When applying Dirichlet boundary conditions, shift boundary value by offset number of cells */


### PR DESCRIPTION
This PR adds the `default` case to the two switch statements in `HpMultiGrid.H`, in order to respect the following `clang-tidy` rule:
- [bugprone-switch-missing-default-case](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/switch-missing-default-case.html)

With this PR, almost all the checks of the `bugprone-*` family in `clang-tidy v20` would pass, except:
- [bugprone-easily-swappable-parameters](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/easily-swappable-parameters.html)
- [bugprone-implicit-widening-of-multiplication-result](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/narrowing-conversions.html)
- [bugprone-narrowing-conversions](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/narrowing-conversions.html)
- [bugprone-unchecked-optional-access](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/unchecked-optional-access.html)

Of these, the first three are probably too annoying to enforce in HiPACE++, while I think that the last one can be useful.

- [X] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [X] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
