### PR TITLE
Add Option to make a Histogram of Particles that exit the Domain

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1252,6 +1252,10 @@ Particles outside the histogram bounds are discarded.
     ``hist_function`` or ``hist_function2``. If disabled the histogram contains data from
     all z slices in the range given by ``patch_lo`` and ``patch_hi``.
 
+* ``<diag name>.hist_exit_boundary`` (`bool`) optional (default `false`)
+    Collect data from particles that exit the simulation domain transversely through the
+    ``boundary.particle = Absorbing`` boundary condition.
+
 In-situ diagnostics
 ^^^^^^^^^^^^^^^^^^^
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -842,6 +842,9 @@ Hipace::SolveOneSlice (int islice, int step, bool is_first_step, bool is_last_st
         m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, false, lev, current_N_level);
     }
 
+    // get plasma and beam histograms of particles that exited the domain
+    m_diags.FillBoundaryHistDiagnostics(islice, m_multi_plasma, m_multi_beam, m_3D_geom);
+
     if (m_depos_order_z == 2) {
         CalculateEzNext(current_N_level, is_first_step);
     }

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -842,9 +842,6 @@ Hipace::SolveOneSlice (int islice, int step, bool is_first_step, bool is_last_st
         m_multi_plasma.AdvanceParticles(m_fields, m_3D_geom, false, lev, current_N_level);
     }
 
-    // get plasma and beam histograms of particles that exited the domain
-    m_diags.FillBoundaryHistDiagnostics(islice, m_multi_plasma, m_multi_beam, m_3D_geom);
-
     if (m_depos_order_z == 2) {
         CalculateEzNext(current_N_level, is_first_step);
     }
@@ -854,6 +851,9 @@ Hipace::SolveOneSlice (int islice, int step, bool is_first_step, bool is_last_st
 
     // Push beam particles
     m_multi_beam.AdvanceBeamParticlesSlice(m_fields, m_3D_geom, islice, current_N_level);
+
+    // get plasma and beam histograms of particles that exited the domain after push
+    m_diags.FillBoundaryHistDiagnostics(islice, m_multi_plasma, m_multi_beam, m_3D_geom);
 
     m_multi_beam.shiftSlippedParticles(islice, m_3D_geom[0]);
 

--- a/src/diagnostics/Diagnostic.H
+++ b/src/diagnostics/Diagnostic.H
@@ -72,6 +72,7 @@ struct DiagnosticData
     amrex::ParserExecutor<9> m_hist_exe_q2;
     amrex::Parser m_hist_parser_w;
     amrex::ParserExecutor<9> m_hist_exe_w;
+    bool m_hist_exit_boundary = false; /**< look at particles that are exiting the domain */
 };
 
 
@@ -185,6 +186,19 @@ public:
     static std::pair<bool, int>
     ReverseShapeFactor (const DiagnosticData& fd, int islice, const amrex::Geometry& geom3d);
 
