### PR TITLE
Add option to load a beam from file with a position offset

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -883,6 +883,9 @@ Option: ``from_file``
     Whether to initialize the beam on the CPU instead of the GPU.
     Initializing the beam on the CPU can be much slower but is necessary if the full beam does not fit into GPU memory.
 
+* ``<beam name> or beams.position_offset`` (3 `float`) optional (default `0 0 0`)
+    Add an offset to the position of all beam particles.
+
 Option: ``from_list``
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/particles/beam/BeamParticleContainer.H
+++ b/src/particles/beam/BeamParticleContainer.H
@@ -304,6 +304,7 @@ private:
     amrex::Array<std::string, AMREX_SPACEDIM> m_file_coordinates_xyz;
     int m_num_iteration {0}; /**< the iteration of the openPMD beam */
     std::string m_species_name; /**< the name of the particle species in the beam file */
+    amrex::RealVect m_position_offset {0, 0, 0}; /**< add an offset to the position of the beam */
 
     // from list
 

--- a/src/particles/beam/BeamParticleContainer.cpp
+++ b/src/particles/beam/BeamParticleContainer.cpp
@@ -271,6 +271,7 @@ BeamParticleContainer::InitData (const amrex::Geometry& geom)
                                                         m_file_coordinates_xyz, pp_alt);
         queryWithParserAlt(pp, "plasma_density", m_plasma_density, pp_alt);
         queryWithParserAlt(pp, "iteration", m_num_iteration, pp_alt);
+        queryWithParserAlt(pp, "position_offset", m_position_offset, pp_alt);
         bool species_specified = queryWithParser(pp, "openPMD_species_name", m_species_name);
         if(!species_specified) {
             m_species_name = m_name;

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -1188,7 +1188,7 @@ InitBeamFromFile (const std::string input_file,
     const input_type * const s_z_ptr = m_do_spin_tracking ? s_z_data.get() : nullptr;
     const input_type * const w_w_ptr = w_w_data.get();
     const bool do_spin_tracking = m_do_spin_tracking;
-    const amrex::Real position_offset = m_position_offset;
+    const amrex::RealVect position_offset = m_position_offset;
 
     amrex::ParallelFor(amrex::Long(num_to_add),
         [=] AMREX_GPU_DEVICE (const amrex::Long i) {

--- a/src/particles/beam/BeamParticleContainerInit.cpp
+++ b/src/particles/beam/BeamParticleContainerInit.cpp
@@ -1188,13 +1188,14 @@ InitBeamFromFile (const std::string input_file,
     const input_type * const s_z_ptr = m_do_spin_tracking ? s_z_data.get() : nullptr;
     const input_type * const w_w_ptr = w_w_data.get();
     const bool do_spin_tracking = m_do_spin_tracking;
+    const amrex::Real position_offset = m_position_offset;
 
     amrex::ParallelFor(amrex::Long(num_to_add),
         [=] AMREX_GPU_DEVICE (const amrex::Long i) {
             AddOneBeamParticle(ptd,
-                static_cast<amrex::Real>(r_x_ptr[i] * unit_rx),
-                static_cast<amrex::Real>(r_y_ptr[i] * unit_ry),
-                static_cast<amrex::Real>(r_z_ptr[i] * unit_rz),
+                static_cast<amrex::Real>(r_x_ptr[i] * unit_rx) + position_offset[0],
+                static_cast<amrex::Real>(r_y_ptr[i] * unit_ry) + position_offset[1],
+                static_cast<amrex::Real>(r_z_ptr[i] * unit_rz) + position_offset[2],
                 static_cast<amrex::Real>(u_x_ptr[i] * unit_ux), // = gamma * beta
                 static_cast<amrex::Real>(u_y_ptr[i] * unit_uy),
                 static_cast<amrex::Real>(u_z_ptr[i] * unit_uz),


### PR DESCRIPTION
When using `beam.injection_type = from_file`, add an `beam.position_offset` option to be able to center the beam at 0, 0, 0 for the hipace simulation. Most useful to apply a -z offset when importing a beam from WarpX.