### PR TITLE
fix issues found by clang-tidy with the rule modernize-use-nodiscard

### DIFF
--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -92,7 +92,8 @@ public:
      * \param[in] output_time physical time of current step
      * \param[in] max_time physical time of last step
      */
-    bool hasAnyFieldOutput (int output_step, int max_step,
+    [[nodiscard]] bool
+    hasAnyFieldOutput (int output_step, int max_step,
                             amrex::Real output_time, amrex::Real max_time) const
     {
         for (const auto& fd : m_field_data) {
@@ -108,7 +109,8 @@ public:
      * \param[in] output_time physical time of current step
      * \param[in] max_time physical time of last step
      */
-    bool hasBeamOutput (int output_step, int max_step,
+    [[nodiscard]] bool
+    hasBeamOutput (int output_step, int max_step,
                         amrex::Real output_time, amrex::Real max_time) const
     {
         return m_output_beam_names.size() > 0 &&
@@ -123,7 +125,8 @@ public:
      * \param[in] output_time physical time of current step
      * \param[in] max_time physical time of last step
      */
-    bool hasAnyOutput (int output_step, int max_step,
+    [[nodiscard]] bool
+    hasAnyOutput (int output_step, int max_step,
                        amrex::Real output_time, amrex::Real max_time) const
     {
         return hasAnyFieldOutput(output_step, max_step, output_time, max_time) ||
@@ -132,15 +135,18 @@ public:
 
     /** \brief determines if rho is requested as a diagnostic
      */
-    bool needsRho () const;
+    [[nodiscard]] bool
+    needsRho () const;
 
     /** \brief determines if rho for every individual plasma is requested as a diagnostic
      */
-    bool needsRhoIndividual () const;
+    [[nodiscard]] bool
+    needsRhoIndividual () const;
 
     /** \brief determines if the temperature parameters for every individual plasma are requested as a diagnostic
      */
-    bool needsTempIndividual () const;
+    [[nodiscard]] bool
+    needsTempIndividual () const;
 
     /** \brief calculate box which possibly was trimmed in case of slice IO
      *

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -104,7 +104,8 @@ public:
     /** get function for the 2D slices (const version)
      * \param[in] lev MR level
      */
-    const amrex::MultiFab& getSlices (int lev) const {return m_slices[lev]; }
+    [[nodiscard]] const amrex::MultiFab&
+    getSlices (int lev) const {return m_slices[lev]; }
     /** get amrex::MultiFab of a field in a slice
      * \param[in] lev MR level
      * \param[in] islice slice index

--- a/src/particles/beam/MultiBeam.H
+++ b/src/particles/beam/MultiBeam.H
@@ -82,13 +82,16 @@ public:
     /** \brief Return 1 species
      * \param[in] i index of the beam
      */
-    const BeamParticleContainer& getBeam (int i) const {return m_all_beams[i];}
+    [[nodiscard]] const BeamParticleContainer&
+    getBeam (int i) const {return m_all_beams[i];}
 
     /** returns the number of beams */
-    int get_nbeams () const {return m_nbeams;}
+    [[nodiscard]] int
+    get_nbeams () const {return m_nbeams;}
 
     /** returns the name of a beam */
-    std::string get_name (int i) const {return m_all_beams[i].get_name();}
+    [[nodiscard]] std::string
+    get_name (int i) const {return m_all_beams[i].get_name();}
 
     /** \brief Store the finest level of every beam particle on which_slice in the cpu() attribute.
      * \param[in] current_N_level number of MR levels active on the current slice
@@ -108,7 +111,8 @@ public:
     /** \brief returns if the SALAME algorithm should be used on this slice
      * \param[in] step time step of simulation
      */
-    bool isSalameNow (const int step);
+    [[nodiscard]] bool
+    isSalameNow (const int step);
 
     /** \brief returns if any beam uses the SALAME algorithm
      */

--- a/src/particles/plasma/MultiPlasma.H
+++ b/src/particles/plasma/MultiPlasma.H
@@ -116,13 +116,16 @@ public:
                             const MultiLaser& laser);
 
     /** \brief whether any plasma species uses a neutralizing background, e.g. no ion motion */
-    bool AnySpeciesNeutralizeBackground () const;
+    [[nodiscard]] bool
+    AnySpeciesNeutralizeBackground () const;
 
     /** returns a Vector of names of the plasmas */
-    const amrex::Vector<std::string>& GetNames() const {return m_names;}
+    [[nodiscard]] const amrex::Vector<std::string>&
+    GetNames() const {return m_names;}
 
     /** returns number of plasma species */
-    int GetNPlasmas() const {return m_nplasmas;}
+    [[nodiscard]] int
+    GetNPlasmas() const {return m_nplasmas;}
 
     /** Reorder particles to speed-up current deposition
      * \param[in] islice zeta slice index

--- a/src/particles/profiles/GetInitialDensity.H
+++ b/src/particles/profiles/GetInitialDensity.H
@@ -78,7 +78,7 @@ struct PlasmaDensityAccessor {
     amrex::RealVect m_dx_inv;
     amrex::Real m_unitSI = 1;
 
-    AMREX_GPU_HOST_DEVICE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
     amrex::Real array (int i, int j, int k) const {
         const int ii = std::min(m_bigend[0], std::max(0, i));
         const int jj = std::min(m_bigend[1], std::max(0, j));
@@ -93,7 +93,7 @@ struct PlasmaDensityAccessor {
         }
     }
 
-    AMREX_GPU_HOST_DEVICE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
     amrex::Real operator() (amrex::Real x, amrex::Real y, amrex::Real z) const {
         if (m_profile_type == 0) {
             return m_density_func(x, y, z);

--- a/src/particles/sorting/BoxSort.H
+++ b/src/particles/sorting/BoxSort.H
@@ -26,16 +26,20 @@ public:
                              const amrex::Geometry& a_geom);
 
     //! \brief returns the pointer to the permutation array
-    index_type* boxCountsPtr () noexcept { return m_box_counts_cpu.dataPtr(); }
+    [[nodiscard]] index_type*
+    boxCountsPtr () noexcept { return m_box_counts_cpu.dataPtr(); }
 
     //! \brief returns the pointer to the offsets array
-    index_type* boxOffsetsPtr () noexcept { return m_box_offsets_cpu.dataPtr(); }
+    [[nodiscard]] index_type*
+    boxOffsetsPtr () noexcept { return m_box_offsets_cpu.dataPtr(); }
 
     //! \brief returns the pointer to the permutation array
-    const index_type* boxCountsPtr () const noexcept { return m_box_counts_cpu.dataPtr(); }
+    [[nodiscard]] const index_type*
+    boxCountsPtr () const noexcept { return m_box_counts_cpu.dataPtr(); }
 
     //! \brief returns the pointer to the offsets array
-    const index_type* boxOffsetsPtr () const noexcept { return m_box_offsets_cpu.dataPtr(); }
+    [[nodiscard]] const index_type*
+    boxOffsetsPtr () const noexcept { return m_box_offsets_cpu.dataPtr(); }
 
 
     /** Number of particles in each box, stored on the cpu */

--- a/src/utils/MultiBuffer.H
+++ b/src/utils/MultiBuffer.H
@@ -136,11 +136,13 @@ private:
 
     // calculate distance of a and b in the periodic range [0,m_nslices) with
     // a barrier at current_slice
-    int periodic_distance (int current_slice, int a, int b) const;
+    [[nodiscard]] int
+    periodic_distance (int current_slice, int a, int b) const;
 
     // calculate min of a and b in the periodic range [0,m_nslices) with
     // a barrier at current_slice
-    int periodic_min (int current_slice, int a, int b) const;
+    [[nodiscard]] int
+    periodic_min (int current_slice, int a, int b) const;
 
     // send some dummy messages so MPI can pre-register the memory
     void pre_register_memory ();


### PR DESCRIPTION
This PR fixes issues found by `clang-tidy` using the [modernize-use-nodiscard](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nodiscard.html) rule.

- [X] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
