### PR TITLE
Per slice plasma density reader

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -470,7 +470,9 @@ When both are specified, the per-species value is used.
 
 * ``<plasma name> or plasmas.read_density_from_path`` (`string`) optional (default "")
     Alternative to ``<plasma name>.density(x,y,z)``. Specify the path to an openPMD file that contains the species' number density for each location of the simulation. Both geometries (Cartesian ``xyz`` and Cylindrical ``rz`` + modes)  are supported, however not all dimensions need to be included. The mesh in the file can be chosen with ``<plasma name> or plasmas.density_mesh_name`` (default ``density``) and must contain a single ``SCALAR`` component. Examples of scripts to generate such files can be found in ``tools/write_plasma_density.py`` and ``tools/write_plasma_density_rz.py``.
-    When loading large 3D density profiles, it can help to set ``<plasma name> or plasmas.read_density_per_slice``
+
+* ``<plasma name> or plasmas.read_density_per_slice`` (`bool`) optional (default `0`)
+    When loading large 3D density profiles with ``read_density_from_path``, it can help to set this
     to true so that only the part of the file that is needed for the current time step is loaded into
     memory, instead of reading the full file upfront. For small files or when using an adaptive timestep,
     this could lead to additional overhead.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -470,6 +470,10 @@ When both are specified, the per-species value is used.
 
 * ``<plasma name> or plasmas.read_density_from_path`` (`string`) optional (default "")
     Alternative to ``<plasma name>.density(x,y,z)``. Specify the path to an openPMD file that contains the species' number density for each location of the simulation. Both geometries (Cartesian ``xyz`` and Cylindrical ``rz`` + modes)  are supported, however not all dimensions need to be included. The mesh in the file can be chosen with ``<plasma name> or plasmas.density_mesh_name`` (default ``density``) and must contain a single ``SCALAR`` component. Examples of scripts to generate such files can be found in ``tools/write_plasma_density.py`` and ``tools/write_plasma_density_rz.py``.
+    When loading large 3D density profiles, it can help to set ``<plasma name> or plasmas.read_density_per_slice``
+    to true so that only the part of the file that is needed for the current time step is loaded into
+    memory, instead of reading the full file upfront. For small files or when using an adaptive timestep,
+    this could lead to additional overhead.
 
 * ``<plasma name> or plasmas.ppc`` (2 `integer`)
     The number of plasma particles per cell in x and y.

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -238,7 +238,7 @@ public:
     std::shared_ptr<double> m_d_density_data; /**< owns data for m_density_func */
     PlasmaDensityAccessor m_density_func; /**< Density function for the plasma */
     amrex::Real m_min_density {0.}; /**< minimal density at which particles are injected */
-    bool m_density_func_specified; /**< if a density value from file was specified */
+    bool m_density_file_specified; /**< if a density value from file was specified */
     std::string m_density_path = ""; /**< path of plasma density file */
     std::string m_density_mesh_name = "density"; /**< name of mesh for density from file */
     bool m_use_density_table; /**< if a density value table was specified */

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -240,6 +240,7 @@ public:
     amrex::Real m_min_density {0.}; /**< minimal density at which particles are injected */
     bool m_density_file_specified; /**< if a density value from file was specified */
     std::string m_density_path = ""; /**< path of plasma density file */
+    bool m_read_density_per_slice = false; /**< if the density from file should be loaded per-slice */
     std::string m_density_mesh_name = "density"; /**< name of mesh for density from file */
     bool m_use_density_table; /**< if a density value table was specified */
     /** plasma density value table, key: position=c*time, value=density function string */

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -238,6 +238,9 @@ public:
     std::shared_ptr<double> m_d_density_data; /**< owns data for m_density_func */
     PlasmaDensityAccessor m_density_func; /**< Density function for the plasma */
     amrex::Real m_min_density {0.}; /**< minimal density at which particles are injected */
