### PR TITLE
Parser.H: optimize calls to std::string::find()

### DIFF
--- a/src/utils/Parser.H
+++ b/src/utils/Parser.H
@@ -155,8 +155,8 @@ namespace Parser
 
         // replace {expression} with to_string(parser(expression))
         static std::set<std::string> recursive_symbols{};
-        while ( (pos=loc_str.rfind("{")) != std::string::npos) {
-            const auto pos_end = loc_str.find("}", pos);
+        while ( (pos=loc_str.rfind('{')) != std::string::npos) {
+            const auto pos_end = loc_str.find('}', pos);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                 pos_end != std::string::npos,
                 "Bad format for input '" + str +  "', unclosed brace!\n"


### PR DESCRIPTION
This PR fixes the issues found by clang-tidy with the following rule:
- [performance-faster-string-find](https://clang.llvm.org/extra/clang-tidy/checks/performance/faster-string-find.html)

- [X] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [X] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
