### PR TITLE
Factor out Physics Extensions from Beam Pusher

### DIFF
--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -16,6 +16,137 @@
 #include "utils/GPUUtil.H"
 #include "utils/OMPUtil.H"
 
+
+template <int depos_order>
+AMREX_GPU_DEVICE
+void InterpolateEzInZ (
+    amrex::Real& Ezp,
+    const amrex::Real xp, const amrex::Real yp, const amrex::Real zp,
+    const amrex::Real x_pos_offset, const amrex::Real y_pos_offset, const amrex::Real min_z,
+    const amrex::Real dx_inv, const amrex::Real dy_inv, const amrex::Real dz_inv,
+    const int ez_comp_prev, const int ez_comp_next, const Array3<const amrex::Real> slice_arr
+)
+{
+    using namespace amrex::literals;
+
+    // x,y,z direction
+    const amrex::Real xmid = (xp-x_pos_offset)*dx_inv;
+    const amrex::Real ymid = (yp-y_pos_offset)*dy_inv;
+    const amrex::Real zmid = (zp-min_z)*dz_inv-0.5_rt;
+
+    const auto [shape_p, pcell] = shape_factor<2>(zmid, 2);
+    const auto [shape_n, ncell] = shape_factor<2>(zmid, 0);
+
+    Ezp *= (1._rt - shape_p - shape_n);
+
+    // Gather Ez field on particle from grid
+    for (int iy=0; iy<=depos_order; iy++){
+        for (int ix=0; ix<=depos_order; ix++){
+            // Compute shape factors
+            auto [shape_y, jcell] = shape_factor<depos_order>(ymid, iy);
+            auto [shape_x, icell] = shape_factor<depos_order>(xmid, ix);
+
+            Ezp += shape_p * shape_y * shape_x * slice_arr(icell, jcell, ez_comp_prev);
+            Ezp += shape_n * shape_y * shape_x * slice_arr(icell, jcell, ez_comp_next);
+        }
+    }
+}
+
+
+AMREX_GPU_DEVICE
+void PushSpin (
+    amrex::RealVect& spin,
+    const amrex::Real ExmByp, const amrex::Real EypBxp, const amrex::Real Ezp,
+    const amrex::Real Bxp, const amrex::Real Byp, const amrex::Real Bzp,
+    const amrex::Real ux_intermediate, const amrex::Real uy_intermediate,
+    const amrex::Real uz_intermediate, const amrex::Real gamma_intermediate_inv,
+    const amrex::Real charge_mass_ratio, const amrex::Real dt,
+    const amrex::Real spin_anom
+)
+{
+    using namespace amrex::literals;
+
+    const amrex::RealVect E {ExmByp + Byp, EypBxp - Bxp, Ezp};
+    const amrex::RealVect B {Bxp, Byp, Bzp};
+    const amrex::RealVect u {ux_intermediate, uy_intermediate, uz_intermediate};
+    const amrex::RealVect beta = u*gamma_intermediate_inv;
+    const amrex::Real gamma_inv_p1 =
+        gamma_intermediate_inv / (1._rt + gamma_intermediate_inv);
+
+    const amrex::RealVect omega = std::abs(charge_mass_ratio) * (
+        B * gamma_intermediate_inv - beta.crossProduct(E) * gamma_inv_p1
+        + spin_anom * (
+            B - gamma_inv_p1 * u * beta.dotProduct(B) - beta.crossProduct(E)
+        )
+    );
+
+    const amrex::RealVect h = omega * dt * 0.5_rt;
+    const amrex::RealVect s_prime = spin + h.crossProduct(spin);
+    const amrex::Real o = 1._rt / (1._rt + h.dotProduct(h));
+    spin = o * (s_prime + (h.dotProduct(s_prime) * h + h.crossProduct(s_prime)));
+}
+
+
+AMREX_GPU_DEVICE
+void ApplyRadiationReaction (
+    amrex::Real& ux_next, amrex::Real& uy_next, amrex::Real& uz_next,
+    const amrex::Real ExmByp, const amrex::Real EypBxp, const amrex::Real Ezp,
+    const amrex::Real Bxp, const amrex::Real Byp, const amrex::Real Bzp,
+    const amrex::Real ux_intermediate, const amrex::Real uy_intermediate,
+    const amrex::Real uz_intermediate, const amrex::Real gamma_intermediate_inv,
+    const amrex::Real dt, const amrex::Real rr_factor
+)
+{
+    using namespace amrex::literals;
+
+    const amrex::Real Exp = ExmByp + Byp;
+    const amrex::Real Eyp = EypBxp - Bxp;
+
+    const amrex::Real gamma_intermediate = std::sqrt( 1._rt
+        + ux_intermediate*ux_intermediate
+        + uy_intermediate*uy_intermediate
+        + uz_intermediate*uz_intermediate);
+
+    // Estimation of normalized velocity beta (v/c) at intermediate time
+    const amrex::Real bx_n = ux_intermediate * gamma_intermediate_inv;
+    const amrex::Real by_n = uy_intermediate * gamma_intermediate_inv;
+    const amrex::Real bz_n = uz_intermediate * gamma_intermediate_inv;
+
+    // Lorentz force over charge
+    const amrex::Real flx_q = (Exp + by_n*Bzp - bz_n*Byp);
+    const amrex::Real fly_q = (Eyp + bz_n*Bxp - bx_n*Bzp);
+    const amrex::Real flz_q = (Ezp + bx_n*Byp - by_n*Bxp);
+    const amrex::Real fl_q2 = flx_q*flx_q + fly_q*fly_q + flz_q*flz_q;
+
+    // Calculation of auxiliary quantities
+    const amrex::Real bdotE = (bx_n*Exp + by_n*Eyp + bz_n*Ezp);
+    const amrex::Real bdotE2 = bdotE*bdotE;
+    const amrex::Real coeff = gamma_intermediate*gamma_intermediate*(fl_q2-bdotE2);
+
+    // Compute the components of the RR force
+    const amrex::Real frx = fly_q*Bzp - flz_q*Byp + bdotE*Exp - coeff*bx_n;
+    const amrex::Real fry = flz_q*Bxp - flx_q*Bzp + bdotE*Eyp - coeff*by_n;
+    const amrex::Real frz = flx_q*Byp - fly_q*Bxp + bdotE*Ezp - coeff*bz_n;
+
+    // Update momentum using the RR force
+    ux_next += dt * rr_factor * frx;
+    uy_next += dt * rr_factor * fry;
+    uz_next += dt * rr_factor * frz;
+}
+
+
+struct MRLevelData {
+    // Array to access fields
+    Array3<const amrex::Real> slice_arr;
+    // Properties associated with physical size of the box
+    amrex::Real dx_inv = 0;
+    amrex::Real dy_inv = 0;
+    // Offset for converting positions to indexes
+    amrex::Real x_pos_offset = 0;
+    amrex::Real y_pos_offset = 0;
+};
+
+
 void
 AdvanceBeamParticlesSlice (
     BeamParticleContainer& beam, const Fields& fields, amrex::Vector<amrex::Geometry> const& gm,
@@ -55,27 +186,26 @@ AdvanceBeamParticlesSlice (
     const amrex::FArrayBox& slice_fab_lev1 = fields.getSlices(lev1_idx)[0];
     const amrex::FArrayBox& slice_fab_lev2 = fields.getSlices(lev2_idx)[0];
 
-    Array3<const amrex::Real> const slice_arr_lev0 = slice_fab_lev0.const_array();
-    Array3<const amrex::Real> const slice_arr_lev1 = slice_fab_lev1.const_array();
-    Array3<const amrex::Real> const slice_arr_lev2 = slice_fab_lev2.const_array();
+    const MRLevelData level0data {
+        slice_fab_lev0.const_array(),
+        gm[lev0_idx].InvCellSize(0), gm[lev0_idx].InvCellSize(1),
+        GetPosOffset(0, gm[lev0_idx], slice_fab_lev0.box()),
+        GetPosOffset(1, gm[lev0_idx], slice_fab_lev0.box())
+    };
 
-    // Extract properties associated with physical size of the box
-    const amrex::Real dx_inv_lev0 = gm[lev0_idx].InvCellSize(0);
-    const amrex::Real dx_inv_lev1 = gm[lev1_idx].InvCellSize(0);
-    const amrex::Real dx_inv_lev2 = gm[lev2_idx].InvCellSize(0);
+    const MRLevelData level1data {
+        slice_fab_lev1.const_array(),
+        gm[lev1_idx].InvCellSize(0), gm[lev1_idx].InvCellSize(1),
+        GetPosOffset(0, gm[lev1_idx], slice_fab_lev1.box()),
+        GetPosOffset(1, gm[lev1_idx], slice_fab_lev1.box())
+    };
 
-    amrex::Real const dy_inv_lev0 = gm[lev0_idx].InvCellSize(1);
-    const amrex::Real dy_inv_lev1 = gm[lev1_idx].InvCellSize(1);
-    const amrex::Real dy_inv_lev2 = gm[lev2_idx].InvCellSize(1);
-
-    // Offset for converting positions to indexes
-    amrex::Real const x_pos_offset_lev0 = GetPosOffset(0, gm[lev0_idx], slice_fab_lev0.box());
-    amrex::Real const x_pos_offset_lev1 = GetPosOffset(0, gm[lev1_idx], slice_fab_lev1.box());
-    amrex::Real const x_pos_offset_lev2 = GetPosOffset(0, gm[lev2_idx], slice_fab_lev2.box());
-
-    const amrex::Real y_pos_offset_lev0 = GetPosOffset(1, gm[lev0_idx], slice_fab_lev0.box());
-    const amrex::Real y_pos_offset_lev1 = GetPosOffset(1, gm[lev1_idx], slice_fab_lev1.box());
-    const amrex::Real y_pos_offset_lev2 = GetPosOffset(1, gm[lev2_idx], slice_fab_lev2.box());
+    const MRLevelData level2data {
+        slice_fab_lev2.const_array(),
+        gm[lev2_idx].InvCellSize(0), gm[lev2_idx].InvCellSize(1),
+        GetPosOffset(0, gm[lev2_idx], slice_fab_lev2.box()),
+        GetPosOffset(1, gm[lev2_idx], slice_fab_lev2.box())
+    };
 
     // z is the same for all levels
     amrex::Real const dz_inv = gm[lev0_idx].InvCellSize(2);
@@ -92,8 +222,8 @@ AdvanceBeamParticlesSlice (
     const amrex::Real inv_clight = 1.0_rt/phys_const.c;
     const amrex::Real charge_mass_ratio = beam.m_charge / beam.m_mass;
     const amrex::Real min_z = gm[0].ProbLo(2) + (slice-gm[0].Domain().smallEnd(2))*gm[0].CellSize(2);
-    bool use_external_fields = beam.m_use_external_fields;
-    auto external_fields = beam.m_external_fields;
+    const bool use_external_fields = beam.m_use_external_fields;
+    const auto external_fields = beam.m_external_fields;
 
     // Radiation reaction constant
     amrex::Real rr_factor = (2.0_rt/3.0_rt) * PhysConstSI::r_e
@@ -126,6 +256,7 @@ AdvanceBeamParticlesSlice (
 
             if (!ptd.id(ip).is_valid()) return;
 
+            // Load particle data
             amrex::Real xp = ptd.pos(0, ip);
             amrex::Real yp = ptd.pos(1, ip);
             amrex::Real zp = ptd.pos(2, ip);
@@ -149,8 +280,7 @@ AdvanceBeamParticlesSlice (
                     break;
                 }
 
-                const amrex::ParticleReal gammap_inv = 1._rt / std::sqrt( 1._rt
-                    + ux*ux + uy*uy + uz*uz);
+                const amrex::Real gammap_inv = amrex::Math::rsqrt( 1._rt + ux*ux + uy*uy + uz*uz);
 
                 // first we do half a step in x,y
                 // This is not required in z, which is pushed in one step later
@@ -159,31 +289,18 @@ AdvanceBeamParticlesSlice (
 
                 if (enforceBC(ptd, ip, xp, yp, ux, uy, BeamIdx::w)) return;
 
-                Array3<const amrex::Real> slice_arr = slice_arr_lev0;
-                amrex::Real dx_inv = dx_inv_lev0;
-                amrex::Real dy_inv = dy_inv_lev0;
-                amrex::Real x_pos_offset = x_pos_offset_lev0;
-                amrex::Real y_pos_offset = y_pos_offset_lev0;
-
+                // Load field data from highest available MR level
+                MRLevelData level_data = level0data; // level 0
                 if (current_N_level > 2 && lev2_bounds.contains(xp, yp)) {
-                    // level 2
-                    slice_arr = slice_arr_lev2;
-                    dx_inv = dx_inv_lev2;
-                    dy_inv = dy_inv_lev2;
-                    x_pos_offset = x_pos_offset_lev2;
-                    y_pos_offset = y_pos_offset_lev2;
+                    level_data = level2data; // level 2
                 } else if (current_N_level > 1 && lev1_bounds.contains(xp, yp)) {
-                    // level 1
-                    slice_arr = slice_arr_lev1;
-                    dx_inv = dx_inv_lev1;
-                    dy_inv = dy_inv_lev1;
-                    x_pos_offset = x_pos_offset_lev1;
-                    y_pos_offset = y_pos_offset_lev1;
+                    level_data = level1data; // level 1
                 }
+                const auto [slice_arr, dx_inv, dy_inv, x_pos_offset, y_pos_offset] = level_data;
 
                 // define field at particle position reals
-                amrex::ParticleReal ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
-                amrex::ParticleReal Bxp = 0._rt, Byp = 0._rt, Bzp = 0._rt;
+                amrex::Real ExmByp = 0._rt, EypBxp = 0._rt, Ezp = 0._rt;
+                amrex::Real Bxp = 0._rt, Byp = 0._rt, Bzp = 0._rt;
 
                 // field gather for a single particle
                 doGatherShapeN<depos_order.value>(xp, yp, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
@@ -191,30 +308,14 @@ AdvanceBeamParticlesSlice (
                     dx_inv, dy_inv, x_pos_offset, y_pos_offset);
 
                 if (c_do_ez_inzerp.value) {
-                    // x,y,z direction
-                    const amrex::Real xmid = (xp-x_pos_offset)*dx_inv;
-                    const amrex::Real ymid = (yp-y_pos_offset)*dy_inv;
-                    const amrex::Real zmid = (zp-min_z)*dz_inv-0.5_rt;
-
-                    auto [shape_p, pcell] = shape_factor<2>(zmid, 2);
-                    auto [shape_n, ncell] = shape_factor<2>(zmid, 0);
-
-                    Ezp *= (1._rt - shape_p - shape_n);
-
-                    // Gather Ez field on particle from grid
-                    for (int iy=0; iy<=depos_order.value; iy++){
-                        for (int ix=0; ix<=depos_order.value; ix++){
-                            // Compute shape factors
-                            auto [shape_y, jcell] = shape_factor<depos_order.value>(ymid, iy);
-                            auto [shape_x, icell] = shape_factor<depos_order.value>(xmid, ix);
-
-                            Ezp += shape_p * shape_y * shape_x * slice_arr(icell, jcell, ez_comp_prev);
-                            Ezp += shape_n * shape_y * shape_x * slice_arr(icell, jcell, ez_comp_next);
-                        }
-                    }
+                    // Update Ez
+                    InterpolateEzInZ<depos_order.value>(Ezp,
+                        xp, yp, zp, x_pos_offset, y_pos_offset, min_z, dx_inv, dy_inv, dz_inv,
+                        ez_comp_prev, ez_comp_next, slice_arr);
                 }
 
                 if (c_use_external_fields.value) {
+                    // Update ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp
                     ApplyExternalField(xp, yp, zp, time, clight, ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp,
                         external_fields);
                 }
@@ -224,85 +325,44 @@ AdvanceBeamParticlesSlice (
                 Ezp *= inv_clight;
 
                 // use intermediate fields to calculate next (n+1) transverse momenta
-                amrex::ParticleReal ux_next = ux + dt * charge_mass_ratio
+                amrex::Real ux_next = ux + dt * charge_mass_ratio
                     * ( ExmByp + ( 1._rt - uz * gammap_inv ) * Byp + uy * gammap_inv * Bzp);
-                amrex::ParticleReal uy_next = uy + dt * charge_mass_ratio
+                amrex::Real uy_next = uy + dt * charge_mass_ratio
                     * ( EypBxp - ( 1._rt - uz * gammap_inv ) * Bxp - ux * gammap_inv * Bzp);
 
                 // Now computing new longitudinal momentum
-                const amrex::ParticleReal ux_intermediate = ( ux_next + ux ) * 0.5_rt;
-                const amrex::ParticleReal uy_intermediate = ( uy_next + uy ) * 0.5_rt;
-                const amrex::ParticleReal uz_intermediate = uz
+                const amrex::Real ux_intermediate = ( ux_next + ux ) * 0.5_rt;
+                const amrex::Real uy_intermediate = ( uy_next + uy ) * 0.5_rt;
+                const amrex::Real uz_intermediate = uz
                     + dt * 0.5_rt * charge_mass_ratio * Ezp;
 
-                const amrex::ParticleReal gamma_intermediate_inv = 1._rt / std::sqrt( 1._rt
+                const amrex::Real gamma_intermediate_inv = amrex::Math::rsqrt( 1._rt
                     + ux_intermediate*ux_intermediate
                     + uy_intermediate*uy_intermediate
                     + uz_intermediate*uz_intermediate);
 
                 if (spin_tracking) {
-                    const amrex::RealVect E {ExmByp + Byp, EypBxp - Bxp, Ezp};
-                    const amrex::RealVect B {Bxp, Byp, Bzp};
-                    const amrex::RealVect u {ux_intermediate, uy_intermediate, uz_intermediate};
-                    const amrex::RealVect beta = u*gamma_intermediate_inv;
-                    const amrex::Real gamma_inv_p1 =
-                        gamma_intermediate_inv / (1._rt + gamma_intermediate_inv);
-
-                    const amrex::RealVect omega = std::abs(charge_mass_ratio) * (
-                        B * gamma_intermediate_inv - beta.crossProduct(E) * gamma_inv_p1
-                        + spin_anom * (
-                            B - gamma_inv_p1 * u * beta.dotProduct(B) - beta.crossProduct(E)
-                        )
-                    );
-
-                    const amrex::RealVect h = omega * dt * 0.5_rt;
-                    const amrex::RealVect s_prime = spin + h.crossProduct(spin);
-                    const amrex::Real o = 1._rt / (1._rt + h.dotProduct(h));
-                    spin = o * (s_prime + (h.dotProduct(s_prime) * h + h.crossProduct(s_prime)));
+                    // Update spin
+                    PushSpin(spin,
+                        ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp, ux_intermediate, uy_intermediate,
+                        uz_intermediate, gamma_intermediate_inv, charge_mass_ratio, dt, spin_anom);
                 }
 
-                amrex::ParticleReal uz_next = uz + dt * charge_mass_ratio
+                amrex::Real uz_next = uz + dt * charge_mass_ratio
                     * ( Ezp + ( ux_intermediate * Byp - uy_intermediate * Bxp )
                     * gamma_intermediate_inv );
 
                 if (radiation_reaction) {
-                    const amrex::ParticleReal Exp = ExmByp + Byp;
-                    const amrex::ParticleReal Eyp = EypBxp - Bxp;
-
-                    const amrex::ParticleReal gamma_intermediate = std::sqrt(
-                        1._rt + ux_intermediate*ux_intermediate
-                              + uy_intermediate*uy_intermediate
-                              + uz_intermediate*uz_intermediate);
-
-                    // Estimation of normalized velocity beta (v/c) at intermediate time
-                    const amrex::ParticleReal bx_n = ux_intermediate * gamma_intermediate_inv;
-                    const amrex::ParticleReal by_n = uy_intermediate * gamma_intermediate_inv;
-                    const amrex::ParticleReal bz_n = uz_intermediate * gamma_intermediate_inv;
-
-                    // Lorentz force over charge
-                    const amrex::ParticleReal flx_q = (Exp + by_n*Bzp - bz_n*Byp);
-                    const amrex::ParticleReal fly_q = (Eyp + bz_n*Bxp - bx_n*Bzp);
-                    const amrex::ParticleReal flz_q = (Ezp + bx_n*Byp - by_n*Bxp);
-                    const amrex::ParticleReal fl_q2 = flx_q*flx_q + fly_q*fly_q + flz_q*flz_q;
-
-                    // Calculation of auxiliary quantities
-                    const amrex::ParticleReal bdotE = (bx_n*Exp + by_n*Eyp + bz_n*Ezp);
-                    const amrex::ParticleReal bdotE2 = bdotE*bdotE;
-                    const amrex::ParticleReal coeff = gamma_intermediate*gamma_intermediate*(fl_q2-bdotE2);
-
-                    // Compute the components of the RR force
-                    const amrex::ParticleReal frx = fly_q*Bzp - flz_q*Byp + bdotE*Exp - coeff*bx_n;
-                    const amrex::ParticleReal fry = flz_q*Bxp - flx_q*Bzp + bdotE*Eyp - coeff*by_n;
-                    const amrex::ParticleReal frz = flx_q*Byp - fly_q*Bxp + bdotE*Ezp - coeff*bz_n;
-
-                    // Update momentum using the RR force
-                    ux_next += dt * rr_factor * frx;
-                    uy_next += dt * rr_factor * fry;
-                    uz_next += dt * rr_factor * frz;
+                    // Update ux_next, uy_next, uz_next
+                    ApplyRadiationReaction(ux_next, uy_next, uz_next,
+                        ExmByp, EypBxp, Ezp, Bxp, Byp, Bzp, ux_intermediate,
+                        uy_intermediate, uz_intermediate, gamma_intermediate_inv,
+                        dt, rr_factor
+                    );
                 }
 
                 /* computing next gamma value */
-                const amrex::ParticleReal gamma_next_inv = 1._rt / std::sqrt( 1._rt
+                const amrex::Real gamma_next_inv = amrex::Math::rsqrt( 1._rt
                     + ux_next*ux_next
                     + uy_next*uy_next
                     + uz_next*uz_next);
@@ -316,12 +376,18 @@ AdvanceBeamParticlesSlice (
                  */
                 xp += dt * clight * 0.5_rt * gamma_next_inv * ux_next;
                 yp += dt * clight * 0.5_rt * gamma_next_inv * uy_next;
-                if (do_z_push) zp += dt * clight * ( uz_next * gamma_next_inv - 1._rt );
+                if (do_z_push) {
+                    zp += dt * clight * ( uz_next * gamma_next_inv - 1._rt );
+                }
                 ux = ux_next;
                 uy = uy_next;
                 uz = uz_next;
+
             } // end for loop over n_subcycles
+
             if (enforceBC(ptd, ip, xp, yp, ux, uy, BeamIdx::w)) return;
+
+            // Store particle data
             ptd.pos(0, ip) = xp;
             ptd.pos(1, ip) = yp;
             ptd.pos(2, ip) = zp;

--- a/src/particles/pusher/BeamParticleAdvance.cpp
+++ b/src/particles/pusher/BeamParticleAdvance.cpp
@@ -18,7 +18,7 @@
 
 
 template <int depos_order>
-AMREX_GPU_DEVICE
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void InterpolateEzInZ (
     amrex::Real& Ezp,
     const amrex::Real xp, const amrex::Real yp, const amrex::Real zp,
@@ -53,7 +53,7 @@ void InterpolateEzInZ (
 }
 
 
-AMREX_GPU_DEVICE
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void PushSpin (
     amrex::RealVect& spin,
     const amrex::Real ExmByp, const amrex::Real EypBxp, const amrex::Real Ezp,
@@ -87,7 +87,7 @@ void PushSpin (
 }
 
 
-AMREX_GPU_DEVICE
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void ApplyRadiationReaction (
     amrex::Real& ux_next, amrex::Real& uy_next, amrex::Real& uz_next,
     const amrex::Real ExmByp, const amrex::Real EypBxp, const amrex::Real Ezp,


### PR DESCRIPTION
The beam pusher function was getting quite long, making it difficult to understand the core update logic. Now the optional components are in separate functions that are called from the beam pusher. 