### PR TITLE
Fix prefactor for temperature calculation in laser ionization

### DIFF
--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -292,8 +292,6 @@ public:
     amrex::Gpu::Buffer<amrex::Real> m_laser_adk_prefactor;
     /** to calculate laser ionization momentum width for linear polarization */
     amrex::Gpu::Buffer<amrex::Real> m_laser_dp_prefactor;
-    /** to calculate laser ionization momentum width at the second order for linear polarization */
-    amrex::Gpu::Buffer<amrex::Real> m_laser_dp_second_prefactor;
 
     // plasma sorting/reordering:
 

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -617,7 +617,6 @@ LaserIonization (const int islice,
         amrex::Real* AMREX_RESTRICT adk_power = m_adk_power.data();
         amrex::Real* AMREX_RESTRICT laser_adk_prefactor = m_laser_adk_prefactor.data();
         amrex::Real* AMREX_RESTRICT laser_dp_prefactor = m_laser_dp_prefactor.data();
-        amrex::Real* AMREX_RESTRICT laser_dp_second_prefactor = m_laser_dp_second_prefactor.data();
         const int max_ion_lev = m_max_ion_lev;
 
         long num_ions = ptile_ion.numParticles();
@@ -760,7 +759,7 @@ LaserIonization (const int islice,
                     const amrex::Real delta = std::sqrt(Ep) * laser_dp_prefactor[ion_lev_loc];
                     const amrex::Real delta2 = delta * delta;
                     const amrex::Real delta4 = delta2 * delta2;
-                    const amrex::Real alpha = laser_dp_second_prefactor[ion_lev_loc];
+                    const amrex::Real alpha = -adk_power[ion_lev_loc];
                     const amrex::Real s1 = - (7._rt/4._rt) + alpha / 2._rt;
                     const amrex::Real s2 = (1._rt/16._rt) * ( 8._rt * (alpha*alpha) - 68._rt*alpha + 131._rt );
                     const amrex::Real width_p = amrex::abs(A) * delta * (1._rt + s1*delta2 + s2*delta4);

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -456,7 +456,6 @@ InitIonizationModule (const amrex::Geometry& geom, const amrex::Real background_
     m_adk_exp_prefactor.resize(ion_atomic_number);
     m_laser_adk_prefactor.resize(ion_atomic_number);
     m_laser_dp_prefactor.resize(ion_atomic_number);
-    m_laser_dp_second_prefactor.resize(ion_atomic_number);
 
     for (int i=0; i<ion_atomic_number; ++i)
     {
@@ -469,8 +468,6 @@ InitIonizationModule (const amrex::Geometry& geom, const amrex::Real background_
             * std::pow(2*std::pow((Uion/UH),3./2.)*Ea,2*n_eff - 1);
         m_adk_exp_prefactor[i] = -2./3. * std::pow( Uion/UH,3./2.) * Ea;
         m_laser_adk_prefactor[i] = (3./MathConst::pi) * std::pow(Uion/UH, -3./2.) / Ea;
-        m_laser_dp_prefactor[i] = std::sqrt(3./2./Ea) * std::pow(UH/Uion, 3./4.);
-        m_laser_dp_second_prefactor[i] = 2.*ion_atomic_number * std::sqrt(UH/Uion) - 1.;
     }
 
     m_adk_power.copyToDeviceAsync();

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -475,5 +475,4 @@ InitIonizationModule (const amrex::Geometry& geom, const amrex::Real background_
     m_adk_exp_prefactor.copyToDeviceAsync();
     m_laser_adk_prefactor.copyToDeviceAsync();
     m_laser_dp_prefactor.copyToDeviceAsync();
-    m_laser_dp_second_prefactor.copyToDeviceAsync();
 }

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -468,6 +468,7 @@ InitIonizationModule (const amrex::Geometry& geom, const amrex::Real background_
             * std::pow(2*std::pow((Uion/UH),3./2.)*Ea,2*n_eff - 1);
         m_adk_exp_prefactor[i] = -2./3. * std::pow( Uion/UH,3./2.) * Ea;
         m_laser_adk_prefactor[i] = (3./MathConst::pi) * std::pow(Uion/UH, -3./2.) / Ea;
+        m_laser_dp_prefactor[i] = std::sqrt(3./2./Ea) * std::pow(UH/Uion, 3./4.);
     }
 
     m_adk_power.copyToDeviceAsync();


### PR DESCRIPTION
Laser ionization of argon gives temperatures way too high, this seems to originate from the definition of Z in Eq. (5) of [Tomassini's paper](https://www.cambridge.org/core/journals/high-power-laser-science-and-engineering/article/accurate-electron-beam-phasespace-theory-for-ionizationinjection-schemes-driven-by-laser-pulses/3EBCA963089C3544041926FE2AAA4A46). This PR proposes to fix this, and re-use an already-defined variable.