### PR TITLE
Add option to always use non-centered push in laser solver

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -954,15 +954,20 @@ Parameters starting with ``lasers.`` apply to all laser pulses, parameters start
 * ``lasers.use_phase`` (`bool`) optional (default `true`)
     Whether the phase terms (:math:`\theta` in Eq. (6) of [C. Benedetti et al. Plasma Phys. Control. Fusion 60.1: 014002 (2017)]) are computed and used in the laser envelope advance. Keeping the phase should be more accurate, but can cause numerical issues in the presence of strong depletion/frequency shift.
 
+* ``lasers.use_non_centered_push`` (`bool`) optional (default `false`)
+    By default, the laser solver uses the two previous time steps to compute the next one.
+    In some cases this can lead to unphysical fast oscillations.
+    With this setting, only one previous time step is used which, can help to reduce oscillations
+    but is less accurate.
+
 * ``lasers.interp_order`` (`int`) optional (default `1`)
     Transverse shape order for the laser to field interpolation of aabs and
     the field to laser interpolation of chi. Currently, `0,1,2,3` are implemented.
 
 * ``lasers.solver_type`` (`string`) optional (default `multigrid`)
-    Type of solver for the laser envelope solver, either ``fft`` or ``multigrid``.
-    Currently, the approximation that the phase is evaluated on-axis only is made with both solvers.
+    Type of solver for the laser envelope solver. Only ``multigrid`` is available.
+    Currently, the approximation that the phase is evaluated on-axis only is made.
     With the multigrid solver, we could drop this assumption.
-    For now, the fft solver should be faster, more accurate and more stable, so only use the multigrid one with care.
 
 * ``lasers.MG_tolerance_rel`` (`float`) optional (default `1e-4`)
     Relative error tolerance of the multigrid solver used for the laser pulse.

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -123,17 +123,17 @@ public:
      * The complex phase of the envelope is evaluated on-axis only, but can be generalized to everywhere.
      *
      * \param[in] dt time step of the simulation
-     * \param[in] is_first_step if this is the first time step of the simulation
+     * \param[in] non_centered_push push using only 2 slices instead of 3
      */
-    void AdvanceSliceMG (amrex::Real dt, bool is_first_step);
+    void AdvanceSliceMG (amrex::Real dt, bool non_centered_push);
 
     /** Advance a laser slice by 1 time step using a FFT solver.
      * The complex phase of the envelope is evaluated on-axis only.
      *
      * \param[in] dt time step of the simulation
-     * \param[in] is_first_step if this is the first time step of the simulation
+     * \param[in] non_centered_push push using only 2 slices instead of 3
      */
-    void AdvanceSliceFFT (amrex::Real dt, bool is_first_step);
+    void AdvanceSliceFFT (amrex::Real dt, bool non_centered_push);
 
     /** Initialize 1 longitudinal slice of the laser, and store it in n00j00 (current time step)
      * and nm1j00 (previous time step).
@@ -215,6 +215,8 @@ private:
     int m_MG_verbose = 0;
     /** Whether to use time-averaged RHS in envelope solver. */
     bool m_MG_average_rhs = true;
+    /** always use 2-slice non-centered push */
+    bool m_use_non_centered_push = false;
     /** hpmg solver for the envelope solver */
     std::unique_ptr<hpmg::MultiGrid> m_mg;
     /** store rhs for MG solver */

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -38,6 +38,7 @@ MultiLaser::ReadParameters ()
     AMREX_ALWAYS_ASSERT(polarization == "linear" || polarization == "circular");
     m_linear_polarization = polarization == "linear";
     queryWithParser(pp, "use_phase", m_use_phase);
+    queryWithParser(pp, "use_non_centered_push", m_use_non_centered_push);
     queryWithParser(pp, "solver_type", m_solver_type);
     AMREX_ALWAYS_ASSERT(m_solver_type == "multigrid" || m_solver_type == "fft");
     queryWithParser(pp, "interp_order", m_interp_order);
@@ -460,16 +461,16 @@ MultiLaser::AdvanceSlice (const int islice, const Fields& fields, amrex::Real dt
     InterpolateChi(fields, geom_field_lev0);
 
     if (m_solver_type == "multigrid") {
-        AdvanceSliceMG(dt, is_first_step);
+        AdvanceSliceMG(dt, is_first_step || m_use_non_centered_push);
     } else if (m_solver_type == "fft") {
-        AdvanceSliceFFT(dt, is_first_step);
+        AdvanceSliceFFT(dt, is_first_step || m_use_non_centered_push);
     } else {
         amrex::Abort("laser.solver_type must be fft or multigrid");
     }
 }
 
 void
