### PR TITLE
Make Diagnostic box selection more robust

### DIFF
--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -365,12 +365,13 @@ Diagnostic::ResizeFDiagFAB (amrex::Vector<amrex::Geometry>& field_geom,
             }
         }
 
+        const amrex::Box sim_domain = domain;
+        amrex::Box cut_domain = domain;
         {
             // shrink box to user specified bounds m_diag_lo and m_diag_hi (in real space)
             const amrex::Real poff_x = GetPosOffset(0, geom, geom.Domain());
             const amrex::Real poff_y = GetPosOffset(1, geom, geom.Domain());
             const amrex::Real poff_z = GetPosOffset(2, geom, geom.Domain());
-            amrex::Box cut_domain = domain;
             if (fd.m_use_custom_size_lo) {
                 cut_domain.setSmall({
                     static_cast<int>(std::round((fd.m_diag_lo[0] - poff_x)/geom.CellSize(0))),
@@ -384,6 +385,10 @@ Diagnostic::ResizeFDiagFAB (amrex::Vector<amrex::Geometry>& field_geom,
                     static_cast<int>(std::round((fd.m_diag_hi[1] - poff_y)/geom.CellSize(1))),
                     static_cast<int>(std::round((fd.m_diag_hi[2] - poff_z)/geom.CellSize(2)))
                 });
+            }
+            // sometimes the cut_domain is off by one cell due to rounding errors
+            if (!(domain & cut_domain).ok()) {
+                cut_domain.grow(1);
             }
             // calculate intersection of boxes to prevent them getting larger
             domain &= cut_domain;
@@ -402,13 +407,21 @@ Diagnostic::ResizeFDiagFAB (amrex::Vector<amrex::Geometry>& field_geom,
 
         domain.coarsen(fd.m_diag_coarsen);
 
-        fd.m_geom_io = amrex::Geometry(domain, &diag_domain, geom.Coord());
+        fd.m_has_field = hasFieldOutput(fd, output_step, max_step, output_time, max_time);
 
-        fd.m_has_field = domain.ok()
-                         && hasFieldOutput(fd, output_step, max_step, output_time, max_time);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(domain.ok(),
+            "Box for diagnostic object '" + fd.m_diag_name + "' is empty. "
+            "Make sure that it intersects with the simulation domain!\n"
+            "Simulation: " + amrex::ToString(sim_domain) + "\n"
+            "Diagnositc: " + amrex::ToString(cut_domain) + "\n"
+            "Intersection: " + amrex::ToString(domain)
+        );
 
         if(fd.m_has_field) {
             HIPACE_PROFILE("Diagnostic::ResizeFDiagFAB()");
+
+            fd.m_geom_io = amrex::Geometry(domain, &diag_domain, geom.Coord());
+
             switch (fd.m_base_geom_type) {
                 case FieldDiagnosticData::geom_type::field:
                     fd.m_F.resize(domain, fd.m_nfields, amrex::The_Pinned_Arena());

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -413,7 +413,7 @@ Diagnostic::ResizeFDiagFAB (amrex::Vector<amrex::Geometry>& field_geom,
             "Box for diagnostic object '" + fd.m_diag_name + "' is empty. "
             "Make sure that it intersects with the simulation domain!\n"
             "Simulation: " + amrex::ToString(sim_domain) + "\n"
-            "Diagnositc: " + amrex::ToString(cut_domain) + "\n"
+            "Diagnostic: " + amrex::ToString(cut_domain) + "\n"
             "Intersection: " + amrex::ToString(domain)
         );
 


### PR DESCRIPTION
This PR fixes an issue where
```powershell
amr.n_cell = 1024 1024 512
geometry.prob_lo     = -400e-6   -400e-6   -50e-6
geometry.prob_hi     =  400e-6    400e-6    50e-6

plasma_diag.patch_lo = -400e-6   -400e-6    50e-6
plasma_diag.patch_hi =  400e-6    400e-6    50e-6
```
would crash with the unhelpful error message
```
0::Assertion `rtmp > std::numeric_limits<ParticleReal>::lowest() && iters < maxiters' failed, file "/home/asinn/hipace/build/_deps/fetchedamrex-src/Src/Base/AMReX_Geometry.cpp", line 590 !!!
SIGABRT
```
because the plasma_diag patch was technically outside the simulation domain.
With this PR the input works and if modified (50e-6 -> 51e-6) would give the error
```
0::Assertion `domain.ok()' failed, file "/home/asinn/hipace/src/diagnostics/Diagnostic.cpp", line 412, Msg: Box for diagnostic object 'plasma_diag' is empty. Make sure that it intersects with the simulation domain!
Simulation: ((0,0,0) (1023,1023,511) (0,0,0))
Diagnositc: ((-2,-2,516) (1024,1024,518) (0,0,0))
Intersection: ((0,0,516) (1023,1023,511) (0,0,0)) !!!
SIGABRT
```

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
