### PR TITLE
Don't install openPMD with brew on MacOS after pybind11 update

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,16 +85,6 @@ jobs:
 
         brew uninstall cmake
 
-        brew tap-new $USER/local
-        brew extract --version=3.0.1 pybind11 $USER/local
-        brew install $USER/local/pybind11@3.0.1
-        brew pin pybind11
-
-        brew tap openpmd/openpmd
-        # brew install openpmd-api --only-dependencies --force
-        brew install openpmd-api
-        brew link openpmd-api
-
     - name: build HiPACE++
       run: |
         export CCACHE_COMPRESS=1
@@ -105,7 +95,7 @@ jobs:
 
         cmake -S . -B build_sp          \
           -DCMAKE_VERBOSE_MAKEFILE=ON   \
-          -DHiPACE_openpmd_internal=OFF \
+          -DHiPACE_openpmd_internal=ON \
           -DHiPACE_PRECISION=SINGLE
         cmake --build build_sp -j 2
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,7 +85,7 @@ jobs:
 
         brew uninstall cmake
 
-        brew install --formula https://raw.githubusercontent.com/Homebrew/homebrew-core/6ba7842798add26b2df2c08dc108acda1370caa1/Formula/p/pybind11.rb
+        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/6ba7842798add26b2df2c08dc108acda1370caa1/Formula/p/pybind11.rb
         brew pin pybind11
 
         brew tap openpmd/openpmd

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,10 +85,8 @@ jobs:
 
         brew uninstall cmake
 
-        brew search pybind11
-        brew install pybind11@3.0.1 --only-dependencies --force
-        brew install pybind11@3.0.1
-        brew link pybind11@3.0.1
+        brew install --formula https://raw.githubusercontent.com/Homebrew/homebrew-core/6ba7842798add26b2df2c08dc108acda1370caa1/Formula/p/pybind11.rb
+        brew pin pybind11
 
         brew tap openpmd/openpmd
         brew install openpmd-api --only-dependencies --force

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,9 +88,10 @@ jobs:
         brew tap-new $USER/local
         brew extract --version=3.0.1 pybind11 $USER/local
         brew install $USER/local/pybind11@3.0.1
+        brew pin pybind11
 
         brew tap openpmd/openpmd
-        brew install openpmd-api --only-dependencies --force
+        # brew install openpmd-api --only-dependencies --force
         brew install openpmd-api
         brew link openpmd-api
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,8 +83,6 @@ jobs:
 
         set -e
 
-        brew uninstall cmake
-
     - name: build HiPACE++
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,9 +85,10 @@ jobs:
 
         brew uninstall cmake
 
-        brew install pybind11@3.0.1_1 --only-dependencies --force
-        brew install pybind11@3.0.1_1
-        brew link pybind11@3.0.1_1
+        brew search pybind11
+        brew install pybind11@3.0.1 --only-dependencies --force
+        brew install pybind11@3.0.1
+        brew link pybind11@3.0.1
 
         brew tap openpmd/openpmd
         brew install openpmd-api --only-dependencies --force

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,6 +85,10 @@ jobs:
 
         brew uninstall cmake
 
+        brew install pybind11@3.0.1_1 --only-dependencies --force
+        brew install pybind11@3.0.1_1
+        brew link pybind11@3.0.1_1
+
         brew tap openpmd/openpmd
         brew install openpmd-api --only-dependencies --force
         brew install openpmd-api

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,8 +85,9 @@ jobs:
 
         brew uninstall cmake
 
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/6ba7842798add26b2df2c08dc108acda1370caa1/Formula/p/pybind11.rb
-        brew pin pybind11
+        brew tap-new $USER/local
+        brew extract --version=3.0.1 pybind11 $USER/local
+        brew install $USER/local/pybind11@3.0.1
 
         brew tap openpmd/openpmd
         brew install openpmd-api --only-dependencies --force


### PR DESCRIPTION
The newest version of pybind11 doesn't work https://github.com/openPMD/openPMD-api/issues/1850

It is not straightforward to use an older version of pybind11 with brew, so I just removed the installation process as we only need the headers for compiling hipace anyway.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