+    bool m_density_func_specified; /**< if a density value from file was specified */
+    std::string m_density_path = ""; /**< path of plasma density file */
+    std::string m_density_mesh_name = "density"; /**< name of mesh for density from file */
     bool m_use_density_table; /**< if a density value table was specified */
     /** plasma density value table, key: position=c*time, value=density function string */
     std::map<amrex::Real, std::string> m_density_table;

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -98,14 +98,14 @@ PlasmaParticleContainer::ReadParameters ()
                     "density(x,y,z) = <density> * (1 + <parabolic_curvature>*(x^2 + y^2) )" );
 
     std::string density_func_str = "0.";
-    m_density_func_specified = queryWithParserAlt(pp, "density(x,y,z)", density_func_str, pp_alt);
-    if (m_density_func_specified) {
+    bool density_func_specified = queryWithParserAlt(pp, "density(x,y,z)", density_func_str, pp_alt);
+    if (density_func_specified) {
         m_density_func.define_parser(
             makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"}));
     }
 
-    bool density_file_specified = queryWithParserAlt(pp, "read_density_from_path", m_density_path, pp_alt);
-    if (density_file_specified) {
+    m_density_file_specified = queryWithParserAlt(pp, "read_density_from_path", m_density_path, pp_alt);
+    if (m_density_file_specified) {
         queryWithParserAlt(pp, "density_mesh_name", m_density_mesh_name, pp_alt);
     }
 
@@ -127,7 +127,7 @@ PlasmaParticleContainer::ReadParameters ()
                                          "Unable to get any data out of 'density_table_file'");
     }
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        (int(m_density_func_specified) + int(density_file_specified) + int(m_use_density_table)) == 1,
+        (int(density_func_specified) + int(m_density_file_specified) + int(m_use_density_table)) == 1,
         "Plasma: Must specify exactly one of either 'density(x,y,z)', "
         "'read_density_from_path' or 'density_table_file'");
 
@@ -323,7 +323,7 @@ PlasmaParticleContainer::ReorderParticles (const int islice)
 void
 PlasmaParticleContainer::UpdateDensityFunction (const amrex::Real pos_z)
 {
-    if (m_density_func_specified) {
+    if (m_density_file_specified) {
         m_density_func.define_from_file(pos_z, m_density_path, m_f_density_data, m_d_density_data,
                                         m_density_mesh_name);
     } else if (m_use_density_table) {

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -98,19 +98,15 @@ PlasmaParticleContainer::ReadParameters ()
                     "density(x,y,z) = <density> * (1 + <parabolic_curvature>*(x^2 + y^2) )" );
 
     std::string density_func_str = "0.";
-    bool density_func_specified = queryWithParserAlt(pp, "density(x,y,z)", density_func_str, pp_alt);
-    if (density_func_specified) {
+    m_density_func_specified = queryWithParserAlt(pp, "density(x,y,z)", density_func_str, pp_alt);
+    if (m_density_func_specified) {
         m_density_func.define_parser(
             makeFunctionWithParser<3>(density_func_str, m_parser, {"x", "y", "z"}));
     }
 
-    std::string density_path = "";
-    bool density_file_specified = queryWithParserAlt(pp, "read_density_from_path", density_path, pp_alt);
+    bool density_file_specified = queryWithParserAlt(pp, "read_density_from_path", m_density_path, pp_alt);
     if (density_file_specified) {
-        std::string density_mesh_name = "density";
-        queryWithParserAlt(pp, "density_mesh_name", density_mesh_name, pp_alt);
-        m_density_func.define_from_file(density_path, m_f_density_data, m_d_density_data,
-                                        density_mesh_name);
+        queryWithParserAlt(pp, "density_mesh_name", m_density_mesh_name, pp_alt);
     }
 
     std::string density_table_file_name{};
@@ -131,7 +127,7 @@ PlasmaParticleContainer::ReadParameters ()
                                          "Unable to get any data out of 'density_table_file'");
     }
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-        (int(density_func_specified) + int(density_file_specified) + int(m_use_density_table)) == 1,
+        (int(m_density_func_specified) + int(density_file_specified) + int(m_use_density_table)) == 1,
         "Plasma: Must specify exactly one of either 'density(x,y,z)', "
         "'read_density_from_path' or 'density_table_file'");
 