+    /** \brief Collect histograms from particles and copy them to the CPU memory
+     *
+     * \param[in] fd field diagnostic
+     * \param[in] islice current slice
+     * \param[in] plasmas MultiPlasma object
+     * \param[in] beams MultiBeam object
+     * \param[in] field_geom geometry for all field MR levels
+     */
+    void
+    HistogramDepositionCopy (DiagnosticData& fd, int islice,
+                             MultiPlasma& plasmas, MultiBeam& beams,
+                             const amrex::Vector<amrex::Geometry>& field_geom);
+
     /** \brief Fill diagnostic arrays with the simulation data available on the current slice
      *
      * \param[in] islice current slice
@@ -200,6 +214,17 @@ public:
                      Fields& fields, MultiLaser& lasers,
                      MultiPlasma& plasmas, MultiBeam& beams,
                      const amrex::Vector<amrex::Geometry>& field_geom);
+
+    /** \brief Collect histograms from particles that exited the domain
+     *
+     * \param[in] islice current slice
+     * \param[in] plasmas MultiPlasma object
+     * \param[in] beams MultiBeam object
+     * \param[in] field_geom geometry for all field MR levels
+     */
+    void
+    FillBoundaryHistDiagnostics (int islice, MultiPlasma& plasmas, MultiBeam& beams,
+                                 const amrex::Vector<amrex::Geometry>& field_geom);
 
 private:
     amrex::Vector<std::string> m_output_beam_names; /**< Component names to Write to output file */

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -254,6 +254,7 @@ Diagnostic::Initialize (int nlev, bool use_laser) {
                 bool add_z_axis = false;
                 queryWithParser(pp, "hist_add_z_axis", add_z_axis);
                 fd.m_integrate_along_z = !add_z_axis;
+                queryWithParser(pp, "hist_exit_boundary", fd.m_hist_exit_boundary);
 
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                     fd.m_hist_num_bins.size() == 1 || fd.m_hist_num_bins.size() == 2,
@@ -622,6 +623,43 @@ Diagnostic::ReverseShapeFactor (const DiagnosticData& fd, int islice,
 }
 
 void
+Diagnostic::HistogramDepositionCopy (DiagnosticData& fd, int islice,
+                                     MultiPlasma& plasmas, MultiBeam& beams,
+                                     const amrex::Vector<amrex::Geometry>& field_geom)
+{
+    auto [collect_data, dst_slice] = ReverseShapeFactor(fd, islice, field_geom[0]);
+    if (!collect_data) {
+        return;
+    }
+    HIPACE_PROFILE("Diagnostic::HistogramDepositionCopy()");
+    for (int icomp = 0; icomp < fd.m_hist_species_names.size(); ++icomp) {
+        const auto& species_name = fd.m_hist_species_names[icomp];
+        amrex::Real* gpu_ptr = fd.m_hist_gpu_fab.dataPtr();
+        amrex::Real* cpu_ptr = fd.m_F_real.dataPtr(icomp) +
+            fd.m_hist_gpu_fab.numPts() * (dst_slice - fd.m_F_real.box().smallEnd(2));
+        if (fd.m_integrate_along_z) {
+            // add to previous data
+            amrex::Gpu::htod_memcpy_async(gpu_ptr, cpu_ptr,
+                sizeof(amrex::Real) * fd.m_hist_gpu_fab.size()
+            );
+        } else {
+            // start from zero
+            fd.m_hist_gpu_fab.setVal<amrex::RunOn::Device>(0);
+        }
+        if (plasmas.HasPlasma(species_name)) {
+            const amrex::Real zmid = amrex::Real(islice) * field_geom[0].CellSize(2) +
+                GetPosOffset(2, field_geom[0], field_geom[0].Domain());
+            HistogramDepositionPlasma(plasmas.GetPlasma(species_name), fd, zmid);
+        } else {
+            HistogramDepositionBeam(beams.getBeam(species_name), fd);
+        }
+        amrex::Gpu::dtoh_memcpy_async(cpu_ptr, gpu_ptr,
+            sizeof(amrex::Real) * fd.m_hist_gpu_fab.size()
+        );
+    }
+}
+
+void
 Diagnostic::FillDiagnostics (int islice, int current_N_level,
                              Fields& fields, MultiLaser& lasers,
                              MultiPlasma& plasmas, MultiBeam& beams,
@@ -636,39 +674,60 @@ Diagnostic::FillDiagnostics (int islice, int current_N_level,
             case DiagnosticData::diag_type::laser:
                 fields.Copy(current_N_level, islice, fd, field_geom, lasers);
                 break;
-            case DiagnosticData::diag_type::histogram: {
-                auto [collect_data, dst_slice] = ReverseShapeFactor(fd, islice, field_geom[0]);
-                if (!collect_data) {
-                    break;
+            case DiagnosticData::diag_type::histogram:
+                if (!fd.m_hist_exit_boundary) {
+                    HistogramDepositionCopy(fd, islice, plasmas, beams, field_geom);
                 }
-                HIPACE_PROFILE("Diagnostic::HistogramDepositionCopy()");
-                for (int icomp = 0; icomp < fd.m_hist_species_names.size(); ++icomp) {
-                    const auto& species_name = fd.m_hist_species_names[icomp];
-                    amrex::Real* gpu_ptr = fd.m_hist_gpu_fab.dataPtr();
-                    amrex::Real* cpu_ptr = fd.m_F_real.dataPtr(icomp) +
-                        fd.m_hist_gpu_fab.numPts() * (dst_slice - fd.m_F_real.box().smallEnd(2));
-                    if (fd.m_integrate_along_z) {
-                        // add to previous data
-                        amrex::Gpu::htod_memcpy_async(gpu_ptr, cpu_ptr,
-                            sizeof(amrex::Real) * fd.m_hist_gpu_fab.size()
-                        );
-                    } else {
-                        // start from zero
-                        fd.m_hist_gpu_fab.setVal<amrex::RunOn::Device>(0);
-                    }
-                    if (plasmas.HasPlasma(species_name)) {
-                        const amrex::Real zmid = amrex::Real(islice) * field_geom[0].CellSize(2) +
-                            GetPosOffset(2, field_geom[0], field_geom[0].Domain());
-                        HistogramDepositionPlasma(plasmas.GetPlasma(species_name), fd, zmid);
-                    } else {
-                        HistogramDepositionBeam(beams.getBeam(species_name), fd);
-                    }
-                    amrex::Gpu::dtoh_memcpy_async(cpu_ptr, gpu_ptr,
-                        sizeof(amrex::Real) * fd.m_hist_gpu_fab.size()
-                    );
-                }
+                break;
+        }
+    }
+}
+
+void
+Diagnostic::FillBoundaryHistDiagnostics (int islice, MultiPlasma& plasmas, MultiBeam& beams,
+                                         const amrex::Vector<amrex::Geometry>& field_geom)
+{
+    std::set<std::string> species_names_with_boundary_hist;
+
+    // first do all histograms before removing the boundary id tag
+    for (auto& fd : m_diag_data) {
+        if (fd.m_has_output &&
+            fd.m_base_diag_type == DiagnosticData::diag_type::histogram &&
+            islice > 0 &&
+            fd.m_hist_exit_boundary)
+        {
+            // particles where already pushed so they are on the next slice now
+            HistogramDepositionCopy(fd, islice - 1, plasmas, beams, field_geom);
+            species_names_with_boundary_hist.insert(
+                fd.m_hist_species_names.begin(), fd.m_hist_species_names.end());
+        }
+    }
+
+    // reset id so we don't double count particles.
+    for (const auto& species_name : species_names_with_boundary_hist) {
+        if (plasmas.HasPlasma(species_name)) {
+            auto& plasma = plasmas.GetPlasma(species_name);
+            for (PlasmaParticleIterator pti(plasma); pti.isValid(); ++pti)
+            {
+                const auto ptd = pti.GetParticleTile().getParticleTileData();
+                amrex::ParallelFor(
+                    pti.numParticles(),
+                    [=] AMREX_GPU_DEVICE (int ip) {
+                        if (ptd.id(ip) == PlasmaID::invalid_at_boundary) {
+                            ptd.id(ip) = PlasmaID::invalid;
+                        }
+                    });
             }
-            break;
+        } else {
+            auto& beam = beams.getBeam(species_name);
+            const auto ptd = beam.getBeamSlice(WhichBeamSlice::This).getParticleTileData();
+            amrex::ParallelFor(
+                beam.getNumParticles(WhichBeamSlice::This),
+                [=] AMREX_GPU_DEVICE (int ip) {
+                    if (ptd.id(ip) == PlasmaID::invalid_at_boundary) {
+                        ptd.id(ip) = PlasmaID::invalid;
+                    }
+                });
         }
     }
 }

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -51,7 +51,7 @@ namespace
         amrex::Real yp = y;
         amrex::Real uxp = ux;
         amrex::Real uyp = uy;
-        if (enforceBC(ptd, ip, xp, yp, uxp, uyp, BeamIdx::w)) return;
+        if (enforceBC(ptd, ip, xp, yp, uxp, uyp)) return;
 
         ptd.rdata(BeamIdx::x )[ip] = xp;
         ptd.rdata(BeamIdx::y )[ip] = yp;
@@ -97,7 +97,7 @@ namespace
         amrex::Real yp = y;
         amrex::Real uxp = ux;
         amrex::Real uyp = uy;
-        if (enforceBC(ptd, ip, xp, yp, uxp, uyp, BeamIdx::w)) return;
+        if (enforceBC(ptd, ip, xp, yp, uxp, uyp)) return;
 
         ptd.rdata(BeamIdx::x )[ip] = xp;
         ptd.rdata(BeamIdx::y )[ip] = yp;

--- a/src/particles/deposition/HistogramDeposition.cpp
+++ b/src/particles/deposition/HistogramDeposition.cpp
@@ -40,6 +40,7 @@ HistogramDepositionPlasma (PlasmaParticleContainer& plasma, DiagnosticData& fd, 
     const CheckDomainBounds realspace_bounds{fd.m_realspace_geom};
 
     const bool use_second_dim = fd.m_hist_num_dims == 2;
+    const bool is_boundary_hist = fd.m_hist_exit_boundary;
 
     const bool can_ionize = plasma.m_can_ionize;
 
@@ -51,14 +52,17 @@ HistogramDepositionPlasma (PlasmaParticleContainer& plasma, DiagnosticData& fd, 
 
         amrex::ParallelFor(pti.numParticles(),
             [=] AMREX_GPU_DEVICE (int ip) {
-                if (!ptd.id(ip).is_valid()) {
+                if (is_boundary_hist ?
+                    ptd.id(ip) != PlasmaID::invalid_at_boundary :
+                    !ptd.id(ip).is_valid())
+                {
                     return;
                 }
 
                 const amrex::Real xp = ptd.pos(0, ip);
                 const amrex::Real yp = ptd.pos(1, ip);
 
-                if (!realspace_bounds.contains(xp, yp)) {
+                if (!is_boundary_hist && !realspace_bounds.contains(xp, yp)) {
                     return;
                 }
 
@@ -122,6 +126,7 @@ HistogramDepositionBeam (BeamParticleContainer& beam, DiagnosticData& fd)
     const CheckDomainBounds realspace_bounds{fd.m_realspace_geom};
 
     const bool use_second_dim = fd.m_hist_num_dims == 2;
+    const bool is_boundary_hist = fd.m_hist_exit_boundary;
 
     // Loop over particle boxes
     auto ptd = beam.getBeamSlice(WhichBeamSlice::This).getConstParticleTileData();
@@ -129,7 +134,10 @@ HistogramDepositionBeam (BeamParticleContainer& beam, DiagnosticData& fd)
 
     amrex::ParallelFor(beam.getNumParticles(WhichBeamSlice::This),
         [=] AMREX_GPU_DEVICE (int ip) {
-            if (!ptd.id(ip).is_valid()) {
+            if (is_boundary_hist ?
+                ptd.id(ip) != PlasmaID::invalid_at_boundary :
+                !ptd.id(ip).is_valid())
+            {
                 return;
             }
 
@@ -137,7 +145,7 @@ HistogramDepositionBeam (BeamParticleContainer& beam, DiagnosticData& fd)
             const amrex::Real yp = ptd.pos(1, ip);
             const amrex::Real zp = ptd.pos(2, ip);
 
-            if (!realspace_bounds.contains(xp, yp)) {
+            if (!is_boundary_hist && !realspace_bounds.contains(xp, yp)) {
                 return;
             }
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -119,6 +119,17 @@ struct PlasmaIdx
     };
 };
 
+struct PlasmaID
+{
+    enum {
+        valid = 1,
+        from_field_ionization = 2,
+        from_laser_ionization = 3,
+        invalid = -1,
+        invalid_at_boundary = -2
+    };
+};
+
 /** \brief Container for particles of 1 plasma species. */
 class PlasmaParticleContainer
     : public amrex::ParticleContainerRTSoA<amrex::Real, int>

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -534,7 +534,7 @@ IonizationModule (const int lev,
 
                 // Copy ion data to new electron
                 // Set the ionized electron ID to 2 (valid/invalid) for the ionized electrons
-                ptd_elec.id(pidx) = 2;
+                ptd_elec.id(pidx) = PlasmaID::from_field_ionization;
                 ptd_elec.cpu(pidx) = lev; // current level
                 ptd_elec.rdata(PlasmaIdx::x      )[pidx] = ptd_ion.rdata(PlasmaIdx::x)[ip];
                 ptd_elec.rdata(PlasmaIdx::y      )[pidx] = ptd_ion.rdata(PlasmaIdx::y)[ip];
@@ -795,7 +795,7 @@ LaserIonization (const int islice,
                 const amrex::Real psi = plasma_psi(ux, uy, uz, amrex::abs(A*A));
                 // Copy ion data to new electron
                 // Set the ionized electron ID to 2 (valid/invalid) for the ionized electrons
-                ptd_elec.id(pidx) = 2;
+                ptd_elec.id(pidx) = PlasmaID::from_laser_ionization;
                 ptd_elec.cpu(pidx) = ptd_ion.cpu(ip);  // current level
                 ptd_elec.rdata(PlasmaIdx::x      )[pidx] = ptd_ion.rdata(PlasmaIdx::x)[ip];
                 ptd_elec.rdata(PlasmaIdx::y      )[pidx] = ptd_ion.rdata(PlasmaIdx::y)[ip];

--- a/src/particles/plasma/PlasmaParticleContainerInit.cpp
+++ b/src/particles/plasma/PlasmaParticleContainerInit.cpp
@@ -274,7 +274,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                     }
 
                     pidx += current_size;
-                    ptd.id(pidx) = 1; // plasma id is only used to distinguish between valid/invalid
+                    ptd.id(pidx) = PlasmaID::valid;
                     ptd.cpu(pidx) = 0; // level 0
                     ptd.rdata(PlasmaIdx::x)[pidx] = x;
                     ptd.rdata(PlasmaIdx::y)[pidx] = y;
@@ -345,7 +345,7 @@ InitParticles (const amrex::RealVect& a_u_std,
                 for (int imirror=0; imirror<3; ++imirror) {
                     const amrex::Long midx = (imirror+1)*total_non_mirrored_particles + pidx;
 
-                    ptd.id(midx) = 1; // plasma id is only used to distinguish between valid/invalid
+                    ptd.id(midx) = PlasmaID::valid;
                     ptd.cpu(midx) = 0; // level 0
                     ptd.rdata(PlasmaIdx::x)[midx] = x_arr[imirror];
                     ptd.rdata(PlasmaIdx::y)[midx] = y_arr[imirror];

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -157,7 +157,7 @@ AdvanceBeamParticlesSlice (
                 xp += dt * clight * 0.5_rt * gammap_inv * ux;
                 yp += dt * clight * 0.5_rt * gammap_inv * uy;
 
-                if (enforceBC(ptd, ip, xp, yp, ux, uy, BeamIdx::w)) return;
+                if (enforceBC(ptd, ip, xp, yp, ux, uy)) return;
 
                 Array3<const amrex::Real> slice_arr = slice_arr_lev0;
                 amrex::Real dx_inv = dx_inv_lev0;
@@ -321,7 +321,7 @@ AdvanceBeamParticlesSlice (
                 uy = uy_next;
                 uz = uz_next;
             } // end for loop over n_subcycles
-            if (enforceBC(ptd, ip, xp, yp, ux, uy, BeamIdx::w)) return;
+            if (enforceBC(ptd, ip, xp, yp, ux, uy)) return;
             ptd.pos(0, ip) = xp;
             ptd.pos(1, ip) = yp;
             ptd.pos(2, ip) = zp;

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -51,7 +51,6 @@ struct EnforceBC
      * \param[in] y y position of particle
      * \param[in] ux x momentum of particle
      * \param[in] uy y momentum of particle
-     * \param[in] w_index index to the weight component
      */
     template<class PTD>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -57,7 +57,7 @@ struct EnforceBC
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool operator() (const PTD& ptd,
         const int ip, amrex::Real& x, amrex::Real& y,
-        amrex::Real& ux, amrex::Real& uy, const int w_index) const noexcept
+        amrex::Real& ux, amrex::Real& uy) const noexcept
     {
         bool invalid = false;
         if (x < m_plo[0] || y < m_plo[1] || x > m_phi[0] || y > m_phi[1]) {
@@ -88,8 +88,7 @@ struct EnforceBC
                 y += m_plo[1];
                 invalid = false;
             } else {
-                ptd.rdata(w_index)[ip] = amrex::Real(0);
-                ptd.id(ip).make_invalid();
+                ptd.id(ip) = PlasmaID::invalid_at_boundary;
                 invalid = true;
             }
         }

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -174,7 +174,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                     xp += dz*(ux * (1._rt/psi));
                     yp += dz*(uy * (1._rt/psi));
 
-                    if (enforceBC(ptd, ip, xp, yp, ux, uy, PlasmaIdx::w)) return;
+                    if (enforceBC(ptd, ip, xp, yp, ux, uy)) return;
                     ptd.pos(0, ip) = xp;
                     ptd.pos(1, ip) = yp;
 
@@ -253,7 +253,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         psi += ab5_coeffs[iab] * ptd.rdata(PlasmaIdx::Fpsi1 + p)[ip];
                     }
 
-                    if (enforceBC(ptd, ip, xp, yp, ux, uy, PlasmaIdx::w)) return;
+                    if (enforceBC(ptd, ip, xp, yp, ux, uy)) return;
                     ptd.pos(0, ip) = xp;
                     ptd.pos(1, ip) = yp;
 


### PR DESCRIPTION
This PR adds
```
<diag name>.hist_exit_boundary = true
```
to allow the creation of histograms of particles right after they leave the domain.

Test: x and y positions of particles that leave the boundary
<img width="872" height="684" alt="image" src="https://github.com/user-attachments/assets/b88dc370-f2cf-4cb0-83ab-b3739a5f4cb9" />
