### PR TITLE
Use lasers.lambda0 from openPMD file

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1017,6 +1017,11 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
           The laser pulse is injected in the HiPACE++ simulation so that the beginning of the temporal profile from the file corresponds to the head of the simulation box, and time (in the file) is converted to space (HiPACE++ longitudinal coordinate) with ``z = -c*t + const``.
           If this parameter is set, then the file is used to initialize all lasers instead of using a gaussian profile.
 
+      * ``<laser name>.lambda0`` (`float`) optional (default `<read from file>`)
+          Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
+          The wavelength is already read in from the metadata of the openPMD file,
+          however it can be overwritten using this parameter.
+
       * ``<laser name>.openPMD_laser_name`` (`string`) optional (default `laserEnvelope`)
           Name of the laser envelope field inside the openPMD file to be read in.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -924,9 +924,6 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
     The names of the laser pulses, separated by a space.
     To run without a laser, choose the name ``no_laser``.
 
-* ``lasers.lambda0`` (`float`)
-    Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
-
 * ``lasers.polarization`` (`linear` or `circular`) optional (default `linear`)
     Polarization of the laser pulse.
     For the same peak amplitude, the ponderomotive force is 2x larger in circular polarization than in linear polarization.
@@ -964,6 +961,9 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
 
       * ``<laser name>.a0`` (`float`) optional (default `0`)
           Peak normalized vector potential of the laser pulse.
+
+      * ``lasers.lambda0`` (`float`)
+          Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
 
       * ``<laser name>.position_mean`` (3 `float`) optional (default `0 0 0`)
           The mean position of the laser in `x, y, z`.
@@ -1030,6 +1030,9 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
 
       * ``<laser name>.laser_imag(x,y,z)`` optional (`string`) (default `""`)
           Expression for the imaginary part of the laser envelope `x, y, z`.
+
+      * ``lasers.lambda0`` (`float`)
+          Wavelength of the laser pulses. Currently, all pulses must have the same wavelength.
 
 Diagnostic parameters
 ---------------------

--- a/src/laser/Laser.H
+++ b/src/laser/Laser.H
@@ -67,8 +67,8 @@ public:
     int m_file_num_iteration = 0;
     /** Geometry of the laser file, 'rt' or 'xyt' */
     std::string m_file_geometry = "";
-    /** Wavelength from file */
-    amrex::Real m_lambda0_from_file {0.};
+    /** central wavelength of the laser */
+    amrex::Real m_init_lambda0 {0.};
 };
 
 #endif // LASER_H_

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -39,7 +39,8 @@ Laser::ReadParameters (const amrex::Geometry& laser_geom_3D)
             m_F_input_file.resize(laser_geom_3D.Domain(), 2, amrex::The_Pinned_Arena());
             GetEnvelopeFromFileHelper(laser_geom_3D);
         }
-        // lambda0 is read from input file
+        // lambda0 is read from input file, but it can be overwritten here
+        queryWithParser(pp, "lambda0", m_init_lambda0);
         return;
     }
     else if (m_laser_init_type == "gaussian") {

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -39,8 +39,13 @@ Laser::ReadParameters (const amrex::Geometry& laser_geom_3D)
             m_F_input_file.resize(laser_geom_3D.Domain(), 2, amrex::The_Pinned_Arena());
             GetEnvelopeFromFileHelper(laser_geom_3D);
         }
