### PR TITLE
Fix bug in grid ionization with multiple plasma species

### DIFF
--- a/src/utils/GridIonization.cpp
+++ b/src/utils/GridIonization.cpp
@@ -152,6 +152,7 @@ GridIonization::IonizeGrid (Fields& fields, const MultiPlasma& multi_plasma,
 
     for (auto& plasma_name : m_names) {
         const auto& plasma = multi_plasma.GetPlasma(plasma_name);
+        const bool is_last_plasma = plasma_name == m_names.back();
 
         const int ion_weight_comp =
             Comps[WhichSlice::This]["grid_ionization_w_" + plasma_name + "_0"];
@@ -296,7 +297,9 @@ GridIonization::IonizeGrid (Fields& fields, const MultiPlasma& multi_plasma,
                     // chi
                     // chi of new electrons does not depend on the laser field strength
                     // or the the new random momentum
-                    chi += arr(i, j, comps[1]) * chi_factor_elec;
+                    if (is_last_plasma) {
+                        chi += arr(i, j, comps[1]) * chi_factor_elec;
+                    }
 
                     // last ion level
                     chi += arr(i, j, ion_weight_comp + max_ion_lev) *


### PR DESCRIPTION
The electron contribution was applied to chi for each plasma species, however it should only be applied once.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
