### PR TITLE
Check laser input file contains a normalized vector potential

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -924,6 +924,9 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
     The names of the laser pulses, separated by a space.
     To run without a laser, choose the name ``no_laser``.
 
+* ``lasers.lambda0`` (`float`)
+    Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
+
 * ``lasers.polarization`` (`linear` or `circular`) optional (default `linear`)
     Polarization of the laser pulse.
     For the same peak amplitude, the ponderomotive force is 2x larger in circular polarization than in linear polarization.
@@ -961,9 +964,6 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
 
       * ``<laser name>.a0`` (`float`) optional (default `0`)
           Peak normalized vector potential of the laser pulse.
-
-      * ``lasers.lambda0`` (`float`)
-          Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
 
       * ``<laser name>.position_mean`` (3 `float`) optional (default `0 0 0`)
           The mean position of the laser in `x, y, z`.
@@ -1030,9 +1030,6 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
 
       * ``<laser name>.laser_imag(x,y,z)`` optional (`string`) (default `""`)
           Expression for the imaginary part of the laser envelope `x, y, z`.
-
-      * ``lasers.lambda0`` (`float`)
-          Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
 
 Diagnostic parameters
 ---------------------

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -98,6 +98,41 @@ Laser::GetEnvelopeFromFileHelper (amrex::Geometry laser_geom_3D) {
 
         auto mesh = iteration.meshes[m_file_envelope_name];
 
+        // Check that we are reading a normalized vector potential and not an electric field
+        const std::array<double, 7> units_file = mesh.unitDimension();
+        const std::array<double, 7> units_norm_potential{0., 0., 0., 0., 0., 0., 0.};
+        const std::array<double, 7> units_electric_field{1., 1., -3., -1., 0., 0., 0.};
+        const std::string help_msg = "Make sure to store the normalized vector potential, "
+            "set the Attribute 'envelopeField' to 'normalized_vector_potential' and "
+            "unitDimension to '" + amrex::ToString(units_norm_potential) + "'. "
+            "If you are using LASY to generate the laser, pass 'save_as_vector_potential=True' "
+            "to laser.write_to_file() or write_to_openpmd_file()";
+
+        if (mesh.containsAttribute("envelopeField")) {
+            const std::string field_type = mesh.getAttribute("envelopeField").get<std::string>();
+            if (field_type == "electric_field") {
+                amrex::Abort("Attribute 'envelopeField' in file '" + m_input_file_path +
+                    "' is set to 'electric_field' which is not compatible with HiAPCE++. " +
+                    help_msg
+                );
+            } else if (field_type != "normalized_vector_potential") {
+                amrex::AllPrint() << "WARNING: Attribute 'envelopeField' in file '"
+                    << m_input_file_path << "' is set to '" << field_type << "' which is not "
+                    " recognized. " << help_msg << '\n';
+            }
+        }
+
+        if (units_file == units_electric_field) {
+            amrex::Abort("unitDimension '" + amrex::ToString(units_file) + "' in file '"
+                + m_input_file_path + "' is that of an electric field which is not compatible "
+                "with HiAPCE++. " + help_msg
+            );
+        } else if (units_file != units_norm_potential) {
+            amrex::AllPrint() << "WARNING: unitDimension '" << amrex::ToString(units_file)
+                << "' in file '" << m_input_file_path << "' is not recognized. "
+                << help_msg << '\n';
+        }
+
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             mesh.containsAttribute("angularFrequency"),
             "Could not find Attribute 'angularFrequency' of iteration "


### PR DESCRIPTION
By default, LASY outputs the electric field instead of the normalized vector potential, which previously HiPACE++ would have misinterpreted as a normalized vector potential, causing it to be off by a factor of 10^12.

Additionally, the `lasers.lambda0` was not documented under the form_file init type, even though it has to be set for all laser init types.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
