### PR TITLE
Remove PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,0 @@
-- [ ] **Small enough** (< few 100s of lines), otherwise it should probably be split into smaller PRs
-- [ ] **Tested** (describe the tests in the PR description)
-- [ ] **Runs on GPU** (basic: the code compiles and run well with the new module)
-- [ ] **Contains an automated test** (checksum and/or comparison with theory)
-- [ ] **Documented**: all elements (classes and their members, functions, namespaces, etc.) are documented
-- [ ] **Constified** (All that can be `const` is `const`)
-- [ ] **Code is clean** (no unwanted comments, )
-- [ ] **Style and code conventions** are respected at the bottom of https://github.com/Hi-PACE/hipace
-- [ ] **Proper label and GitHub project**, if applicable


### PR DESCRIPTION
I think this will be enough to remove the PR template, as we don't use it consistently. An updated one could help.