@@ -327,11 +323,15 @@ PlasmaParticleContainer::ReorderParticles (const int islice)
 void
 PlasmaParticleContainer::UpdateDensityFunction (const amrex::Real pos_z)
 {
-    if (!m_use_density_table) return;
-    auto iter = m_density_table.lower_bound(pos_z);
-    if (iter == m_density_table.end()) --iter;
-    m_density_func.define_parser(
-        makeFunctionWithParser<3>(iter->second, m_parser, {"x", "y", "z"}));
+    if (m_density_func_specified) {
+        m_density_func.define_from_file(pos_z, m_density_path, m_f_density_data, m_d_density_data,
+                                        m_density_mesh_name);
+    } else if (m_use_density_table) {
+        auto iter = m_density_table.lower_bound(pos_z);
+        if (iter == m_density_table.end()) --iter;
+        m_density_func.define_parser(
+            makeFunctionWithParser<3>(iter->second, m_parser, {"x", "y", "z"}));
+    }
 }
 
 void

--- a/src/particles/plasma/PlasmaParticleContainer.cpp
+++ b/src/particles/plasma/PlasmaParticleContainer.cpp
@@ -106,7 +106,12 @@ PlasmaParticleContainer::ReadParameters ()
 
     m_density_file_specified = queryWithParserAlt(pp, "read_density_from_path", m_density_path, pp_alt);
     if (m_density_file_specified) {
+        queryWithParserAlt(pp, "read_density_per_slice", m_read_density_per_slice, pp_alt);
         queryWithParserAlt(pp, "density_mesh_name", m_density_mesh_name, pp_alt);
+        if (!m_read_density_per_slice) {
+            m_density_func.define_from_file(0, false, m_density_path, m_f_density_data,
+                                            m_d_density_data, m_density_mesh_name);
+        }
     }
 
     std::string density_table_file_name{};
