### PR TITLE
Simplify CMake logic to add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,250 +222,79 @@ install(TARGETS HiPACE
 if(BUILD_TESTING)
     enable_testing()
 
+    function(add_test_list)
+        foreach(test_name IN LISTS ARGN)
+            add_test(NAME ${test_name}
+                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/${test_name}.sh
+                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
+                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            )
+        endforeach()
+    endfunction()
+
     if(NOT HiPACE_MPI)
 
-        add_test(NAME blowout_wake.Serial
-                 COMMAND bash ${HiPACE_SOURCE_DIR}/tests/blowout_wake.Serial.sh
-                         $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME beam_in_vacuum.SI.Serial
-                 COMMAND bash ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.SI.Serial.sh
-                         $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME beam_in_vacuum.normalized.Serial
-                 COMMAND bash ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.normalized.Serial.sh
-                         $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        add_test_list(
+            blowout_wake.Serial
+            beam_in_vacuum.SI.Serial
+            beam_in_vacuum.normalized.Serial
         )
 
     else()
 
         # These tests run on CPU and on GPU
 
-        add_test(NAME blowout_wake.2Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/blowout_wake.2Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME beam_evolution.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/beam_evolution.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME adaptive_time_step.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/adaptive_time_step.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME radiation_reaction.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/radiation_reaction.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME grid_current.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/grid_current.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME linear_wake.normalized.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/linear_wake.normalized.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME linear_wake.SI.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/linear_wake.SI.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME gaussian_linear_wake.normalized.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/gaussian_linear_wake.normalized.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME gaussian_linear_wake.SI.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/gaussian_linear_wake.SI.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME reset.2Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/reset.2Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME beam_in_vacuum.SI.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.SI.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME beam_in_vacuum.normalized.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.normalized.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME slice_IO.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/slice_IO.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME output_coarsening.2Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/output_coarsening.2Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME beam_in_vacuum_open_boundary.normalized.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum_open_boundary.normalized.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME laser_evolution.SI.2Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/laser_evolution.SI.2Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME laser_ionization.1Rank
-                COMMAND bash ${HiPACE_SOURCE_DIR}/tests/laser_ionization.1Rank.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR} ${HiPACE_COMPUTE}
-                WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-        add_test(NAME laser_STC.1Rank
-            COMMAND bash ${HiPACE_SOURCE_DIR}/tests/laser_STC.1Rank.sh
-                    $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR} ${HiPACE_COMPUTE}
-            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-        )
-
-        add_test(NAME plasma_density_from_file.SI.1Rank
-            COMMAND bash ${HiPACE_SOURCE_DIR}/tests/plasma_density_from_file.SI.1Rank.sh
-                    $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR} ${HiPACE_COMPUTE}
-            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        add_test_list(
+            blowout_wake.2Rank
+            beam_evolution.1Rank
+            adaptive_time_step.1Rank
+            radiation_reaction.1Rank
+            grid_current.1Rank
+            linear_wake.normalized.1Rank
+            linear_wake.SI.1Rank
+            gaussian_linear_wake.normalized.1Rank
+            gaussian_linear_wake.SI.1Rank
+            reset.2Rank
+            beam_in_vacuum.SI.1Rank
+            beam_in_vacuum.normalized.1Rank
+            slice_IO.1Rank
+            output_coarsening.2Rank
+            beam_in_vacuum_open_boundary.normalized.1Rank
+            laser_evolution.SI.2Rank
+            laser_ionization.1Rank
+            laser_STC.1Rank
+            plasma_density_from_file.SI.1Rank
         )
 
         if (NOT HiPACE_COMPUTE STREQUAL CUDA)
 
             # These tests only run on CPU
 
-            add_test(NAME collisions.SI.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/collisions.SI.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME collisions_beam.SI.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/collisions_beam.SI.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME ion_motion.SI.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/ion_motion.SI.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME ionization.2Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/ionization.2Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME from_file.normalized.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/from_file.normalized.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME from_file.SI.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/from_file.SI.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME restart.normalized.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/restart.normalized.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME blowout_wake_explicit.2Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/blowout_wake_explicit.2Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME laser_blowout_wake_explicit.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/laser_blowout_wake_explicit.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME laser_blowout_wake_explicit.SI.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/laser_blowout_wake_explicit.SI.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME next_deposition_beam.2Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/next_deposition_beam.2Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME gaussian_weight.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/gaussian_weight.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME beam_in_vacuum.normalized.2Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/beam_in_vacuum.normalized.2Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME production_pwfa.SI.2Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/production_pwfa.SI.2Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME production_lwfa.SI.2Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/production_lwfa.SI.2Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-            )
-
-            add_test(NAME mesh_refinement.SI.2Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/mesh_refinement.SI.2Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            add_test_list(
+                collisions.SI.1Rank
+                collisions_beam.SI.1Rank
+                ion_motion.SI.1Rank
+                ionization.2Rank
+                from_file.normalized.1Rank
+                from_file.SI.1Rank
+                restart.normalized.1Rank
+                blowout_wake_explicit.2Rank
+                laser_blowout_wake_explicit.1Rank
+                laser_blowout_wake_explicit.SI.1Rank
+                next_deposition_beam.2Rank
+                gaussian_weight.1Rank
+                beam_in_vacuum.normalized.2Rank
+                production_pwfa.SI.2Rank
+                production_lwfa.SI.2Rank
+                mesh_refinement.SI.2Rank
             )
 
         else()
 
-            add_test(NAME transverse_benchmark.1Rank
-                    COMMAND bash ${HiPACE_SOURCE_DIR}/tests/transverse_benchmark.1Rank.sh
-                            $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
-                    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+            # These tests only run on GPU
+
+            add_test_list(
+                transverse_benchmark.1Rank
             )
 
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ if(BUILD_TESTING)
         foreach(test_name IN LISTS ARGN)
             add_test(NAME ${test_name}
                 COMMAND bash ${HiPACE_SOURCE_DIR}/tests/${test_name}.sh
-                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR}
+                        $<TARGET_FILE:HiPACE> ${HiPACE_SOURCE_DIR} ${HiPACE_COMPUTE}
                 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
             )
         endforeach()


### PR DESCRIPTION
This will make it easier to add a new CI test.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
