### PR TITLE
Add missing stream sync in Fields::Copy

### DIFF
--- a/src/fields/Fields.cpp
+++ b/src/fields/Fields.cpp
@@ -624,6 +624,9 @@ Fields::Copy (const int current_N_level, const int i_slice, FieldDiagnosticData&
                 });
         }
     }
+
+    // sync before m_rel_z_vec is written to again by the next Copy
+    amrex::Gpu::streamSynchronize();
 }
 
 void


### PR DESCRIPTION
If a lot of work was queued up on the GPU, 
```
m_rel_z_vec.copyToDeviceAsync();
```
could take so long to start the transfer that the next call to Copy (in case there are multiple diagnostic objects) would overwrite the host side of the buffer before the H2D transfer. This would lead to the incorrect prefactor being applied.

- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
- [ ] **Tested** (describe the tests in the PR description)
- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
- [ ] **Contains an automated test** (checksum and/or comparison with theory)
- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
- [ ] **Constified** (All that can be `const` is `const`)
- [ ] **Code is clean** (no unwanted comments, )
- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
- [ ] **Proper label and GitHub project**, if applicable
