### PR TITLE
Fix shared memory TemperatureDeposition with Laser

### DIFF
--- a/src/particles/deposition/TemperatureDeposition.cpp
+++ b/src/particles/deposition/TemperatureDeposition.cpp
@@ -60,7 +60,7 @@ DepositTemperature (PlasmaParticleContainer& plasma,
             * (plasma.m_charge/pc.q_e) * (pc.m_e/plasma.m_mass);
 
         // Loop over particles
-        SharedMemoryDeposition<1, 1, true>(
+        SharedMemoryDeposition<3, 3, true>(
             int(pti.numParticles()),
             // is_valid
             // return whether the particle is valid and should deposit
@@ -83,7 +83,7 @@ DepositTemperature (PlasmaParticleContainer& plasma,
                 auto [shape_y, j] =
                 compute_single_shape_factor<false, 0>(ymid, 0);
 
-                return {i, j};
+                return {i-1, j-1};
             },
             // deposit of weight, momentum (ux, uy, uz) and their squares (uxsq, uysq, uzsq)
             [=] AMREX_GPU_DEVICE (int ip, auto ptd,


### PR DESCRIPTION
Currently the shape factor of the temperature deposition is zero, however the gathering of the laser field uses shape factor two. This causes the actual stencil size of the operation to be 3 by 3 with an offset for the laser, similar to what is done in ExplicitDeposition.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
