### PR TITLE
Release 26.05

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # Preamble ####################################################################
 #
 cmake_minimum_required(VERSION 3.24.0)
-project(HiPACE VERSION 26.04)
+project(HiPACE VERSION 26.05)
 
 # helper functions
 include(${HiPACE_SOURCE_DIR}/cmake/HiPACEFunctions.cmake)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -130,7 +130,7 @@ macro(find_amrex)
     else()
         message(STATUS "Searching for pre-installed AMReX ...")
         set(COMPONENT_PRECISION ${HiPACE_PRECISION} P${HiPACE_PRECISION})
-        find_package(AMReX 26.04 CONFIG REQUIRED COMPONENTS 3D ${COMPONENT_PRECISION} PARTICLES)
+        find_package(AMReX 26.05 CONFIG REQUIRED COMPONENTS 3D ${COMPONENT_PRECISION} PARTICLES)
         # note: TINYP skipped because user-configured and optional
 
         # AMReX CMake helper scripts
@@ -149,7 +149,7 @@ set(HiPACE_amrex_src ""
 set(HiPACE_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     CACHE STRING
     "Repository URI to pull and build AMReX from if(HiPACE_amrex_internal)")
-set(HiPACE_amrex_branch "development"
+set(HiPACE_amrex_branch "26.05"
     CACHE STRING
     "Repository branch for HiPACE_amrex_repo if(HiPACE_amrex_internal)")
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,8 +26,8 @@ sys.path.insert(0, os.path.abspath('../../src/'))
 project = 'HiPACE++'
 copyright = '2021, Severin Diederichs, Axel Huebl, Remi Lehe, Andrew Myers, Alexander Sinn, Maxence Thevenet, Weiqun Zhang'
 author = 'Severin Diederichs, Axel Huebl, Remi Lehe, Andrew Myers, Alexander Sinn, Maxence Thevenet, Weiqun Zhang'
-version = u'26.04'
-release = u'26.04'
+version = u'26.05'
+release = u'26.05'
 
 # -- General configuration ---------------------------------------------------
 

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-HiPACE++ v26.04 Copyright (c) 2021-2026, The Regents of the University of California,
+HiPACE++ v26.05 Copyright (c) 2021-2026, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of
 any required approvals from the U.S. Dept. of Energy) and Deutsches
 Elektronen-Synchrotron (DESY). All rights reserved.


### PR DESCRIPTION
This should fix the macOS CI test for the conda-forge package.