### PR TITLE
Change NProcs <= NStep Assert into Warning

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -188,6 +188,10 @@ General parameters
     Note that z refers to the location of the beam particle inside the moving frame of reference
     (zeta) and t to the physical time of the current time step.
 
+* ``hipace.ignore_noncritical_warnings`` (`bool`) optional (default `0`)
+    Don't crash the simulation from assertions that check for suboptimal input parameters
+    but are not needed for correctness.
+
 Geometry
 --------
 

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -76,6 +76,9 @@ struct Hipace_early_init
 
     /* Number of mesh refinement levels */
     int m_N_level = 1;
+
+    /* Don't stop the simulation if user inputs are potentially suboptimal */
+    inline static bool m_ignore_noncritical_warnings = false;
 };
 
 /** \brief Singleton class that initializes, runs and finalizes the simulation */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -118,8 +118,10 @@ Hipace::ReadParameters ()
     queryWithParser(pph, "max_time", m_max_time);
     queryWithParser(pph, "verbose", m_verbose);
     m_numprocs = amrex::ParallelDescriptor::NProcs();
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_numprocs <= m_max_step+1,
-                                     "Please use more or equal time steps than number of ranks");
+    if (m_numprocs > m_max_step + 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::ErrorStream()
+            << "WARNING: Please use more or equal time steps than the number of MPI ranks\n";
+    }
     queryWithParser(pph, "predcorr_B_error_tolerance", m_predcorr_B_error_tolerance);
     queryWithParser(pph, "predcorr_max_iterations", m_predcorr_max_iterations);
     queryWithParser(pph, "predcorr_B_mixing_factor", m_predcorr_B_mixing_factor);

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -58,6 +58,7 @@ Hipace_early_init::Hipace_early_init (Hipace* instance)
     int max_level = 0;
     queryWithParser(pp_amr, "max_level", max_level);
     m_N_level = max_level + 1;
+    queryWithParser(pph, "ignore_noncritical_warnings", m_ignore_noncritical_warnings);
     AnyFFT::setup();
 }
 
@@ -118,9 +119,14 @@ Hipace::ReadParameters ()
     queryWithParser(pph, "max_time", m_max_time);
     queryWithParser(pph, "verbose", m_verbose);
     m_numprocs = amrex::ParallelDescriptor::NProcs();
-    if (m_numprocs > m_max_step + 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::ErrorStream()
-            << "WARNING: Please use more or equal time steps than the number of MPI ranks\n";
+    if (m_ignore_noncritical_warnings) {
+        if (m_numprocs > m_max_step + 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::OutStream()
+                << "WARNING: Please use more or equal time steps than the number of MPI ranks\n";
+        }
+    } else {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_numprocs <= m_max_step + 1,
+            "Please use more or equal time steps than the number of MPI ranks");
     }
     queryWithParser(pph, "predcorr_B_error_tolerance", m_predcorr_B_error_tolerance);
     queryWithParser(pph, "predcorr_max_iterations", m_predcorr_max_iterations);


### PR DESCRIPTION
Sometimes it is convenient to run with more MPI ranks than the simulation can utilize. For example, when using one node with 4 GPUs but running only a single time step, the run script can still have `srun -n $(($NODES * $NTASKSPERNODE)) --ntasks-per-node $NTASKSPERNODE` with this PR.