@@ -323,9 +328,9 @@ PlasmaParticleContainer::ReorderParticles (const int islice)
 void
 PlasmaParticleContainer::UpdateDensityFunction (const amrex::Real pos_z)
 {
-    if (m_density_file_specified) {
-        m_density_func.define_from_file(pos_z, m_density_path, m_f_density_data, m_d_density_data,
-                                        m_density_mesh_name);
+    if (m_density_file_specified && m_read_density_per_slice) {
+        m_density_func.define_from_file(pos_z, true, m_density_path, m_f_density_data,
+                                        m_d_density_data, m_density_mesh_name);
     } else if (m_use_density_table) {
         auto iter = m_density_table.lower_bound(pos_z);
         if (iter == m_density_table.end()) --iter;

--- a/src/particles/profiles/GetInitialDensity.H
+++ b/src/particles/profiles/GetInitialDensity.H
@@ -137,7 +137,7 @@ struct PlasmaDensityAccessor {
 
     void define_parser (const amrex::ParserExecutor<3>& exe);
 
-    void define_from_file (const amrex::Real z_pos,
+    void define_from_file (const amrex::Real z_pos, bool per_slice,
                            const std::string& path, std::shared_ptr<float>& f_data,
                            std::shared_ptr<double>& d_data,
                            const std::string& density_mesh_name);

--- a/src/particles/profiles/GetInitialDensity.H
+++ b/src/particles/profiles/GetInitialDensity.H
@@ -137,7 +137,8 @@ struct PlasmaDensityAccessor {
 
     void define_parser (const amrex::ParserExecutor<3>& exe);
 
-    void define_from_file (const std::string& path, std::shared_ptr<float>& f_data,
+    void define_from_file (const amrex::Real z_pos,
+                           const std::string& path, std::shared_ptr<float>& f_data,
                            std::shared_ptr<double>& d_data,
                            const std::string& density_mesh_name);
 };

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -143,8 +143,8 @@ PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
         constexpr int interp_order = 2;
         auto [sz, k] = shape_factor<interp_order>(zmid, 0);
 
-        int k_lo = std::max(0, std::min(extent[z_idx_extent]-1, k));
-        int k_hi = std::max(0, std::min(extent[z_idx_extent]-1, k + interp_order + 1));
+        int k_lo = std::max(0, std::min(static_cast<int>(extent[z_idx_extent])-1, k));
+        int k_hi = std::max(0, std::min(static_cast<int>(extent[z_idx_extent])-1, k + interp_order + 1));
         file_read_offset[z_idx_extent] = k_lo;
         file_read_extent[z_idx_extent] = k_hi - k_lo + 1;
         extent[z_idx_extent] = file_read_extent[z_idx_extent];

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -46,7 +46,8 @@ PlasmaDensityAccessor::define_parser (const amrex::ParserExecutor<3>& exe) {
 }
 
 void
-PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_ptr<float>& f_data,
+PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
+                                         const std::string& path, std::shared_ptr<float>& f_data,
                                          std::shared_ptr<double>& d_data,
                                          const std::string& density_mesh_name) {
 #ifdef HIPACE_USE_OPENPMD
@@ -72,21 +73,10 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
 
     auto comp = mesh[openPMD::RecordComponent::SCALAR];
 
-    auto extent = comp.getExtent();
-    auto strides = extent;
-
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         mesh.dataOrder() == openPMD::Mesh::DataOrder::C,
         "Must use DataOrder::C in file " + path + "\n"
     );
-
-    for (int i=static_cast<int>(strides.size())-1; i>=0; --i) {
-        if (i == static_cast<int>(strides.size())-1) {
-            strides[i] = 1;
-        } else {
-            strides[i] = strides[i+1] * extent[i+1];
-        }
-    }
 
     const std::vector<std::string> axis_labels = mesh.axisLabels();
     std::map<std::string, int> axis_labels_map;
@@ -95,6 +85,7 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
         axis_labels_map[axis_labels[i]] = i;
     }
 
+    auto extent = comp.getExtent();
     std::vector<double> offset = mesh.gridGlobalOffset();
     std::vector<double> position = comp.position<double>();
     std::vector<double> spacing = mesh.gridSpacing<double>();
@@ -102,8 +93,6 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
     amrex::IntVect idx_perm;
 
     bool use_mode = false;
-    std::uint64_t mode_stride = 0;
-    std::uint64_t mode_bigend = 0;
 
     if (mesh.geometry() == openPMD::Mesh::Geometry::cartesian) {
         m_profile_type = 1;
@@ -121,10 +110,6 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
 
         if (axis_labels_map.size() + 1 == extent.size()) {
             use_mode = true;
-            mode_stride = strides[0];
-            mode_bigend = extent[0] - 1;
-            extent.erase(extent.begin());
-            strides.erase(strides.begin());
         }
 
         idx_perm[0] = axis_labels_map.count("r") > 0 ? axis_labels_map["r"] : -1;
@@ -142,17 +127,51 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
         "Unknown Axis label, must be subset of xyz or rz in file " + path + "\n"
     );
 
+    openPMD::Offset file_read_offset(extent.size(), 0);
+    openPMD::Extent file_read_extent = extent;
+
+    const int z_index = mesh.geometry() == openPMD::Mesh::Geometry::cartesian ? 2 : 1;
+    if (idx_perm[z_index] != -1) {
+        const int z_idx_file = idx_perm[z_index];
+        const int z_idx_extent = idx_perm[z_index] + use_mode ? 1 : 0;
+
+        const amrex::Real pos_offset = static_cast<amrex::Real>(
+            offset[z_idx_file] + spacing[z_idx_file] * position[z_idx_file]);
+        const amrex::Real dz_inv = static_cast<amrex::Real>(1. / spacing[z_idx_file]);
+        const amrex::Real zmid = (z_pos - pos_offset) * dz_inv;
+
+        constexpr int interp_order = 2;
+        auto [sz, k] = shape_factor<interp_order>(zmid, 0);
+
+        int k_lo = std::max(0, std::min(extent[z_idx_extent]-1, k));
+        int k_hi = std::max(0, std::min(extent[z_idx_extent]-1, k + interp_order + 1));
+        file_read_offset[z_idx_extent] = k_lo;
+        file_read_extent[z_idx_extent] = k_hi - k_lo + 1;
+        extent[z_idx_extent] = file_read_extent[z_idx_extent];
+    }
+
+    auto strides = extent;
+    for (int i=static_cast<int>(strides.size())-1; i>=0; --i) {
+        if (i == static_cast<int>(strides.size())-1) {
+            strides[i] = 1;
+        } else {
+            strides[i] = strides[i+1] * extent[i+1];
+        }
+    }
+
+    if (use_mode) {
+        m_strides[2] = strides[0];
+        m_bigend[2] = extent[0] - 1;
+        extent.erase(extent.begin());
+        strides.erase(strides.begin());
+    }
+
     for (int i=0; i<3; ++i) {
         m_strides[i] = idx_perm[i] != -1 ? strides[idx_perm[i]] : 0;
         m_bigend[i] = idx_perm[i] != -1 ? extent[idx_perm[i]] - 1 : 0;
         m_pos_offset[i] = idx_perm[i] != -1 ? static_cast<amrex::Real>(
             offset[idx_perm[i]] + spacing[idx_perm[i]] * position[idx_perm[i]]) : 0;
         m_dx_inv[i] = idx_perm[i] != -1 ? static_cast<amrex::Real>(1. / spacing[idx_perm[i]]) : 0;
-    }
-
-    if (use_mode) {
-        m_strides[2] = mode_stride;
-        m_bigend[2] = mode_bigend;
     }
 
     m_unitSI = static_cast<amrex::Real>(comp.unitSI());
@@ -170,7 +189,7 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
             reinterpret_cast<float*>(amrex::The_Managed_Arena()->alloc(num_cells*sizeof(float))),
             [](float *p){ amrex::The_Managed_Arena()->free(reinterpret_cast<void*>(p)); });
 
-        comp.loadChunk(f_data, {0u}, {-1u});
+        comp.loadChunk(f_data, file_read_offset, file_read_extent);
 
         m_f_ptr = f_data.get();
 
@@ -182,7 +201,7 @@ PlasmaDensityAccessor::define_from_file (const std::string& path, std::shared_pt
             reinterpret_cast<double*>(amrex::The_Managed_Arena()->alloc(num_cells*sizeof(double))),
             [](double *p){ amrex::The_Managed_Arena()->free(reinterpret_cast<void*>(p)); });
 
-        comp.loadChunk(d_data, {0u}, {-1u});
+        comp.loadChunk(d_data, file_read_offset, file_read_extent);
 
         m_d_ptr = d_data.get();
 

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -159,19 +159,28 @@ PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
         }
     }
 
+    std::uint64_t mode_stride = 0;
+    std::uint64_t mode_bigend = 0;
+    openPMD::Offset idx_offset = file_read_offset;
     if (use_mode) {
-        m_strides[2] = strides[0];
-        m_bigend[2] = extent[0] - 1;
+        mode_stride = strides[0];
+        mode_bigend = extent[0] - 1;
         extent.erase(extent.begin());
         strides.erase(strides.begin());
+        idx_offset.erase(idx_offset.begin());
     }
 
     for (int i=0; i<3; ++i) {
         m_strides[i] = idx_perm[i] != -1 ? strides[idx_perm[i]] : 0;
         m_bigend[i] = idx_perm[i] != -1 ? extent[idx_perm[i]] - 1 : 0;
-        m_pos_offset[i] = idx_perm[i] != -1 ? static_cast<amrex::Real>(
-            offset[idx_perm[i]] + spacing[idx_perm[i]] * position[idx_perm[i]]) : 0;
+        m_pos_offset[i] = idx_perm[i] != -1 ? static_cast<amrex::Real>(offset[idx_perm[i]] +
+            spacing[idx_perm[i]] * (position[idx_perm[i]] + idx_offset[idx_perm[i]])) : 0;
         m_dx_inv[i] = idx_perm[i] != -1 ? static_cast<amrex::Real>(1. / spacing[idx_perm[i]]) : 0;
+    }
+
+    if (use_mode) {
+        m_strides[2] = mode_stride;
+        m_bigend[2] = mode_bigend;
     }
 
     m_unitSI = static_cast<amrex::Real>(comp.unitSI());

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -133,7 +133,7 @@ PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
     const int z_index = mesh.geometry() == openPMD::Mesh::Geometry::cartesian ? 2 : 1;
     if (idx_perm[z_index] != -1) {
         const int z_idx_file = idx_perm[z_index];
-        const int z_idx_extent = idx_perm[z_index] + use_mode ? 1 : 0;
+        const int z_idx_extent = idx_perm[z_index] + (use_mode ? 1 : 0);
 
         const amrex::Real pos_offset = static_cast<amrex::Real>(
             offset[z_idx_file] + spacing[z_idx_file] * position[z_idx_file]);

--- a/src/particles/profiles/GetInitialDensity.cpp
+++ b/src/particles/profiles/GetInitialDensity.cpp
@@ -46,7 +46,7 @@ PlasmaDensityAccessor::define_parser (const amrex::ParserExecutor<3>& exe) {
 }
 
 void
-PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
+PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos, bool per_slice,
                                          const std::string& path, std::shared_ptr<float>& f_data,
                                          std::shared_ptr<double>& d_data,
                                          const std::string& density_mesh_name) {
@@ -131,7 +131,7 @@ PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
     openPMD::Extent file_read_extent = extent;
 
     const int z_index = mesh.geometry() == openPMD::Mesh::Geometry::cartesian ? 2 : 1;
-    if (idx_perm[z_index] != -1) {
+    if (per_slice && idx_perm[z_index] != -1) {
         const int z_idx_file = idx_perm[z_index];
         const int z_idx_extent = idx_perm[z_index] + (use_mode ? 1 : 0);
 
@@ -144,7 +144,8 @@ PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
         auto [sz, k] = shape_factor<interp_order>(zmid, 0);
 
         int k_lo = std::max(0, std::min(static_cast<int>(extent[z_idx_extent])-1, k));
-        int k_hi = std::max(0, std::min(static_cast<int>(extent[z_idx_extent])-1, k + interp_order + 1));
+        int k_hi = std::max(0, std::min(static_cast<int>(extent[z_idx_extent])-1,
+            k + interp_order + 1));
         file_read_offset[z_idx_extent] = k_lo;
         file_read_extent[z_idx_extent] = k_hi - k_lo + 1;
         extent[z_idx_extent] = file_read_extent[z_idx_extent];
@@ -194,6 +195,7 @@ PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
 
     if (input_type == openPMD::Datatype::FLOAT) {
 
+        f_data.reset();
         f_data.reset(
             reinterpret_cast<float*>(amrex::The_Managed_Arena()->alloc(num_cells*sizeof(float))),
             [](float *p){ amrex::The_Managed_Arena()->free(reinterpret_cast<void*>(p)); });
@@ -206,6 +208,7 @@ PlasmaDensityAccessor::define_from_file (const amrex::Real z_pos,
 
         m_profile_type += 1;
 
+        d_data.reset();
         d_data.reset(
             reinterpret_cast<double*>(amrex::The_Managed_Arena()->alloc(num_cells*sizeof(double))),
             [](double *p){ amrex::The_Managed_Arena()->free(reinterpret_cast<void*>(p)); });


### PR DESCRIPTION
Read plasma density file only on the slice where it is currently needed. This is much faster for large files but potentially slower for small ones and possibly really slow with adaptive timestep that reads the density in advance.