### PR TITLE
Add ability to choose mesh in plasma density file

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -453,13 +453,7 @@ When both are specified, the per-species value is used.
     `<density function>` which is used for that time step.
 
 * ``<plasma name> or plasmas.read_density_from_path`` (`string`) optional (default "")
-    Alternative to ``<plasma name>.density(x,y,z)``. Specify the path to an openPMD file that
-    contains the plasma density for each location of the simulation. Both Cartesian ``xyz`` and
-    Cylidrical geometries ``rz`` with modes are supported, however not all dimensions need to be
-    included. The mesh in the file can be chosen with
-    ``<plasma name> or plasmas.density_mesh_name`` (default ``density``) and must contain
-    a single ``SCALAR`` component. Examples of scripts to gernerete such files can be found in
-    ``tools\write_plasma_density.py`` and ``tools\write_plasma_density_rz.py``.
+    Alternative to ``<plasma name>.density(x,y,z)``. Specify the path to an openPMD file that contains the species' number density for each location of the simulation. Both geometries (Cartesian ``xyz`` and Cylindrical ``rz`` + modes)  are supported, however not all dimensions need to be included. The mesh in the file can be chosen with ``<plasma name> or plasmas.density_mesh_name`` (default ``density``) and must contain a single ``SCALAR`` component. Examples of scripts to generate such files can be found in ``tools/write_plasma_density.py`` and ``tools/write_plasma_density_rz.py``.
 
 * ``<plasma name> or plasmas.ppc`` (2 `integer`)
     The number of plasma particles per cell in x and y.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -457,7 +457,7 @@ When both are specified, the per-species value is used.
     contains the plasma density for each location of the simulation. Both Cartesian ``xyz`` and
     Cylidrical geometries ``rz`` with modes are supported, however not all dimensions need to be
     included. The mesh in the file can be chosen with
-    ``<plasma name> or plasmas.read_density_from_path`` (default ``density``) and must contain
+    ``<plasma name> or plasmas.density_mesh_name`` (default ``density``) and must contain
     a single ``SCALAR`` component. Examples of scripts to gernerete such files can be found in
     ``tools\write_plasma_density.py`` and ``tools\write_plasma_density_rz.py``.
 

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -452,6 +452,15 @@ When both are specified, the per-species value is used.
     position :math:`time \cdot c` is rounded up to the nearest `<position>` in the file to get it's
     `<density function>` which is used for that time step.
 
+* ``<plasma name> or plasmas.read_density_from_path`` (`string`) optional (default "")
+    Alternative to ``<plasma name>.density(x,y,z)``. Specify the path to an openPMD file that
+    contains the plasma density for each location of the simulation. Both Cartesian ``xyz`` and
+    Cylidrical geometries ``rz`` with modes are supported, however not all dimensions need to be
+    included. The mesh in the file can be chosen with
+    ``<plasma name> or plasmas.read_density_from_path`` (default ``density``) and must contain
+    a single ``SCALAR`` component. Examples of scripts to gernerete such files can be found in
+    ``tools\write_plasma_density.py`` and ``tools\write_plasma_density_rz.py``.
+
 * ``<plasma name> or plasmas.ppc`` (2 `integer`)
     The number of plasma particles per cell in x and y.
     Since in a quasi-static code, there is only a 2D plasma slice evolving along the longitudinal

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -107,7 +107,10 @@ PlasmaParticleContainer::ReadParameters ()
     std::string density_path = "";
     bool density_file_specified = queryWithParserAlt(pp, "read_density_from_path", density_path, pp_alt);
     if (density_file_specified) {
-        m_density_func.define_from_file(density_path, m_f_density_data, m_d_density_data);
+        std::string density_mesh_name = "density";
+        queryWithParserAlt(pp, "density_mesh_name", density_mesh_name, pp_alt);
+        m_density_func.define_from_file(density_path, m_f_density_data, m_d_density_data,
+                                        density_mesh_name);
     }
 
     std::string density_table_file_name{};

--- a/src/particles/profiles/GetInitialDensity.H
+++ b/src/particles/profiles/GetInitialDensity.H
@@ -138,7 +138,8 @@ struct PlasmaDensityAccessor {
     void define_parser (const amrex::ParserExecutor<3>& exe);
 
     void define_from_file (const std::string& path, std::shared_ptr<float>& f_data,
-                           std::shared_ptr<double>& d_data);
+                           std::shared_ptr<double>& d_data,
+                           const std::string& density_mesh_name);
 };
 
 #endif // GETINTIALDENSITY_H_

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -47,7 +47,8 @@ PlasmaDensityAccessor::define_parser (const amrex::ParserExecutor<3>& exe) {
 
 void
 PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_ptr<float>& f_data,
-                                         std::shared_ptr<double>& d_data) {
+                                         std::shared_ptr<double>& d_data,
+                                         const std::string& density_mesh_name) {
 #ifdef HIPACE_USE_OPENPMD
 
     HIPACE_PROFILE("PlasmaParticleContainer::ReadDensityFile()");
@@ -56,11 +57,11 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
     auto iteration = series.iterations.begin()->second;
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        iteration.meshes.contains("density"),
-        "Could not find mesh 'density' in file " + path + "\n"
+        iteration.meshes.contains(density_mesh_name),
+        "Could not find mesh '" + density_mesh_name + "' in file " + path + "\n"
     );
 
-    auto mesh = iteration.meshes["density"];
+    auto mesh = iteration.meshes[density_mesh_name];
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         mesh.contains(openPMD::RecordComponent::SCALAR),


### PR DESCRIPTION
This way, multiple species can use the same density file with different meshes.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