-MultiLaser::AdvanceSliceMG (amrex::Real dt, bool is_first_step)
+MultiLaser::AdvanceSliceMG (amrex::Real dt, bool non_centered_push)
 {
 
     HIPACE_PROFILE("MultiLaser::AdvanceSliceMG()");
@@ -565,9 +566,9 @@ MultiLaser::AdvanceSliceMG (amrex::Real dt, bool is_first_step)
 
         // D_j^n as defined in Benedetti's 2017 paper
         djn = ( -3._rt*dt1 + dt2 ) / (2._rt*dz);
-        acoeff_real_scalar = is_first_step ? 6._rt/(c*dt*dz)
+        acoeff_real_scalar = non_centered_push ? 6._rt/(c*dt*dz)
             : 3._rt/(c*dt*dz) + 2._rt/(c*c*dt*dt);
-        acoeff_imag_scalar = is_first_step ? -4._rt * ( k0 + djn ) / (c*dt)
+        acoeff_imag_scalar = non_centered_push ? -4._rt * ( k0 + djn ) / (c*dt)
             : -2._rt * ( k0 + djn ) / (c*dt);
 
         amrex::ParallelFor(
@@ -577,7 +578,7 @@ MultiLaser::AdvanceSliceMG (amrex::Real dt, bool is_first_step)
                 using namespace WhichLaserSlice;
                 // Transverse Laplacian of real and imaginary parts of A_j^n-1
                 amrex::Real lapR, lapI;
-                if (is_first_step) {
+                if (non_centered_push) {
                     lapR = i>imin && i<imax && j>jmin && j<jmax ?
                         (arr(i+1, j, n00j00_r)+arr(i-1, j, n00j00_r)-2._rt*arr(i, j, n00j00_r))/(dx*dx) +
                         (arr(i, j+1, n00j00_r)+arr(i, j-1, n00j00_r)-2._rt*arr(i, j, n00j00_r))/(dy*dy) : 0._rt;
@@ -600,7 +601,7 @@ MultiLaser::AdvanceSliceMG (amrex::Real dt, bool is_first_step)
                     acoeff_real_scalar + arr(i, j, chi) : acoeff_real_scalar;
 
                 Complex rhs;
-                if (is_first_step) {
+                if (non_centered_push) {
                     // First time step: non-centered push to go
                     // from step 0 to step 1 without knowing -1.
                     const Complex an00jp1 = arr(i, j, n00jp1_r) + I * arr(i, j, n00jp1_i);
@@ -649,7 +650,7 @@ MultiLaser::AdvanceSliceMG (amrex::Real dt, bool is_first_step)
 }
 
 void
-MultiLaser::AdvanceSliceFFT (const amrex::Real dt, bool is_first_step)
+MultiLaser::AdvanceSliceFFT (const amrex::Real dt, bool non_centered_push)
 {
 
     HIPACE_PROFILE("MultiLaser::AdvanceSliceFFT()");
@@ -752,7 +753,7 @@ MultiLaser::AdvanceSliceFFT (const amrex::Real dt, bool is_first_step)
                 using namespace WhichLaserSlice;
                 // Transverse Laplacian of real and imaginary parts of A_j^n-1
                 amrex::Real lapR, lapI;
-                if (is_first_step) {
+                if (non_centered_push) {
                     lapR = i>imin && i<imax && j>jmin && j<jmax ?
                         (arr(i+1, j, n00j00_r)+arr(i-1, j, n00j00_r)-2._rt*arr(i, j, n00j00_r))/(dx*dx) +
                         (arr(i, j+1, n00j00_r)+arr(i, j-1, n00j00_r)-2._rt*arr(i, j, n00j00_r))/(dy*dy) : 0._rt;
@@ -772,7 +773,7 @@ MultiLaser::AdvanceSliceFFT (const amrex::Real dt, bool is_first_step)
                 const Complex anp1jp1 = arr(i, j, np1jp1_r) + I * arr(i, j, np1jp1_i);
                 const Complex anp1jp2 = arr(i, j, np1jp2_r) + I * arr(i, j, np1jp2_i);
                 Complex rhs;
-                if (is_first_step) {
+                if (non_centered_push) {
                     // First time step: non-centered push to go
                     // from step 0 to step 1 without knowing -1.
                     const Complex an00jp1 = arr(i, j, n00jp1_r) + I * arr(i, j, n00jp1_i);
@@ -807,7 +808,7 @@ MultiLaser::AdvanceSliceFFT (const amrex::Real dt, bool is_first_step)
         // acoeff_imag is supposed to be a nx*ny array.
         // For the sake of simplicity, we evaluate it on-axis only.
         const Complex acoeff =
-            is_first_step ? 6._rt/(c*dt*dz) - I * 4._rt * ( k0 + djn ) / (c*dt) :
+            non_centered_push ? 6._rt/(c*dt*dz) - I * 4._rt * ( k0 + djn ) / (c*dt) :
              3._rt/(c*dt*dz) + 2._rt/(c*c*dt*dt) - I * 2._rt * ( k0 + djn ) / (c*dt);
         amrex::ParallelFor(
             to2D(bx),


### PR DESCRIPTION
By default, the laser solver uses the two previous time steps to compute the next one. In some cases this can lead to unphysical fast oscillations. With this PR, only one previous time step is used, which can help to reduce oscillations but is less accurate.