-        // lambda0 is read from input file, but it can be overwritten here
-        queryWithParser(pp, "lambda0", m_init_lambda0);
+        if (m_init_lambda0 != 0.) {
+            // lambda0 is read from input file, but it can be overwritten explicitly here
+            queryWithParser(pp, "lambda0", m_init_lambda0);
+        } else {
+            // lambda0 not defined in file
+            getWithParserAlt(pp, "lambda0", m_init_lambda0, pp_lasers);
+        }
         return;
     }
     else if (m_laser_init_type == "gaussian") {
@@ -139,15 +144,10 @@ Laser::GetEnvelopeFromFileHelper (amrex::Geometry laser_geom_3D) {
                 << help_msg << '\n';
         }
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            mesh.containsAttribute("angularFrequency"),
-            "Could not find Attribute 'angularFrequency' of iteration "
-            + std::to_string(m_file_num_iteration) + " in file "
-            + m_input_file_path + "\n"
-        );
-
-        m_init_lambda0 = 2.*MathConst::pi*PhysConstSI::c
-            / mesh.getAttribute("angularFrequency").get<double>();
+        if (mesh.containsAttribute("angularFrequency")) {
+            m_init_lambda0 = 2.*MathConst::pi*PhysConstSI::c
+                / mesh.getAttribute("angularFrequency").get<double>();
+        }
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             mesh.contains(openPMD::RecordComponent::SCALAR),

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -39,6 +39,16 @@ Laser::ReadParameters (const amrex::Geometry& laser_geom_3D)
             m_F_input_file.resize(laser_geom_3D.Domain(), 2, amrex::The_Pinned_Arena());
             GetEnvelopeFromFileHelper(laser_geom_3D);
         }
+
+        // m_init_lambda0 is only read by the HeadRank, so we need to communicate it
+#ifdef AMREX_USE_MPI
+        MPI_Bcast(&m_init_lambda0,
+                  1,
+                  amrex::ParallelDescriptor::Mpi_typemap<decltype(m_init_lambda0)>::type(),
+                  Hipace::HeadRankID(),
+                  amrex::ParallelDescriptor::Communicator());
+#endif
+
         if (m_init_lambda0 != 0.) {
             // lambda0 is read from input file, but it can be overwritten explicitly here
             queryWithParser(pp, "lambda0", m_init_lambda0);

--- a/src/laser/Laser.cpp
+++ b/src/laser/Laser.cpp
@@ -28,6 +28,8 @@ void
 Laser::ReadParameters (const amrex::Geometry& laser_geom_3D)
 {
     amrex::ParmParse pp(m_name);
+    amrex::ParmParse pp_lasers("lasers");
+
     queryWithParser(pp, "init_type", m_laser_init_type);
     if (m_laser_init_type == "from_file") {
         queryWithParser(pp, "input_file", m_input_file_path);
@@ -37,6 +39,7 @@ Laser::ReadParameters (const amrex::Geometry& laser_geom_3D)
             m_F_input_file.resize(laser_geom_3D.Domain(), 2, amrex::The_Pinned_Arena());
             GetEnvelopeFromFileHelper(laser_geom_3D);
         }
+        // lambda0 is read from input file
         return;
     }
     else if (m_laser_init_type == "gaussian") {
@@ -56,6 +59,7 @@ Laser::ReadParameters (const amrex::Geometry& laser_geom_3D)
         queryWithParser(pp, "zeta",  m_zeta);
         queryWithParser(pp, "beta",  m_beta);
         queryWithParser(pp, "phi2",  m_phi2);
+        getWithParser(pp_lasers, "lambda0", m_init_lambda0);
         return;
     }
     else if (m_laser_init_type == "parser") {
@@ -65,6 +69,7 @@ Laser::ReadParameters (const amrex::Geometry& laser_geom_3D)
         getWithParser(pp, "laser_imag(x,y,z)", profile_imag_str);
         m_profile_real = makeFunctionWithParser<3>( profile_real_str, m_parser_lr, {"x", "y", "z"});
         m_profile_imag = makeFunctionWithParser<3>( profile_imag_str, m_parser_li, {"x", "y", "z"});
+        getWithParser(pp_lasers, "lambda0", m_init_lambda0);
         return;
     }
     else {
@@ -140,7 +145,7 @@ Laser::GetEnvelopeFromFileHelper (amrex::Geometry laser_geom_3D) {
             + m_input_file_path + "\n"
         );
 
-        m_lambda0_from_file = 2.*MathConst::pi*PhysConstSI::c
+        m_init_lambda0 = 2.*MathConst::pi*PhysConstSI::c
             / mesh.getAttribute("angularFrequency").get<double>();
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -129,7 +129,7 @@ MultiLaser::MakeLaserGeometry (const amrex::Geometry& field_geom_3D)
                     "for lasers read from an openPMD file, lambda0 is also read from the file.\n" +
                     m_names[0] + " lambda0: " + amrex::ToString(m_lambda0) + "\n" +
                     m_names[1] + " lambda0: " + amrex::ToString(m_all_lasers[i].m_init_lambda0) +
-                    "\ndiffereance: " + amrex::ToString(m_lambda0 - m_all_lasers[i].m_init_lambda0)
+                    "\ndifference: " + amrex::ToString(m_lambda0 - m_all_lasers[i].m_init_lambda0)
                 );
             }
         }

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -32,7 +32,6 @@ MultiLaser::ReadParameters ()
     m_use_laser = m_names[0] != "no_laser";
 
     if (!m_use_laser) return;
