### PR TITLE
Add verbose message to assert when using adaptive time step

### DIFF
--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -500,7 +500,10 @@ Hipace::Evolve ()
         const amrex::Box& bx = m_3D_ba[0][0];
 
         if (m_multi_laser.UseLaser()) {
-            AMREX_ALWAYS_ASSERT(!m_adaptive_time_step.m_do_adaptive_time_step);
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                !m_adaptive_time_step.m_do_adaptive_time_step,
+                "Adaptive time step cannot be used with laser pulses."
+            );
         }
 
         m_physical_time = step == 0 ? m_initial_time : m_multi_buffer.get_time();


### PR DESCRIPTION
Happy to discard if this is incorrect, but it seems to me that the point of this assert is to avoid using the adaptive time step if laser pulses are present.
I tried doing that before and the code failed on the assert, but there was not any useful message.
If this is a general limitation, it's probably better to warn the user with a clear message.


- [x] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
