### PR TITLE
Use amrex::ArrayND

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -126,7 +126,7 @@ macro(find_amrex)
         mark_as_advanced(AMReX_TP_PROFILE)
         mark_as_advanced(USE_XSDK_DEFAULTS)
 
-        message(STATUS "AMReX: Using version '${AMREX_PKG_VERSION}' (${AMREX_GIT_VERSION})") 
+        message(STATUS "AMReX: Using version '${AMREX_PKG_VERSION}' (${AMREX_GIT_VERSION})")
     else()
         message(STATUS "Searching for pre-installed AMReX ...")
         set(COMPONENT_PRECISION ${HiPACE_PRECISION} P${HiPACE_PRECISION})
@@ -146,10 +146,10 @@ set(HiPACE_amrex_src ""
     "Local path to AMReX source directory (preferred if set)")
 
 # Git fetcher
-set(HiPACE_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
+set(HiPACE_amrex_repo "https://github.com/ankithadas/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(HiPACE_amrex_internal)")
-set(HiPACE_amrex_branch "development"
+set(HiPACE_amrex_branch "ArrayND"
     CACHE STRING
     "Repository branch for HiPACE_amrex_repo if(HiPACE_amrex_internal)")
 

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -146,10 +146,10 @@ set(HiPACE_amrex_src ""
     "Local path to AMReX source directory (preferred if set)")
 
 # Git fetcher
-set(HiPACE_amrex_repo "https://github.com/ankithadas/amrex.git"
+set(HiPACE_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(HiPACE_amrex_internal)")
-set(HiPACE_amrex_branch "ArrayND"
+set(HiPACE_amrex_branch "development"
     CACHE STRING
     "Repository branch for HiPACE_amrex_repo if(HiPACE_amrex_internal)")
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -902,7 +902,7 @@ Hipace::InitializeSxSyWithBeam (const int lev)
 
         amrex::Box const& bx = mfi.tilebox();
 
-        Array3<amrex::Real> const arr = slicemf.array(mfi);
+        Array3<amrex::Real> const arr = to3D(slicemf.array(mfi));
 
         const int Sx = Comps[WhichSlice::This]["Sx"];
         const int Sy = Comps[WhichSlice::This]["Sy"];
@@ -1212,7 +1212,7 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
 
         amrex::Box const& bx = mfi.tilebox();
 
-        Array3<amrex::Real> const arr = slicemf.array(mfi);
+        Array3<amrex::Real> const arr = to3D(slicemf.array(mfi));
 
         amrex::ParallelFor(to2D(bx),
             [=] AMREX_GPU_DEVICE (int i, int j) noexcept

--- a/src/fields/Fields.H
+++ b/src/fields/Fields.H
@@ -308,7 +308,7 @@ public:
 #pragma omp parallel
 #endif
         for (amrex::MFIter mfi(mfab, DfltMfiTlng); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real> array = mfab.array(mfi);
+            const Array3<amrex::Real> array = to3D(mfab.array(mfi));
             // only one Kernel for all fields
             amrex::ParallelFor(to2D(mfi.growntilebox()),
                 [=] AMREX_GPU_DEVICE(int i, int j)
@@ -337,7 +337,7 @@ public:
 #pragma omp parallel
 #endif
         for (amrex::MFIter mfi(mfab, DfltMfiTlng); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real> array = mfab.array(mfi);
+            const Array3<amrex::Real> array = to3D(mfab.array(mfi));
             // only one Kernel for all fields
             amrex::ParallelFor(to2D(mfi.growntilebox()),
                 [=] AMREX_GPU_DEVICE(int i, int j)
@@ -367,7 +367,7 @@ public:
 #pragma omp parallel
 #endif
         for (amrex::MFIter mfi(mfab, DfltMfiTlng); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real> array = mfab.array(mfi);
+            const Array3<amrex::Real> array = to3D(mfab.array(mfi));
             // only one Kernel for all fields
             amrex::ParallelFor(to2D(mfi.growntilebox()),
                 [=] AMREX_GPU_DEVICE(int i, int j)
@@ -404,7 +404,7 @@ public:
 #pragma omp parallel
 #endif
         for (amrex::MFIter mfi(mfab, DfltMfiTlng); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real> array = mfab.array(mfi);
+            const Array3<amrex::Real> array = to3D(mfab.array(mfi));
             // only one Kernel for all fields
             amrex::ParallelFor(to2D(mfi.growntilebox()),
                 [=] AMREX_GPU_DEVICE(int i, int j)
@@ -441,7 +441,7 @@ public:
 #pragma omp parallel
 #endif
         for (amrex::MFIter mfi(mfab, DfltMfiTlng); mfi.isValid(); ++mfi) {
-            const Array3<amrex::Real> array = mfab.array(mfi);
+            const Array3<amrex::Real> array = to3D(mfab.array(mfi));
             // only one Kernel for all fields
             amrex::ParallelFor(to2D(mfi.growntilebox()),
                 [=] AMREX_GPU_DEVICE(int i, int j)

--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -296,7 +296,7 @@ struct derivative {
 
     // use .array(mfi) like with amrex::MultiFab
     derivative_inner<dir> array (amrex::MFIter& mfi) const {
-        return derivative_inner<dir>{f_view.array(mfi), 0.5_rt*geom.InvCellSize(dir)};
+        return derivative_inner<dir>{to2D(f_view.array(mfi)), 0.5_rt*geom.InvCellSize(dir)};
     }
 };
 
@@ -310,7 +310,7 @@ struct derivative<Direction::z> {
 
     // use .array(mfi) like with amrex::MultiFab
     derivative_inner<Direction::z> array (amrex::MFIter& mfi) const {
-        return derivative_inner<Direction::z>{f_view1.array(mfi), f_view2.array(mfi),
+        return derivative_inner<Direction::z>{to2D(f_view1.array(mfi)), to2D(f_view2.array(mfi)),
             0.5_rt*geom.InvCellSize(Direction::z)};
     }
 };
@@ -391,7 +391,7 @@ struct guarded_field_xy {
     // use .array(mfi) like with amrex::MultiFab
     guarded_field_xy_inner array (amrex::MFIter& mfi) const {
         const amrex::Box bx = mfab[mfi].box();
-        return guarded_field_xy_inner{mfab.const_array(mfi), bx.smallEnd(Direction::x),
+        return guarded_field_xy_inner{to3D(mfab.const_array(mfi)), bx.smallEnd(Direction::x),
             bx.bigEnd(Direction::x), bx.smallEnd(Direction::y), bx.bigEnd(Direction::y)};
     }
 };
@@ -414,7 +414,7 @@ LinCombination (amrex::MultiFab dst,
 #pragma omp parallel
 #endif
     for ( amrex::MFIter mfi(dst, DfltMfiTlng); mfi.isValid(); ++mfi ){
-        const Array2<amrex::Real> dst_array = dst.array(mfi);
+        const Array2<amrex::Real> dst_array = to2D(dst.array(mfi));
         const auto src_a_array = to_array2(src_a.array(mfi));
         const auto src_b_array = to_array2(src_b.array(mfi));
         amrex::ParallelFor(to2D(mfi.growntilebox()),
@@ -439,7 +439,7 @@ Multiply (amrex::MultiFab dst, const amrex::Real factor, const FV& src)
 #pragma omp parallel
 #endif
     for ( amrex::MFIter mfi(dst, DfltMfiTlng); mfi.isValid(); ++mfi ){
-        const Array2<amrex::Real> dst_array = dst.array(mfi);
+        const Array2<amrex::Real> dst_array = to2D(dst.array(mfi));
         const auto src_array = to_array2(src.array(mfi));
         amrex::ParallelFor(to2D(mfi.growntilebox()),
             [=] AMREX_GPU_DEVICE(int i, int j) noexcept
@@ -757,7 +757,7 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
             "Open Boundaries only work for lev0 with everything in one box");
         amrex::FArrayBox& staging_area_fab = staging_area[0];
 
-        const Array2<amrex::Real> arr_staging_area = staging_area_fab.array();
+        const Array2<amrex::Real> arr_staging_area = to2D(staging_area_fab.array());
 
         const amrex::Real poff_x = GetPosOffset(0, geom[lev], staging_box);
         const amrex::Real poff_y = GetPosOffset(1, geom[lev], staging_box);
@@ -817,7 +817,7 @@ Fields::SetBoundaryCondition (amrex::Vector<amrex::Geometry> const& geom, const 
         for (amrex::MFIter mfi(staging_area, DfltMfi); mfi.isValid(); ++mfi)
         {
             const auto arr_solution_interp = solution_interp.array(mfi);
-            const Array2<amrex::Real> arr_staging_area = staging_area.array(mfi);
+            const Array2<amrex::Real> arr_staging_area = to2D(staging_area.array(mfi));
 
             SetDirichletBoundaries(arr_staging_area, staging_box, geom[lev],
                                    offset, factor, arr_solution_interp);
@@ -842,7 +842,7 @@ Fields::LevelUpBoundary (amrex::Vector<amrex::Geometry> const& geom, const int l
     for (amrex::MFIter mfi( field_fine, DfltMfi); mfi.isValid(); ++mfi)
     {
         auto arr_field_coarse_interp = field_coarse_interp.array(mfi);
-        const Array2<amrex::Real> arr_field_fine = field_fine.array(mfi);
+        const Array2<amrex::Real> arr_field_fine = to2D(field_fine.array(mfi));
         const amrex::Box fine_box_extended = mfi.growntilebox(outer_edge);
         const amrex::Box fine_box_narrow = mfi.growntilebox(inner_edge);
 
@@ -885,7 +885,7 @@ Fields::LevelUp (amrex::Vector<amrex::Geometry> const& geom, const int lev,
     for (amrex::MFIter mfi( field_fine, DfltMfi); mfi.isValid(); ++mfi)
     {
         auto arr_field_coarse_interp = field_coarse_interp.array(mfi);
-        const Array2<amrex::Real> arr_field_fine = field_fine.array(mfi);
+        const Array2<amrex::Real> arr_field_fine = to2D(field_fine.array(mfi));
 
         const amrex::Real dx = geom[lev].CellSize(0);
         const amrex::Real dy = geom[lev].CellSize(1);
@@ -1002,7 +1002,7 @@ Fields::SolvePoissonPsiExmByEypBxEzBz (amrex::Vector<amrex::Geometry> const& geo
 #pragma omp parallel
 #endif
         for ( amrex::MFIter mfi(slicemf, DfltMfiTlng); mfi.isValid(); ++mfi ){
-            const Array3<amrex::Real> arr = slicemf.array(mfi);
+            const Array3<amrex::Real> arr = to3D(slicemf.array(mfi));
             const int Psi   = Comps[WhichSlice::This]["Psi"];
             const int ExmBy = Comps[WhichSlice::This]["ExmBy"];
             const int EypBx = Comps[WhichSlice::This]["EypBx"];
@@ -1153,7 +1153,7 @@ Fields::SymmetrizeFields (int field_comp, const int lev, const int symm_x, const
     amrex::MultiFab& slicemf = getSlices(lev);
 
     for ( amrex::MFIter mfi(slicemf, DfltMfiTlng); mfi.isValid(); ++mfi ) {
-        const Array2<amrex::Real> arr = slicemf.array(mfi, field_comp);
+        const Array2<amrex::Real> arr = to2D(slicemf.array(mfi, field_comp));
 
         const amrex::Box full_box = mfi.growntilebox();
 
@@ -1315,7 +1315,7 @@ Fields::ComputeRelBFieldError (const int which_slice, const int which_slice_iter
         for ( amrex::MFIter mfi(slicemf, DfltMfiTlng); mfi.isValid(); ++mfi ){
             const amrex::Box& bx = mfi.tilebox();
 
-            Array3<amrex::Real const> const arr = slicemf.const_array(mfi);
+            Array3<amrex::Real const> const arr = to3D(slicemf.const_array(mfi));
             const int Bx_comp = Comps[which_slice]["Bx"];
             const int By_comp = Comps[which_slice]["By"];
             const int Bx_iter_comp = Comps[which_slice_iter]["Bx"];
@@ -1384,7 +1384,7 @@ Fields::InSituComputeDiags (int step, amrex::Real time, int islice, const amrex:
     using ReduceTuple = typename decltype(reduce_data)::Type;
 
     for ( amrex::MFIter mfi(slicemf, DfltMfi); mfi.isValid(); ++mfi ) {
-        Array3<amrex::Real const> const arr = slicemf.const_array(mfi);
+        Array3<amrex::Real const> const arr = to3D(slicemf.const_array(mfi));
         reduce_op.eval(
             mfi.tilebox(), reduce_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int) -> ReduceTuple

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletDirect.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletDirect.cpp
@@ -64,7 +64,7 @@ FFTPoissonSolverDirichletDirect::define (amrex::BoxArray const& a_realspace_ba,
 
     // Calculate the array of m_eigenvalue_matrix
     for (amrex::MFIter mfi(m_eigenvalue_matrix, DfltMfi); mfi.isValid(); ++mfi ){
-        Array2<amrex::Real> eigenvalue_matrix = m_eigenvalue_matrix.array(mfi);
+        Array2<amrex::Real> eigenvalue_matrix = to2D(m_eigenvalue_matrix.array(mfi));
         amrex::IntVect lo = fft_box.smallEnd();
         amrex::ParallelFor(
             to2D(fft_box), [=] AMREX_GPU_DEVICE (int i, int j) noexcept
@@ -110,8 +110,8 @@ FFTPoissonSolverDirichletDirect::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
     for ( amrex::MFIter mfi(m_stagingArea, DfltMfiTlng); mfi.isValid(); ++mfi ){
         // Solve Poisson equation in Fourier space:
         // Multiply `tmpSpectralField` by eigenvalue_matrix
-        Array2<amrex::Real> tmp_cmplx_arr = m_tmpSpectralField.array(mfi);
-        Array2<amrex::Real> eigenvalue_matrix = m_eigenvalue_matrix.array(mfi);
+        Array2<amrex::Real> tmp_cmplx_arr = to2D(m_tmpSpectralField.array(mfi));
+        Array2<amrex::Real> eigenvalue_matrix = to2D(m_eigenvalue_matrix.array(mfi));
 
         amrex::ParallelFor( to2D(mfi.growntilebox()),
             [=] AMREX_GPU_DEVICE(int i, int j) noexcept {
@@ -126,8 +126,8 @@ FFTPoissonSolverDirichletDirect::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
 #endif
     for ( amrex::MFIter mfi(m_stagingArea, DfltMfiTlng); mfi.isValid(); ++mfi ){
         // Copy from the staging area to output array (and normalize)
-        Array2<amrex::Real> tmp_real_arr = m_stagingArea.array(mfi);
-        Array2<amrex::Real> lhs_arr = lhs_mf.array(mfi);
+        Array2<amrex::Real> tmp_real_arr = to2D(m_stagingArea.array(mfi));
+        Array2<amrex::Real> lhs_arr = to2D(lhs_mf.array(mfi));
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lhs_mf.size() == 1,
                                          "Slice MFs must be defined on one box only");
         amrex::ParallelFor( to2D(lhs_mf[mfi].box() & mfi.growntilebox()),

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletExpanded.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletExpanded.cpp
@@ -48,8 +48,8 @@ void ExpandR2R (amrex::FArrayBox& dst, const amrex::FArrayBox& src)
     const int ny = bx.length(1);
     const int refx = dst.box().bigEnd(0)+lox+1;
     const int refy = dst.box().bigEnd(1)+loy+1;
-    const Array2<amrex::Real const> src_array = src.array();
-    const Array2<amrex::Real> dst_array = dst.array();
+    const Array2<amrex::Real const> src_array = to2D(src.array());
+    const Array2<amrex::Real> dst_array = to2D(dst.array());
 
     amrex::ParallelFor(to2D(bx),
         [=] AMREX_GPU_DEVICE(int i, int j)
@@ -87,9 +87,9 @@ void Shrink_Mult_Expand (amrex::FArrayBox& dst,
     const int ny = bx.length(1);
     const int refx = dst.box().bigEnd(0)+lox+1;
     const int refy = dst.box().bigEnd(1)+loy+1;
-    const Array2<amrex::GpuComplex<amrex::Real> const> src_array = src.array();
-    const Array2<amrex::Real> dst_array = dst.array();
-    const Array2<amrex::Real const> eigenvalue_array= eigenvalue.array();
+    const Array2<amrex::GpuComplex<amrex::Real> const> src_array = to2D(src.array());
+    const Array2<amrex::Real> dst_array = to2D(dst.array());
+    const Array2<amrex::Real const> eigenvalue_array = to2D(eigenvalue.array());
 
     amrex::ParallelFor(to2D(bx),
         [=] AMREX_GPU_DEVICE(int i, int j)
@@ -116,8 +116,8 @@ void Shrink_Mult_Expand (amrex::FArrayBox& dst,
 void ShrinkC2R (amrex::FArrayBox& dst, const amrex::BaseFab<amrex::GpuComplex<amrex::Real>>& src,
                 amrex::Box bx)
 {
-    const Array2<amrex::GpuComplex<amrex::Real> const> src_array = src.array();
-    const Array2<amrex::Real> dst_array = dst.array();
+    const Array2<amrex::GpuComplex<amrex::Real> const> src_array = to2D(src.array());
+    const Array2<amrex::Real> dst_array = to2D(dst.array());
     amrex::ParallelFor(to2D(bx),
         [=] AMREX_GPU_DEVICE(int i, int j)
         {
@@ -165,7 +165,7 @@ FFTPoissonSolverDirichletExpanded::define (amrex::BoxArray const& a_realspace_ba
 
     // Calculate the array of m_eigenvalue_matrix
     for (amrex::MFIter mfi(m_eigenvalue_matrix, DfltMfi); mfi.isValid(); ++mfi ){
-        Array2<amrex::Real> eigenvalue_matrix = m_eigenvalue_matrix.array(mfi);
+        const Array2<amrex::Real> eigenvalue_matrix = to2D(m_eigenvalue_matrix.array(mfi));
         amrex::IntVect lo = fft_box.smallEnd();
         amrex::ParallelFor(
             to2D(fft_box), [=] AMREX_GPU_DEVICE (int i, int j) noexcept

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletFast.cpp
@@ -132,8 +132,8 @@ void ToSine_Transpose_ToComplex (const Array2<amrex::Real> in,
             const int tile_end_x = tile_begin_x + tile_dim_x_ex;
             const int tile_end_y = tile_begin_y + tile_dim_y;
 
-            Array2<amrex::Real> shared{{tile_ptr, {tile_begin_x, tile_begin_y, 0},
-                                                  {tile_end_x, tile_end_y, 1}, 1}};
+            Array2<amrex::Real> shared{tile_ptr, {tile_begin_x, tile_begin_y},
+                                                 {tile_end_x, tile_end_y}};
 
             {
                 const int thread_x = threadIdx.x / tile_dim_y;
@@ -230,7 +230,7 @@ FFTPoissonSolverDirichletFast::define (amrex::BoxArray const& a_realspace_ba,
 
     // Calculate the array of m_eigenvalue_matrix
     m_eigenvalue_matrix.resize({{0,0,0}, {ny-1,nx-1,0}});
-    Array2<amrex::Real> eigenvalue_matrix = m_eigenvalue_matrix.array();
+    Array2<amrex::Real> eigenvalue_matrix = to2D(m_eigenvalue_matrix.array());
     amrex::ParallelFor(amrex::BoxND<2>{{0,0}, {ny-1,nx-1}},
         [=] AMREX_GPU_DEVICE (int j, int i) noexcept
         {
@@ -290,13 +290,13 @@ FFTPoissonSolverDirichletFast::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
     const int nx = m_stagingArea[0].box().length(0); // initially contiguous
     const int ny = m_stagingArea[0].box().length(1); // contiguous after transpose
 
-    Array2<amrex::Real> pos_arr {{m_stagingArea[0].dataPtr(), {0,0,0}, {nx,ny,1}, 1}};
+    Array2<amrex::Real> pos_arr {m_stagingArea[0].dataPtr(), {0,0}, {nx,ny}};
 
-    Array2<amrex::Real> real_arr {{m_position_array.dataPtr(), {0,0,0}, {nx+1,ny,1}, 1}};
-    Array2<amrex::Real> real_arr_t {{m_position_array.dataPtr(), {0,0,0}, {ny+1,nx,1}, 1}};
+    Array2<amrex::Real> real_arr {m_position_array.dataPtr(), {0,0}, {nx+1,ny}};
+    Array2<amrex::Real> real_arr_t {m_position_array.dataPtr(), {0,0}, {ny+1,nx}};
 
-    Array2<amrex::GpuComplex<amrex::Real>> comp_arr {{ m_fourier_array.dataPtr(), {0,0,0}, {(nx+1)/2+1,ny,1}, 1}};
-    Array2<amrex::GpuComplex<amrex::Real>> comp_arr_t {{ m_fourier_array.dataPtr(), {0,0,0}, {(ny+1)/2+1,nx,1}, 1}};
+    Array2<amrex::GpuComplex<amrex::Real>> comp_arr {m_fourier_array.dataPtr(), {0,0}, {(nx+1)/2+1,ny}};
+    Array2<amrex::GpuComplex<amrex::Real>> comp_arr_t {m_fourier_array.dataPtr(), {0,0}, {(ny+1)/2+1,nx}};
 
     // 1D DST in x
     ToComplex(pos_arr, comp_arr, nx, ny);
@@ -309,7 +309,7 @@ FFTPoissonSolverDirichletFast::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
     m_y_fft.Execute();
 
     // 1D DST in y
-    ToSine_Mult_ToComplex(real_arr_t, comp_arr_t, m_eigenvalue_matrix.array(),
+    ToSine_Mult_ToComplex(real_arr_t, comp_arr_t, to2D(m_eigenvalue_matrix.array()),
                           m_sine_y_factor.dataPtr(), ny, nx);
 
     m_y_fft.Execute();
@@ -322,7 +322,7 @@ FFTPoissonSolverDirichletFast::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
     amrex::Box lhs_bx = lhs_mf[0].box();
     // shift box to handle ghost cells properly
     lhs_bx -= m_stagingArea[0].box().smallEnd();
-    Array2<amrex::Real> lhs_arr {{lhs_mf[0].dataPtr(), amrex::begin(lhs_bx), amrex::end(lhs_bx), 1}};
+    Array2<amrex::Real> lhs_arr {lhs_mf[0].dataPtr(), to2D(lhs_bx)};
 
     ToSine(real_arr, lhs_arr, m_sine_x_factor.dataPtr(), nx, ny);
 }

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletQuick.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverDirichletQuick.cpp
@@ -366,18 +366,18 @@ FFTPoissonSolverDirichletQuick::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
     const int nx = m_stagingArea[0].box().length(0); // initially contiguous
     const int ny = m_stagingArea[0].box().length(1); // contiguous after transpose
 
-    Array2<amrex::Real> input_arr {{m_stagingArea[0].dataPtr(), {0,0,0}, {nx,ny,1}, 1}};
+    Array2<amrex::Real> input_arr {m_stagingArea[0].dataPtr(), {0,0}, {nx,ny}};
 
-    Array2<amrex::Real> real_arr {{m_real_array.dataPtr(), {0,0,0}, {nx,ny,1}, 1}};
-    Array2<amrex::Real> real_arr_t {{m_real_array.dataPtr(), {0,0,0}, {ny,nx,1}, 1}};
+    Array2<amrex::Real> real_arr {m_real_array.dataPtr(), {0,0}, {nx,ny}};
+    Array2<amrex::Real> real_arr_t {m_real_array.dataPtr(), {0,0}, {ny,nx}};
 
-    Array2<amrex::GpuComplex<amrex::Real>> comp_arr {{m_comp_array.dataPtr(), {0,0,0}, {nx/2+1,ny,1}, 1}};
-    Array2<amrex::GpuComplex<amrex::Real>> comp_arr_t {{m_comp_array.dataPtr(), {0,0,0}, {ny/2+1,nx,1}, 1}};
+    Array2<amrex::GpuComplex<amrex::Real>> comp_arr {m_comp_array.dataPtr(), {0,0}, {nx/2+1,ny}};
+    Array2<amrex::GpuComplex<amrex::Real>> comp_arr_t {m_comp_array.dataPtr(), {0,0}, {ny/2+1,nx}};
 
     amrex::Box lhs_bx = lhs_mf[0].box();
     // shift box to handle ghost cells properly
     lhs_bx -= m_stagingArea[0].box().smallEnd();
-    Array2<amrex::Real> lhs_arr {{lhs_mf[0].dataPtr(), amrex::begin(lhs_bx), amrex::end(lhs_bx), 1}};
+    Array2<amrex::Real> lhs_arr {lhs_mf[0].dataPtr(), to2D(lhs_bx)};
 
     amrex::ParallelFor(amrex::BoxND<2>{{0, 0}, {nx-1, ny-1}},
         [=] AMREX_GPU_DEVICE (int i, int j){

--- a/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
+++ b/src/fields/fft_poisson_solver/FFTPoissonSolverPeriodic.cpp
@@ -73,7 +73,7 @@ FFTPoissonSolverPeriodic::define ( amrex::BoxArray const& realspace_ba,
     m_inv_k2 = amrex::MultiFab(spectralspace_ba, dm, 1, 0);
     // Loop over boxes and calculate inv_k2 in each box
     for (amrex::MFIter mfi(m_inv_k2, DfltMfi); mfi.isValid(); ++mfi ){
-        Array2<amrex::Real> inv_k2_arr = m_inv_k2.array(mfi);
+        Array2<amrex::Real> inv_k2_arr = to2D(m_inv_k2.array(mfi));
         amrex::Box const& bx = mfi.validbox();  // The lower corner of the "2D" slice Box is zero.
         int const Ny = bx.length(1);
         int const mid_point_y = (Ny+1)/2;
@@ -120,8 +120,8 @@ FFTPoissonSolverPeriodic::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
     for ( amrex::MFIter mfi(m_tmpSpectralField, DfltMfiTlng); mfi.isValid(); ++mfi ){
         // Solve Poisson equation in Fourier space:
         // Multiply `tmpSpectralField` by inv_k2
-        Array2<amrex::GpuComplex<amrex::Real>> tmp_cmplx_arr = m_tmpSpectralField.array(mfi);
-        Array2<amrex::Real> inv_k2_arr = m_inv_k2.array(mfi);
+        Array2<amrex::GpuComplex<amrex::Real>> tmp_cmplx_arr = to2D(m_tmpSpectralField.array(mfi));
+        Array2<amrex::Real> inv_k2_arr = to2D(m_inv_k2.array(mfi));
         amrex::ParallelFor( to2D(mfi.growntilebox()),
             [=] AMREX_GPU_DEVICE(int i, int j) noexcept {
                 tmp_cmplx_arr(i,j) *= -inv_k2_arr(i,j);
@@ -135,8 +135,8 @@ FFTPoissonSolverPeriodic::SolvePoissonEquation (amrex::MultiFab& lhs_mf)
 #endif
     for ( amrex::MFIter mfi(m_stagingArea, DfltMfiTlng); mfi.isValid(); ++mfi ){
         // Copy from the staging area to output array (and normalize)
-        Array2<amrex::Real> tmp_real_arr = m_stagingArea.array(mfi);
-        Array2<amrex::Real> lhs_arr = lhs_mf.array(mfi);
+        Array2<amrex::Real> tmp_real_arr = to2D(m_stagingArea.array(mfi));
+        Array2<amrex::Real> lhs_arr = to2D(lhs_mf.array(mfi));
         const amrex::Box fft_box = m_stagingArea[mfi].box();
         const amrex::Real inv_N = 1./fft_box.numPts();
         amrex::ParallelFor( to2D(mfi.growntilebox()),

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -214,7 +214,7 @@ MultiLaser::ShiftLaserSlices (const int islice)
 
     for ( amrex::MFIter mfi(m_slices, DfltMfi); mfi.isValid(); ++mfi ){
         const amrex::Box bx = mfi.tilebox();
-        Array3<amrex::Real> arr = m_slices.array(mfi);
+        Array3<amrex::Real> arr = to3D(m_slices.array(mfi));
         amrex::ParallelFor(
         to2D(bx), 2,
         [=] AMREX_GPU_DEVICE(int i, int j, int n) noexcept
@@ -259,9 +259,9 @@ MultiLaser::UpdateLaserAabs (const int islice, const int current_N_level, Fields
 
     // write aabs into fields MultiFab
     for ( amrex::MFIter mfi(fields.getSlices(0), DfltMfi); mfi.isValid(); ++mfi ){
-        const Array3<const amrex::Real> laser_arr = m_slices.const_array(mfi);
+        const Array3<const amrex::Real> laser_arr = to3D(m_slices.const_array(mfi));
         const Array2<amrex::Real> field_arr =
-            fields.getSlices(0).array(mfi, Comps[WhichSlice::This]["aabs"]);
+            to2D(fields.getSlices(0).array(mfi, Comps[WhichSlice::This]["aabs"]));
 
         const amrex::Real poff_field_x = GetPosOffset(0, field_geom[0], field_geom[0].Domain());
         const amrex::Real poff_field_y = GetPosOffset(1, field_geom[0], field_geom[0].Domain());
@@ -330,7 +330,7 @@ MultiLaser::SetInitialChi (const MultiPlasma& multi_plasma)
     HIPACE_PROFILE("MultiLaser::SetInitialChi()");
 
     for ( amrex::MFIter mfi(m_slices, DfltMfi); mfi.isValid(); ++mfi ){
-        Array2<amrex::Real> laser_arr_chi = m_slices.array(mfi, WhichLaserSlice::chi_initial);
+        Array2<amrex::Real> laser_arr_chi = to2D(m_slices.array(mfi, WhichLaserSlice::chi_initial));
 
         // put chi from the plasma density function on the laser grid as if it were deposited there,
         // this works even outside the field grid
@@ -369,9 +369,9 @@ MultiLaser::InterpolateChi (const Fields& fields, amrex::Geometry const& geom_fi
     HIPACE_PROFILE("MultiLaser::InterpolateChi()");
 
     for ( amrex::MFIter mfi(m_slices, DfltMfi); mfi.isValid(); ++mfi ){
-        Array3<amrex::Real> laser_arr = m_slices.array(mfi);
+        Array3<amrex::Real> laser_arr = to3D(m_slices.array(mfi));
         Array2<const amrex::Real> field_arr_chi =
-            fields.getSlices(0).array(mfi, Comps[WhichSlice::This]["chi"]);
+            to2D(fields.getSlices(0).array(mfi, Comps[WhichSlice::This]["chi"]));
 
         const amrex::Real poff_laser_x = GetPosOffset(0, m_laser_geom_3D, m_laser_geom_3D.Domain());
         const amrex::Real poff_laser_y = GetPosOffset(1, m_laser_geom_3D, m_laser_geom_3D.Domain());
@@ -489,9 +489,9 @@ MultiLaser::AdvanceSliceMG (amrex::Real dt, int step)
         const int jmin = bx.smallEnd(1);
         const int jmax = bx.bigEnd  (1);
 
-        Array3<amrex::Real> arr = m_slices.array(mfi);
-        Array3<amrex::Real> rhs_mg_arr = m_rhs_mg.array();
-        Array3<amrex::Real> acoeff_real_arr = m_mg_acoeff_real.array();
+        Array3<amrex::Real> arr = to3D(m_slices.array(mfi));
+        Array3<amrex::Real> rhs_mg_arr = to3D(m_rhs_mg.array());
+        Array3<amrex::Real> acoeff_real_arr = to3D(m_mg_acoeff_real.array());
 
         // Calculate phase terms. 0 if !m_use_phase
         amrex::Real tj00 = 0.;
@@ -667,11 +667,11 @@ MultiLaser::AdvanceSliceFFT (const amrex::Real dt, int step)
         // The right-hand side is computed and stored in rhs
         // Then rhs is Fourier-transformed into rhs_fourier, then multiplied by -1/(k**2+a)
         // rhs_fourier is FFT-back-transformed to sol, and sol is normalized and copied into np1j00.
-        Array3<Complex> sol_arr = m_sol.array();
-        Array3<Complex> rhs_arr = m_rhs.array();
-        Array2<Complex> rhs_fourier_arr = m_rhs_fourier.array();
+        Array2<Complex> sol_arr = to2D(m_sol.array());
+        Array2<Complex> rhs_arr = to2D(m_rhs.array());
+        Array2<Complex> rhs_fourier_arr = to2D(m_rhs_fourier.array());
 
-        Array3<amrex::Real> arr = m_slices.array(mfi);
+        Array3<amrex::Real> arr = to3D(m_slices.array(mfi));
 
         int const Nx = bx.length(0);
         int const Ny = bx.length(1);
@@ -785,7 +785,7 @@ MultiLaser::AdvanceSliceFFT (const amrex::Real dt, int step)
                         - lapA
                         + ( -3._rt/(c*dt*dz) + 2._rt*I*djn/(c*dt) + 2._rt/(c*c*dt*dt) + I*2._rt*k0/(c*dt) ) * anm1j00;
                 }
-                rhs_arr(i,j,0) = rhs;
+                rhs_arr(i,j) = rhs;
             });
 
         // Transform rhs to Fourier space
@@ -822,8 +822,8 @@ MultiLaser::AdvanceSliceFFT (const amrex::Real dt, int step)
             [=] AMREX_GPU_DEVICE(int i, int j) noexcept {
                 using namespace WhichLaserSlice;
                 if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
-                    arr(i, j, np1j00_r) = sol_arr(i,j,0).real() * inv_numPts;
-                    arr(i, j, np1j00_i) = sol_arr(i,j,0).imag() * inv_numPts;
+                    arr(i, j, np1j00_r) = sol_arr(i,j).real() * inv_numPts;
+                    arr(i, j, np1j00_i) = sol_arr(i,j).imag() * inv_numPts;
                 } else {
                     arr(i, j, np1j00_r) = 0._rt;
                     arr(i, j, np1j00_i) = 0._rt;
@@ -989,7 +989,7 @@ MultiLaser::InSituComputeDiags (int step, amrex::Real time, int islice,
     using ReduceTuple = typename decltype(reduce_data)::Type;
 
     for ( amrex::MFIter mfi(m_slices, DfltMfi); mfi.isValid(); ++mfi ) {
-        Array3<amrex::Real const> const arr = m_slices.const_array(mfi);
+        Array3<amrex::Real const> const arr = to3D(m_slices.const_array(mfi));
         reduce_op.eval(
             mfi.tilebox(), reduce_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int) -> ReduceTuple

--- a/src/mg_solver/HpMultiGrid.cpp
+++ b/src/mg_solver/HpMultiGrid.cpp
@@ -876,8 +876,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
     {
         Real facx = Real(1.)/(dx0*dx0);
         Real facy = Real(1.)/(dy0*dy0);
-        int lenx = cor[0].end.x - cor[0].begin.x - 2*corner_offset;
-        int leny = cor[0].end.y - cor[0].begin.y - 2*corner_offset;
+        int lenx = cor[0].end[0] - cor[0].begin[0] - 2*corner_offset;
+        int leny = cor[0].end[1] - cor[0].begin[1] - 2*corner_offset;
         int ncells = lenx*leny;
 #if defined(AMREX_USE_DPCPP)
         const int icell = item.get_local_linear_id();
@@ -886,8 +886,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
 #endif
         int j = icell /   lenx;
         int i = icell - j*lenx;
-        j += cor[0].begin.y + corner_offset;
-        i += cor[0].begin.x + corner_offset;
+        j += cor[0].begin[1] + corner_offset;
+        i += cor[0].begin[0] + corner_offset;
 
         for (int ilev = 0; ilev < nlevs-1; ++ilev) {
             // set phi to zero
@@ -906,8 +906,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
                 if (icell < ncells) {
                     if ((i+j+is)%2 == 0) {
                         fgs(i, j,
-                            cor[ilev].begin.x, cor[ilev].begin.y,
-                            cor[ilev].end.x-1, cor[ilev].end.y-1,
+                            cor[ilev].begin[0], cor[ilev].begin[1],
+                            cor[ilev].end[0]-1, cor[ilev].end[1]-1,
                             cor[ilev], res[ilev], acf[ilev],
                             facx, facy);
                     }
@@ -919,8 +919,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
             if (icell < ncells) {
                 fres(i, j,
                      rescor[ilev],
-                     cor[ilev].begin.x, cor[ilev].begin.y,
-                     cor[ilev].end.x-1, cor[ilev].end.y-1,
+                     cor[ilev].begin[0], cor[ilev].begin[1],
+                     cor[ilev].end[0]-1, cor[ilev].end[1]-1,
                      cor[ilev],
                      res[ilev],
                      acf[ilev], facx, facy);
@@ -928,14 +928,14 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
             HPMG_SYNCTHREADS;
 
             // interpolate residual to next level
-            lenx = cor[ilev+1].end.x - cor[ilev+1].begin.x - 2*corner_offset;
-            leny = cor[ilev+1].end.y - cor[ilev+1].begin.y - 2*corner_offset;
+            lenx = cor[ilev+1].end[0] - cor[ilev+1].begin[0] - 2*corner_offset;
+            leny = cor[ilev+1].end[1] - cor[ilev+1].begin[1] - 2*corner_offset;
             ncells = lenx*leny;
             if (icell < ncells) {
                 j = icell /   lenx;
                 i = icell - j*lenx;
-                j += cor[ilev+1].begin.y + corner_offset;
-                i += cor[ilev+1].begin.x + corner_offset;
+                j += cor[ilev+1].begin[1] + corner_offset;
+                i += cor[ilev+1].begin[0] + corner_offset;
                 if (corner_offset == 0) {
                     if (system_type == 1 || system_type == 2) {
                         restrict_cc(i,j,0,res[ilev+1],rescor[ilev]);
@@ -977,8 +977,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
                 if (icell < ncells) {
                     if ((i+j+is)%2 == 0) {
                         fgs(i, j,
-                            cor[ilev].begin.x, cor[ilev].begin.y,
-                            cor[ilev].end.x-1, cor[ilev].end.y-1,
+                            cor[ilev].begin[0], cor[ilev].begin[1],
+                            cor[ilev].end[0]-1, cor[ilev].end[1]-1,
                             cor[ilev], res[ilev], acf[ilev],
                             facx, facy);
                     }
@@ -989,8 +989,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
 
         // interpolate solution from previous level to phi
         for (int ilev = nlevs-2; ilev >=0; --ilev) {
-            lenx = cor[ilev].end.x - cor[ilev].begin.x - 2*corner_offset;
-            leny = cor[ilev].end.y - cor[ilev].begin.y - 2*corner_offset;
+            lenx = cor[ilev].end[0] - cor[ilev].begin[0] - 2*corner_offset;
+            leny = cor[ilev].end[1] - cor[ilev].begin[1] - 2*corner_offset;
             ncells = lenx*leny;
             facx *= Real(4.);
             facy *= Real(4.);
@@ -998,8 +998,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
             if (icell < ncells) {
                 j = icell /   lenx;
                 i = icell - j*lenx;
-                j += cor[ilev].begin.y + corner_offset;
-                i += cor[ilev].begin.x + corner_offset;
+                j += cor[ilev].begin[1] + corner_offset;
+                i += cor[ilev].begin[0] + corner_offset;
                 if (corner_offset == 0) {
                     if (system_type == 1 || system_type == 2) {
                         interpadd_cc(i, j, 0, cor[ilev], cor[ilev+1]);
@@ -1023,8 +1023,8 @@ void bottomsolve_gpu (Real dx0, Real dy0, Array4<Real> const* acf,
                 if (icell < ncells) {
                     if ((i+j+is)%2 == 0) {
                         fgs(i, j,
-                            cor[ilev].begin.x, cor[ilev].begin.y,
-                            cor[ilev].end.x-1, cor[ilev].end.y-1,
+                            cor[ilev].begin[0], cor[ilev].begin[1],
+                            cor[ilev].end[0]-1, cor[ilev].end[1]-1,
                             cor[ilev], res[ilev], acf[ilev],
                             facx, facy);
                     }
@@ -1609,8 +1609,8 @@ namespace {
 #endif
         {
             for (int ilev = 1; ilev < nlevels; ++ilev) {
-                const int lenx = acf[ilev].end.x - acf[ilev].begin.x;
-                const int leny = acf[ilev].end.y - acf[ilev].begin.y;
+                const int lenx = acf[ilev].end[0] - acf[ilev].begin[0];
+                const int leny = acf[ilev].end[1] - acf[ilev].begin[1];
                 const int ncells = lenx*leny;
 #if defined(AMREX_USE_DPCPP)
                 for (int icell = item.get_local_range(0)*item.get_group_linear_id()
@@ -1622,8 +1622,8 @@ namespace {
                      icell < ncells; icell += stride) {
                     int j = icell /   lenx;
                     int i = icell - j*lenx;
-                    j += acf[ilev].begin.y;
-                    i += acf[ilev].begin.x;
+                    j += acf[ilev].begin[1];
+                    i += acf[ilev].begin[0];
                     for (int n = 0; n < ncomp; ++n) {
                         f(i,j,n,acf[ilev],acf[ilev-1]);
                     }
@@ -1675,10 +1675,10 @@ MultiGrid::average_down_acoef ()
                         [] AMREX_GPU_DEVICE (int i, int j, int n, Array4<Real> const& crse,
                                              Array4<Real> const& fine) noexcept
                         {
-                            if (i == crse.begin.x ||
-                                j == crse.begin.y ||
-                                i == crse.end.x-1 ||
-                                j == crse.end.y-1) {
+                            if (i == crse.begin[0] ||
+                                j == crse.begin[1] ||
+                                i == crse.end[0]-1 ||
+                                j == crse.end[1]-1) {
                                 crse(i,j,0,n) = Real(0.);
                             } else {
                                 restrict_nd(i,j,n,crse,fine);

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -234,12 +234,10 @@ InitBeamFixedPPCSlice (const int islice, const int which_beam_slice)
     // First: loop over all cells, and count the particles effectively injected.
 
     amrex::Gpu::DeviceVector<int> counts(slice_box.numPts(), 0);
-    const Array2<int> count_arr {{counts.dataPtr(), amrex::begin(slice_box),
-                                  amrex::end(slice_box), 1}};
+    const Array2<int> count_arr {counts.dataPtr(), to2D(slice_box)};
 
     amrex::Gpu::DeviceVector<int> offsets(slice_box.numPts());
-    const Array2<int> offset_arr {{offsets.dataPtr(), amrex::begin(slice_box),
-                                   amrex::end(slice_box), 1}};
+    const Array2<int> offset_arr {offsets.dataPtr(), to2D(slice_box)};
 
     amrex::ParallelForRNG(to2D(slice_box),
         [=] AMREX_GPU_DEVICE (int i, int j, const amrex::RandomEngine& engine) noexcept

--- a/src/particles/deposition/BeamDepositCurrent.cpp
+++ b/src/particles/deposition/BeamDepositCurrent.cpp
@@ -97,7 +97,7 @@ DepositCurrentSlice (BeamParticleContainer& beam, Fields& fields,
             constexpr int stencil_size = depos_order + 1;
             SharedMemoryDeposition<stencil_size, stencil_size, true>(
                 beam.getNumParticles(which_beam_slice), is_valid, get_cell, deposit,
-                isl_fab.array(), isl_fab.box(),
+                to3D(isl_fab.array()), isl_fab.box(),
                 beam.getBeamSlice(which_beam_slice).getParticleTileData(),
                 amrex::GpuArray<int, 0>{},
                 amrex::GpuArray<int, 4>{jxb_cmp, jyb_cmp, jzb_cmp, rhomjzb_cmp});

--- a/src/particles/deposition/DepositionUtil.H
+++ b/src/particles/deposition/DepositionUtil.H
@@ -130,7 +130,7 @@ SharedMemoryDeposition (int num_particles,
                     shared_ptr,
                     amrex::IntVectND{tile_begin_x, tile_begin_y},
                     amrex::IntVectND{tile_end_x, tile_end_y},
-                    max_cache + max_depos
+                    static_cast<int>(max_cache + max_depos)
                 };
 
                 for (int s = threadIdx.x; s < tile_s_x * tile_s_y; s+=threads_per_tile) {
@@ -148,7 +148,7 @@ SharedMemoryDeposition (int num_particles,
                         for (int n=0; n != max_depos; ++n) {
                             if (!dynamic_comps || idx_depos[n] != -1) {
                                 // set idx_depos components to zero
-                                shared_arr(sx, sy, n+max_cache) = 0;
+                                shared_arr(sx, sy, static_cast<int>(n+max_cache)) = 0;
                             }
                         }
                     }
@@ -187,7 +187,8 @@ SharedMemoryDeposition (int num_particles,
                         for (int n=0; n != max_depos; ++n) {
                             if (!dynamic_comps || idx_depos[n] != -1) {
                                 amrex::Gpu::Atomic::Add(
-                                    field.ptr(sx, sy, idx_depos[n]), shared_arr(sx, sy, n+max_cache));
+                                    field.ptr(sx, sy, idx_depos[n]),
+                                    shared_arr(sx, sy, static_cast<int>(n+max_cache)));
                             }
                         }
                     }

--- a/src/particles/deposition/DepositionUtil.H
+++ b/src/particles/deposition/DepositionUtil.H
@@ -126,12 +126,12 @@ SharedMemoryDeposition (int num_particles,
                 const int tile_end_y = std::min(tile_begin_y + tile_s_y, hi_y + 1);
 
                 // make Array3 reference shared memory tile
-                Array3<amrex::Real> shared_arr{{
+                Array3<amrex::Real> shared_arr{
                     shared_ptr,
-                    {tile_begin_x, tile_begin_y, 0},
-                    {tile_end_x, tile_end_y, 1},
+                    amrex::IntVectND{tile_begin_x, tile_begin_y},
+                    amrex::IntVectND{tile_end_x, tile_end_y},
                     max_cache + max_depos
-                }};
+                };
 
                 for (int s = threadIdx.x; s < tile_s_x * tile_s_y; s+=threads_per_tile) {
                     int sy = s / tile_s_x;

--- a/src/particles/deposition/ExplicitDeposition.cpp
+++ b/src/particles/deposition/ExplicitDeposition.cpp
@@ -81,14 +81,14 @@ ExplicitDeposition (PlasmaParticleContainer& plasma, Fields& fields,
                     // need extra cells for gathering the laser
                     constexpr int stencil_size = depos_order + 2 + 1;
                     SharedMemoryDeposition<stencil_size, stencil_size, false>(
-                        int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
+                        int(pti.numParticles()), is_valid, get_cell, deposit, to3D(isl_fab.array()),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
                         amrex::GpuArray<int, 5>{Bz, Ez, ExmBy, EypBx, aabs_comp},
                         amrex::GpuArray<int, 2>{Sy, Sx});
                 } else {
                     constexpr int stencil_size = depos_order + derivative_type + 1;
                     SharedMemoryDeposition<stencil_size, stencil_size, false>(
-                        int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
+                        int(pti.numParticles()), is_valid, get_cell, deposit, to3D(isl_fab.array()),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
                         amrex::GpuArray<int, 4>{Bz, Ez, ExmBy, EypBx},
                         amrex::GpuArray<int, 2>{Sy, Sx});

--- a/src/particles/deposition/PlasmaDepositCurrent.cpp
+++ b/src/particles/deposition/PlasmaDepositCurrent.cpp
@@ -114,13 +114,13 @@ DepositCurrent (PlasmaParticleContainer& plasma, Fields & fields,
                 constexpr int stencil_size = depos_order + 1;
                 if constexpr (use_laser) {
                     SharedMemoryDeposition<stencil_size, stencil_size, true>(
-                        int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
+                        int(pti.numParticles()), is_valid, get_cell, deposit, to3D(isl_fab.array()),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
                         amrex::GpuArray<int, 1>{aabs},
                         amrex::GpuArray<int, 6>{jx, jy, jz, rho, chi, rhomjz});
                 } else {
                     SharedMemoryDeposition<stencil_size, stencil_size, true>(
-                        int(pti.numParticles()), is_valid, get_cell, deposit, isl_fab.array(),
+                        int(pti.numParticles()), is_valid, get_cell, deposit,to3D( isl_fab.array()),
                         isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
                         amrex::GpuArray<int, 0>{},
                         amrex::GpuArray<int, 6>{jx, jy, jz, rho, chi, rhomjz});

--- a/src/particles/deposition/TemperatureDeposition.cpp
+++ b/src/particles/deposition/TemperatureDeposition.cpp
@@ -130,12 +130,12 @@ DepositTemperature (PlasmaParticleContainer& plasma,
                 amrex::Gpu::Atomic::Add(arr.ptr(i, j, depos_idx[5]), wp*uyp*uyp);
                 amrex::Gpu::Atomic::Add(arr.ptr(i, j, depos_idx[6]), wp*uzp*uzp);
             },
-            isl_fab.array(),
+            to3D(isl_fab.array()),
             isl_fab.box(), pti.GetParticleTile().getParticleTileData(),
             amrex::GpuArray<int, 1>{aabs},
             amrex::GpuArray<int, 7>{w, ux, uy, uz, uxsq, uysq, uzsq}
         );
-        Array3<amrex::Real> field_arr = isl_fab.array();
+        Array3<amrex::Real> field_arr = to3D(isl_fab.array());
 
         // Normalize the components of momentum (ux, uy, uz) and their squares (uxsq, uysq, uzsq)
         // by dividing them by the total weight (w) in each cell. If the weight is zero, no division is performed.

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -377,7 +377,7 @@ IonizationModule (const int lev,
     {
         // Extract field array from FabArray
         const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[mfi_ion];
-        Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
+        Array3<const amrex::Real> const slice_arr = to3D(slice_fab.const_array());
         const int psi_comp = Comps[WhichSlice::This]["Psi"];
         const int ez_comp = Comps[WhichSlice::This]["Ez"];
         const int bx_comp = Comps[WhichSlice::This]["Bx"];
@@ -566,7 +566,7 @@ LaserIonization (const int islice,
     for (amrex::MFIter mfi_ion = MakeMFIter(0, DfltMfi); mfi_ion.isValid(); ++mfi_ion)
     {
         // Extract laser array
-        Array3<const amrex::Real> const laser_arr = laser.getSlices().const_array(mfi_ion);
+        Array3<const amrex::Real> const laser_arr = to3D(laser.getSlices().const_array(mfi_ion));
 
         const CheckDomainBounds laser_bounds {laser_geom};
 
@@ -827,7 +827,7 @@ PlasmaParticleContainer::InSituComputeDiags (int islice)
         const amrex::Geometry& gm = Hipace::GetInstance().m_3D_geom[0];
         const int aabs_comp = Hipace::m_use_laser ? Comps[WhichSlice::This]["aabs"] : -1;
         amrex::FArrayBox& isl_fab = Hipace::GetInstance().m_fields.getSlices(0)[pti];
-        Array3<amrex::Real> arr = isl_fab.array();
+        Array3<amrex::Real> arr = to3D(isl_fab.array());
         const amrex::Real x_pos_offset = GetPosOffset(0, gm, isl_fab.box());
         const amrex::Real y_pos_offset = GetPosOffset(1, gm, isl_fab.box());
         const amrex::Real dx_inv = gm.InvCellSize(0);

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -110,7 +110,7 @@ InitParticles (const amrex::RealVect& a_u_std,
         if (use_fine_patch) {
             fab_fine.resize(tile_box, 2);
         }
-        const Array3<int> arr_fine = fab_fine.array();
+        const Array3<int> arr_fine = to3D(fab_fine.array());
         int comp_a = 0;
         int comp_b = 1;
         const int fine_transition_cells = m_fine_transition_cells;

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -55,9 +55,9 @@ AdvanceBeamParticlesSlice (
     const amrex::FArrayBox& slice_fab_lev1 = fields.getSlices(lev1_idx)[0];
     const amrex::FArrayBox& slice_fab_lev2 = fields.getSlices(lev2_idx)[0];
 
-    Array3<const amrex::Real> const slice_arr_lev0 = slice_fab_lev0.const_array();
-    Array3<const amrex::Real> const slice_arr_lev1 = slice_fab_lev1.const_array();
-    Array3<const amrex::Real> const slice_arr_lev2 = slice_fab_lev2.const_array();
+    Array3<const amrex::Real> const slice_arr_lev0 = to3D(slice_fab_lev0.const_array());
+    Array3<const amrex::Real> const slice_arr_lev1 = to3D(slice_fab_lev1.const_array());
+    Array3<const amrex::Real> const slice_arr_lev2 = to3D(slice_fab_lev2.const_array());
 
     // Extract properties associated with physical size of the box
     const amrex::Real dx_inv_lev0 = gm[lev0_idx].InvCellSize(0);

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -41,7 +41,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
     {
         // Extract field array from FabArray
         const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[pti];
-        Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
+        Array3<const amrex::Real> const slice_arr = to3D(slice_fab.const_array());
         const int psi_comp = Comps[WhichSlice::This]["Psi"];
         const int ez_comp = Comps[WhichSlice::This]["Ez"];
         const int bx_comp = Comps[WhichSlice::This]["Bx"];

--- a/src/salame/Salame.cpp
+++ b/src/salame/Salame.cpp
@@ -202,7 +202,7 @@ SalameInitializeSxSyWithBeam (Hipace* hipace, const int lev)
 
     for ( amrex::MFIter mfi(slicemf, DfltMfiTlng); mfi.isValid(); ++mfi ){
 
-        Array3<amrex::Real> const arr = slicemf.array(mfi);
+        Array3<amrex::Real> const arr = to3D(slicemf.array(mfi));
 
         const int Sx = Comps[WhichSlice::Salame]["Sx"];
         const int Sy = Comps[WhichSlice::Salame]["Sy"];
@@ -241,7 +241,7 @@ SalameGetJxJyFromBxBy (Hipace* hipace, const int lev)
 
     for ( amrex::MFIter mfi(slicemf, DfltMfiTlng); mfi.isValid(); ++mfi ){
 
-        Array3<amrex::Real> const arr = slicemf.array(mfi);
+        Array3<amrex::Real> const arr = to3D(slicemf.array(mfi));
 
         const int Bx = Comps[WhichSlice::Salame]["Bx"];
         const int By = Comps[WhichSlice::Salame]["By"];
@@ -273,7 +273,7 @@ SalameOnlyAdvancePlasma (Hipace* hipace, const int lev)
         for (PlasmaParticleIterator pti(plasma); pti.isValid(); ++pti)
         {
             const amrex::FArrayBox& slice_fab = hipace->m_fields.getSlices(lev)[pti];
-            Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
+            Array3<const amrex::Real> const slice_arr = to3D(slice_fab.const_array());
             const int bx_comp = Comps[WhichSlice::Salame]["Bx"];
             const int by_comp = Comps[WhichSlice::Salame]["By"];
 
@@ -359,7 +359,7 @@ SalameGetW (Hipace* hipace, const int current_N_level, const int islice)
             amrex::ReduceData<amrex::Real, amrex::Real,
                             amrex::Real, amrex::Real> reduce_data(reduce_op);
             using ReduceTuple = typename decltype(reduce_data)::Type;
-            Array3<amrex::Real> const arr = slicemf.array(mfi);
+            Array3<amrex::Real> const arr = to3D(slicemf.array(mfi));
 
             const int Ez = Comps[WhichSlice::Salame]["Ez"];
             const int Ez_target = Comps[WhichSlice::Salame]["Ez_target"];

--- a/src/utils/AdaptiveTimeStep.cpp
+++ b/src/utils/AdaptiveTimeStep.cpp
@@ -285,7 +285,7 @@ AdaptiveTimeStep::GatherMinAccSlice (MultiBeam& beams, const amrex::Geometry& ge
 
         // Data required to gather the Ez field
         const amrex::FArrayBox& slice_fab = fields.getSlices(lev)[0];
-        Array3<const amrex::Real> const slice_arr = slice_fab.const_array();
+        Array3<const amrex::Real> const slice_arr = to3D(slice_fab.const_array());
         const int ez_comp = Comps[WhichSlice::This]["Ez"];
         const amrex::Real dx_inv = geom.InvCellSize(0);
         const amrex::Real dy_inv = geom.InvCellSize(1);

--- a/src/utils/GPUUtil.H
+++ b/src/utils/GPUUtil.H
@@ -12,10 +12,10 @@
 #include <AMReX_MFIter.H>
 
 template<class T>
-using Array2 = amrex::ArrayND<T, 2>;
+using Array2 = amrex::ArrayND<T, 2, false>;
 
 template<class T>
-using Array3 = amrex::ArrayND<T, 3>;
+using Array3 = amrex::ArrayND<T, 3, true>;
 
 template<class T> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Array2<T> to2D (const amrex::Array4<T>& arr) {

--- a/src/utils/GPUUtil.H
+++ b/src/utils/GPUUtil.H
@@ -12,82 +12,34 @@
 #include <AMReX_MFIter.H>
 
 template<class T>
-struct Array2 {
-    T* AMREX_RESTRICT p;
-    amrex::Long jstride = 0;
-    amrex::Long start = 0;
+using Array2 = amrex::ArrayND<T, 2>;
 
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-    amrex::Dim3 begin{1,1,1};
-    amrex::Dim3 end{0,0,0};  // end is hi + 1
-    int ncomp=0;
-#endif
+template<class T>
+using Array3 = amrex::ArrayND<T, 3>;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    Array2 (const amrex::Array4<T>& rhs) noexcept
-        : p(rhs.p),
-          jstride(rhs.jstride),
-          start(-rhs.begin.x - rhs.begin.y * rhs.jstride)
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-          ,begin(rhs.begin),
-          end(rhs.end),
-          ncomp(rhs.ncomp)
-#endif
-    {
-        // slice is only one cell thick if allocated
-        AMREX_IF_ON_HOST((AMREX_ALWAYS_ASSERT(!rhs.p || rhs.begin.z + 1 == rhs.end.z);));
-    }
+template<class T> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Array2<T> to2D (const amrex::Array4<T>& arr) {
+    // slice is only one cell thick if allocated
+    AMREX_IF_ON_HOST((AMREX_ALWAYS_ASSERT(!arr.p || arr.begin[2] + 1 == arr.end[2]);))
+    return Array2<T>(arr.p, {arr.begin[0], arr.begin[1]}, {arr.end[0], arr.end[1]});
+}
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T& operator() (int i, int j) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-        index_assert(i,j,begin.z,0);
-#endif
-        return p[i + j*jstride + start];
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T* ptr (int i, int j) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-        index_assert(i,j,begin.z,0);
-#endif
-        return p + (i + j*jstride + start);
-    }
-
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-    AMREX_GPU_HOST_DEVICE inline
-    void index_assert (int i, int j, int k, int n) const
-    {
-        if (i<begin.x || i>=end.x || j<begin.y || j>=end.y || k<begin.z || k>=end.z
-            || n < 0 || n >= ncomp) {
-#if AMREX_DEVICE_COMPILE
-            AMREX_DEVICE_PRINTF(" (%d,%d,%d,%d) is out of bound (%d:%d,%d:%d,%d:%d,0:%d)\n",
-                                i, j, k, n, begin.x, end.x-1, begin.y, end.y-1,
-                                begin.z, end.z-1, ncomp-1);
-            amrex::Abort();
-#else
-            std::stringstream ss;
-            ss << " (" << i << "," << j << "," << k << "," <<  n
-               << ") is out of bound ("
-               << begin.x << ":" << end.x-1 << ","
-               << begin.y << ":" << end.y-1 << ","
-               << begin.z << ":" << end.z-1 << ","
-               << "0:" << ncomp-1 << ")";
-            amrex::Abort(ss.str());
-#endif
-        }
-    }
-#endif
-};
+template<class T> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Array3<T> to3D (const amrex::Array4<T>& arr) {
+    // slice is only one cell thick if allocated
+    AMREX_IF_ON_HOST((AMREX_ALWAYS_ASSERT(!arr.p || arr.begin[2] + 1 == arr.end[2]);))
+    return Array3<T>(arr.p, {arr.begin[0], arr.begin[1], arr.begin[3]},
+                            {arr.end[0], arr.end[1], arr.end[3]});
+}
 
 template<class T> inline
 Array2<T> to_array2 (amrex::Array4<T>&& in) {
-    return Array2<T>{in};
+    return to2D(in);
 }
 
 template<class T> inline
 Array2<T> to_array2 (const amrex::Array4<T>& in) {
-    return Array2<T>{in};
+    return to2D(in);
 }
 
 template<class T> inline
@@ -95,100 +47,14 @@ T to_array2 (T&& in) {
     return in;
 }
 
-template<class T>
-struct Array3 {
-    T* AMREX_RESTRICT p;
-    amrex::Long jstride = 0;
-    amrex::Long nstride = 0;
-    amrex::Long start = 0;
-
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-    amrex::Dim3 begin{1,1,1};
-    amrex::Dim3 end{0,0,0};  // end is hi + 1
-    int ncomp=0;
-#endif
-
-    template <class U=T, std::enable_if_t<std::is_const_v<U>,int> = 0>
-    AMREX_GPU_HOST_DEVICE
-    Array3 (const Array3<std::remove_const_t<T>>& rhs) noexcept
-        : p(rhs.p),
-          jstride(rhs.jstride),
-          nstride(rhs.nstride),
-          start(rhs.start)
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-          ,begin(rhs.begin),
-          end(rhs.end),
-          ncomp(rhs.ncomp)
-#endif
-    {}
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    Array3 (const amrex::Array4<T>& rhs) noexcept
-        : p(rhs.p),
-          jstride(rhs.jstride),
-          nstride(rhs.nstride),
-          start(-rhs.begin.x - rhs.begin.y * rhs.jstride)
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-          ,begin(rhs.begin),
-          end(rhs.end),
-          ncomp(rhs.ncomp)
-#endif
-    {
-        // slice is only one cell thick if allocated
-        AMREX_IF_ON_HOST((AMREX_ALWAYS_ASSERT(!rhs.p || rhs.begin.z + 1 == rhs.end.z);));
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T& operator() (int i, int j, int n) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-        index_assert(i,j,begin.z,n);
-#endif
-        return p[(start + i + j*jstride) + n*nstride];
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T* ptr (int i, int j, int n) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-        index_assert(i,j,begin.z,n);
-#endif
-        return p + ((start + i + j*jstride) + n*nstride);
-    }
-
-
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-    AMREX_GPU_HOST_DEVICE inline
-    void index_assert (int i, int j, int k, int n) const
-    {
-        if (i<begin.x || i>=end.x || j<begin.y || j>=end.y || k<begin.z || k>=end.z
-            || n < 0 || n >= ncomp) {
-#if AMREX_DEVICE_COMPILE
-            AMREX_DEVICE_PRINTF(" (%d,%d,%d,%d) is out of bound (%d:%d,%d:%d,%d:%d,0:%d)\n",
-                                i, j, k, n, begin.x, end.x-1, begin.y, end.y-1,
-                                begin.z, end.z-1, ncomp-1);
-            amrex::Abort();
-#else
-            std::stringstream ss;
-            ss << " (" << i << "," << j << "," << k << "," <<  n
-               << ") is out of bound ("
-               << begin.x << ":" << end.x-1 << ","
-               << begin.y << ":" << end.y-1 << ","
-               << begin.z << ":" << end.z-1 << ","
-               << "0:" << ncomp-1 << ")";
-            amrex::Abort(ss.str());
-#endif
-        }
-    }
-#endif
-};
-
 template<class T> inline
 Array3<T> to_array3 (amrex::Array4<T>&& in) {
-    return Array3<T>{in};
+    return to3D(in);
 }
 
 template<class T> inline
 Array3<T> to_array3 (const amrex::Array4<T>& in) {
-    return Array3<T>{in};
+    return to3D(in);
 }
 
 template<class T> inline
@@ -205,9 +71,9 @@ amrex::Real abssq(amrex::Real r, amrex::Real i)
     return r*r + i*i;
 }
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::BoxND<2> to2D (const amrex::BoxND<3>& box) {
-    AMREX_ALWAYS_ASSERT(box.length(2) == 1);
+    AMREX_IF_ON_HOST((AMREX_ALWAYS_ASSERT(box.length(2) == 1);))
     return amrex::BoxShrink<2>(box);
 }
 

--- a/src/utils/GridCurrent.cpp
+++ b/src/utils/GridCurrent.cpp
@@ -51,8 +51,8 @@ GridCurrent::DepositCurrentSlice (Fields& fields, const amrex::Geometry& geom, i
 
     for ( amrex::MFIter mfi(S, DfltMfiTlng); mfi.isValid(); ++mfi ){
         const amrex::Box& bx = mfi.tilebox();
-        Array2<amrex::Real> const jz_arr = S.array(mfi, Hipace::m_explicit ?
-            Comps[WhichSlice::This]["jz_beam"] : Comps[WhichSlice::This]["jz"]);
+        Array2<amrex::Real> const jz_arr = to2D(S.array(mfi, Hipace::m_explicit ?
+            Comps[WhichSlice::This]["jz_beam"] : Comps[WhichSlice::This]["jz"]));
 
         amrex::ParallelFor( to2D(bx),
         [=] AMREX_GPU_DEVICE(int i, int j)


### PR DESCRIPTION
Needed after https://github.com/AMReX-Codes/amrex/pull/4868

Unfortunately, this makes some functions 3-5% slower.

PR
```
TinyProfiler total time across processes [min...avg...max]: 74.7 ... 74.7 ... 74.7

-------------------------------------------------------------------------------------------------------
Name                                                    NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-------------------------------------------------------------------------------------------------------
ExplicitDeposition()                                      1000       18.6       18.6       18.6  24.90%
AdvancePlasmaParticles()                                  1000      15.37      15.37      15.37  20.58%
hpmg::MultiGrid::solve1()                                 1000       14.7       14.7       14.7  19.68%
DepositCurrent_PlasmaParticleContainer()                  1001      14.19      14.19      14.19  19.00%
FFTPoissonSolverDirichletQuick::SolvePoissonEquation()    3000       5.58       5.58       5.58   7.47%
AdvanceBeamParticlesSlice()                               1000      1.711      1.711      1.711   2.29%
Fields::SolvePoissonPsiExmByEypBxEzBz()                   1000      1.157      1.157      1.157   1.55%
Fields::ShiftSlices()                                     1000      1.039      1.039      1.039   1.39%
Fields::InitializeSlices()                                1000     0.8715     0.8715     0.8715   1.17%
Hipace::InitializeSxSyWithBeam()                          1000     0.7412     0.7412     0.7412   0.99%
Fields::AddRhoIons()                                      1000     0.3009     0.3009     0.3009   0.40%
BeamParticleContainer::InitBeamFixedWeightPDFSlice()      1000     0.1495     0.1495     0.1495   0.20%
DepositCurrentSlice_BeamParticleContainer()               2000     0.1167     0.1167     0.1167   0.16%
Hipace::SolveOneSlice()                                   1000    0.03368    0.03368    0.03368   0.05%
PlasmaParticleContainer::InitParticles()                     1    0.02763    0.02763    0.02763   0.04%
MultiBuffer::get_data()                                   1000    0.02632    0.02632    0.02632   0.04%
shiftSlippedParticles()                                    749    0.02392    0.02392    0.02392   0.03%
FFTPoissonSolverDirichletQuick::define()                     1    0.01242    0.01242    0.01242   0.02%
Hipace::ExplicitMGSolveBxBy()                             1000    0.01007    0.01007    0.01007   0.01%
FabArray::setVal()                                           3   0.008716   0.008716   0.008716   0.01%
BeamParticleContainer::resize()                           3749   0.008206   0.008206   0.008206   0.01%
BeamParticleContainer::InitBeamFixedWeightPDF3D()            1   0.003649   0.003649   0.003649   0.00%
Hipace::Evolve()                                             1   0.002835   0.002835   0.002835   0.00%
main()                                                       1   0.002423   0.002423   0.002423   0.00%
MultiBuffer::put_data()                                   1000   0.001919   0.001919   0.001919   0.00%
Hipace::InitData()                                           1  0.0004946  0.0004946  0.0004946   0.00%
Fields::AllocData()                                          1  0.0001953  0.0001953  0.0001953   0.00%
ParticleContainer::clearParticles()                          1    5.8e-07    5.8e-07    5.8e-07   0.00%
-------------------------------------------------------------------------------------------------------
```
Dev
```
TinyProfiler total time across processes [min...avg...max]: 72.83 ... 72.83 ... 72.83

-------------------------------------------------------------------------------------------------------
Name                                                    NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-------------------------------------------------------------------------------------------------------
ExplicitDeposition()                                      1000      18.59      18.59      18.59  25.53%
AdvancePlasmaParticles()                                  1000      14.59      14.59      14.59  20.03%
hpmg::MultiGrid::solve1()                                 1000      14.27      14.27      14.27  19.60%
DepositCurrent_PlasmaParticleContainer()                  1001      13.63      13.63      13.63  18.72%
FFTPoissonSolverDirichletQuick::SolvePoissonEquation()    3000      5.578      5.578      5.578   7.66%
AdvanceBeamParticlesSlice()                               1000      1.654      1.654      1.654   2.27%
Fields::SolvePoissonPsiExmByEypBxEzBz()                   1000      1.158      1.158      1.158   1.59%
Fields::ShiftSlices()                                     1000      1.039      1.039      1.039   1.43%
Fields::InitializeSlices()                                1000     0.8724     0.8724     0.8724   1.20%
Hipace::InitializeSxSyWithBeam()                          1000      0.737      0.737      0.737   1.01%
Fields::AddRhoIons()                                      1000     0.3009     0.3009     0.3009   0.41%
BeamParticleContainer::InitBeamFixedWeightPDFSlice()      1000     0.1429     0.1429     0.1429   0.20%
DepositCurrentSlice_BeamParticleContainer()               2000     0.1135     0.1135     0.1135   0.16%
Hipace::SolveOneSlice()                                   1000    0.03352    0.03352    0.03352   0.05%
MultiBuffer::get_data()                                   1000     0.0246     0.0246     0.0246   0.03%
PlasmaParticleContainer::InitParticles()                     1    0.02395    0.02395    0.02395   0.03%
shiftSlippedParticles()                                    749    0.02187    0.02187    0.02187   0.03%
Hipace::ExplicitMGSolveBxBy()                             1000   0.009958   0.009958   0.009958   0.01%
FabArray::setVal()                                           3   0.008549   0.008549   0.008549   0.01%
BeamParticleContainer::resize()                           3749   0.008266   0.008266   0.008266   0.01%
FFTPoissonSolverDirichletQuick::define()                     1   0.008008   0.008008   0.008008   0.01%
BeamParticleContainer::InitBeamFixedWeightPDF3D()            1   0.003618   0.003618   0.003618   0.00%
Hipace::Evolve()                                             1   0.002458   0.002458   0.002458   0.00%
MultiBuffer::put_data()                                   1000   0.001976   0.001976   0.001976   0.00%
main()                                                       1   0.001535   0.001535   0.001535   0.00%
Hipace::InitData()                                           1   0.000317   0.000317   0.000317   0.00%
Fields::AllocData()                                          1  7.731e-05  7.731e-05  7.731e-05   0.00%
ParticleContainer::clearParticles()                          1    3.9e-07    3.9e-07    3.9e-07   0.00%
-------------------------------------------------------------------------------------------------------
```


- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