-    queryWithParser(pp, "lambda0", m_lambda0);
     DeprecatedInput("lasers", "3d_on_host", "comms_buffer.on_gpu", "", true);
     std::string polarization = "linear";
     queryWithParser(pp, "polarization", polarization);
@@ -117,6 +116,25 @@ MultiLaser::MakeLaserGeometry (const amrex::Geometry& field_geom_3D)
         m_all_lasers.emplace_back(Laser(m_names[i]));
         m_all_lasers.back().ReadParameters(m_laser_geom_3D);
         amrex::Print()<<"Laser "+ m_names[i] + " loaded" << "\n";
+    }
+
+    if (m_nlasers > 0) {
+        for (int i = 0; i < m_nlasers; ++i) {
+            if (i == 0) {
+                m_lambda0 = m_all_lasers[i].m_init_lambda0;
+            } else {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    m_all_lasers[i].m_init_lambda0 == m_lambda0,
+                    "The central wavelength (lambda0) of all lasers must be identical. Note that "
+                    "for lasers read from an openPMD file, lambda0 is also read from the file.\n" +
+                    m_names[0] + " lambda0: " + amrex::ToString(m_lambda0) + "\n" +
+                    m_names[1] + " lambda0: " + amrex::ToString(m_all_lasers[i].m_init_lambda0) +
+                    "\ndiffereance: " + amrex::ToString(m_lambda0 - m_all_lasers[i].m_init_lambda0)
+                );
+            }
+        }
+    } else {
+        getWithParser(pp, "lambda0", m_lambda0);
     }
 
     m_slice_box = domain_3D_laser;
@@ -854,11 +872,6 @@ MultiLaser::InitLaserSlice (const int islice, const int comp)
                     arr(i, j, k, comp ) += arr_ff(i, j, islice, 0 );
                     arr(i, j, k, comp + 1 ) += arr_ff(i, j, islice, 1 );
                 }
-                );
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-                    laser.m_lambda0_from_file == m_lambda0 && m_lambda0 != 0,
-                    "The central wavelength of laser from openPMD file and "
-                    "other lasers must be identical"
                 );
             }
             if (laser.m_laser_init_type == "parser") {


### PR DESCRIPTION
This PR makes it so that lasers.lambda0 can be omitted if all lasers are read from openPMD files. Notably, this also checks that all lasers have the same lambda0. If not, the following assertion is triggered:
```
Laser laser1 loaded
Laser laser2 loaded
0::Assertion `m_all_lasers[i].m_init_lambda0 == m_lambda0' failed, file "/home/asinn/hipace/src/laser/MultiLaser.cpp", line 126, Msg: The central wavelength (lambda0) of all lasers must be identical. Note that for lasers read from an openPMD file, lambda0 is also read from the file.
laser1 lambda0: 8.15e-07
laser2 lambda0: 8e-07
differeance: 1.5e-08 !!!
```


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
