### PR TITLE
Implement thermal boundaries #1255

### DIFF
--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -227,6 +227,8 @@ public:
     bool m_has_last_step = false;
     /** Level of verbosity */
     inline static int m_verbose = 0;
+    /** Print interval for slice number (only for a single timestep simulation) */
+    inline static int m_print_slice_interval = 0;
     /** Relative transverse B field error tolerance in the predictor corrector loop
      */
     inline static amrex::Real m_predcorr_B_error_tolerance = 4e-2;

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -147,8 +147,9 @@ public:
 
     /**
      * \brief does Coulomb collisions between plasmas and beams
+     * \param[in] islice slice number
      */
-    void doCoulombCollision ();
+    void doCoulombCollision (int islice);
 
     /**
      * \brief add external fields to the field grid

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -339,7 +339,7 @@ public:
     /** type of boundary used for particles */
     inline static ParticleBoundary::type m_boundary_particles = ParticleBoundary::Absorbing;
     /** boundary temperature (if using Thermal particle boundaries) */
-    amrex::Real m_boundary_temperature = 0;
+    inline static amrex::Real m_boundary_temperature {0};
     /** lower bound of bounding box for the particles */
     inline static std::array<amrex::Real, 2> m_boundary_particle_lo;
     /** upper bound of bounding box for the particles */

--- a/src/Hipace.H
+++ b/src/Hipace.H
@@ -46,7 +46,8 @@ namespace ParticleBoundary {
     enum type {
         Reflecting,
         Periodic,
-        Absorbing
+        Absorbing,
+        Thermal
     };
 }
 
@@ -337,6 +338,8 @@ public:
     inline static FieldBoundary::type m_boundary_field = FieldBoundary::Dirichlet;
     /** type of boundary used for particles */
     inline static ParticleBoundary::type m_boundary_particles = ParticleBoundary::Absorbing;
+    /** boundary temperature (if using Thermal particle boundaries) */
+    amrex::Real m_boundary_temperature = 0;
     /** lower bound of bounding box for the particles */
     inline static std::array<amrex::Real, 2> m_boundary_particle_lo;
     /** upper bound of bounding box for the particles */

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -233,9 +233,12 @@ Hipace::ReadParameters ()
         m_boundary_particles = ParticleBoundary::Periodic;
     } else if (particle_boundary == "Absorbing") {
         m_boundary_particles = ParticleBoundary::Absorbing;
+    } else if (particle_boundary == "Thermal") {
+        m_boundary_particles = ParticleBoundary::Thermal;
+        queryWithParser(ppb, "temperature_in_ev", m_boundary_temperature);
     } else {
         amrex::Abort("Unknown particle boundary '" + particle_boundary +
-            "', must be 'Reflecting', 'Periodic' or 'Absorbing'");
+            "', must be 'Reflecting', 'Periodic', 'Absorbing', or 'Thermal'");
     }
 
     MakeGeometry();
@@ -1301,7 +1304,7 @@ Hipace::doCoulombCollision (int islice)
 
             // TODO: enable tiling
 
-            CoulombCollision::doBeamPlasmaCoulombCollision( islice,
+            CoulombCollision::doBeamPlasmaCoulombCollision( islice, m_all_collisions[i].m_collide_every,
                 lev, m_slice_geom[0].Domain(), m_slice_geom[0], species1, species2,
                 m_all_collisions[i].m_CoulombLog, m_background_density_SI);
         } else {

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -686,7 +686,7 @@ Hipace::SolveOneSlice (int islice, int step, bool is_first_step, bool is_last_st
     int current_N_level = 1;
 
     if (m_print_slice_interval > 0 && islice%m_print_slice_interval == 0) {
-        amrex::Print() << "On slice number: ", islice, '\n';
+        amrex::Print() << "On slice number: " << islice << '\n';
     }
 
     for (int lev=1; lev<m_N_level; ++lev) {

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -858,7 +858,7 @@ Hipace::SolveOneSlice (int islice, int step, bool is_first_step, bool is_last_st
     m_multi_beam.shiftSlippedParticles(islice, m_3D_geom[0]);
 
     // collisions for plasmas and beams
-    doCoulombCollision();
+    doCoulombCollision(islice);
 
     // get minimum beam uz after push
     m_adaptive_time_step.GatherMinUzSlice(m_multi_beam, false);
@@ -1286,7 +1286,7 @@ Hipace::AddGridExternalFields (const int lev, const int islice)
 }
 
 void
-Hipace::doCoulombCollision ()
+Hipace::doCoulombCollision (int islice)
 {
 
     // collisions for all particles calculated on level 0
@@ -1301,7 +1301,7 @@ Hipace::doCoulombCollision ()
 
             // TODO: enable tiling
 
-            CoulombCollision::doBeamPlasmaCoulombCollision(
+            CoulombCollision::doBeamPlasmaCoulombCollision( islice,
                 lev, m_slice_geom[0].Domain(), m_slice_geom[0], species1, species2,
                 m_all_collisions[i].m_CoulombLog, m_background_density_SI);
         } else {
@@ -1311,7 +1311,7 @@ Hipace::doCoulombCollision ()
 
             // TODO: enable tiling
 
-            CoulombCollision::doPlasmaPlasmaCoulombCollision(
+            CoulombCollision::doPlasmaPlasmaCoulombCollision( islice, m_all_collisions[i].m_collide_every,
                 lev, m_slice_geom[0].Domain(), m_slice_geom[0], species1, species2, m_all_collisions[i].m_isSameSpecies,
                 m_all_collisions[i].m_CoulombLog, m_background_density_SI);
         }

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -118,6 +118,7 @@ Hipace::ReadParameters ()
     }
     queryWithParser(pph, "max_time", m_max_time);
     queryWithParser(pph, "verbose", m_verbose);
+    queryWithParser(pph, "print_slice_interval", m_print_slice_interval);
     m_numprocs = amrex::ParallelDescriptor::NProcs();
     if (m_ignore_noncritical_warnings) {
         if (m_numprocs > m_max_step + 1 && amrex::ParallelDescriptor::IOProcessor()) {
@@ -683,6 +684,10 @@ Hipace::SolveOneSlice (int islice, int step, bool is_first_step, bool is_last_st
     HIPACE_PROFILE("Hipace::SolveOneSlice()");
 
     int current_N_level = 1;
+
+    if (m_print_slice_interval > 0 && islice%m_print_slice_interval == 0) {
+        amrex::Print() << "On slice number: ", islice, '\n';
+    }
 
     for (int lev=1; lev<m_N_level; ++lev) {
         if (m_3D_geom[lev].Domain().smallEnd(Direction::z) <= islice &&

--- a/src/diagnostics/Diagnostic.cpp
+++ b/src/diagnostics/Diagnostic.cpp
@@ -696,7 +696,7 @@ Diagnostic::FillBoundaryHistDiagnostics (int islice, MultiPlasma& plasmas, Multi
             islice > 0 &&
             fd.m_hist_exit_boundary)
         {
-            // particles where already pushed so they are on the next slice now
+            // particles were already pushed so they are on the next slice now
             HistogramDepositionCopy(fd, islice - 1, plasmas, beams, field_geom);
             species_names_with_boundary_hist.insert(
                 fd.m_hist_species_names.begin(), fd.m_hist_species_names.end());

--- a/src/particles/collisions/CoulombCollision.H
+++ b/src/particles/collisions/CoulombCollision.H
@@ -20,6 +20,7 @@ public:
     int  m_nbeams {0};
     bool m_isSameSpecies {false};
     amrex::Real m_CoulombLog {-1.};
+    int  m_collide_every {1};
 
     /** Read parameters from the input file */
     void ReadParameters (
@@ -31,6 +32,8 @@ public:
      * \brief Perform Coulomb collisions of plasma species over longitudinal push by 1 cell.
      *        Particles of both species are sorted per cell, paired, and collided pairwise.
      *
+     * \param[in] islice current slice number
+     * \param[in] collide_every interval between collision calculations
      * \param[in] lev MR level
      * \param[in] bx transverse box (plasma particles will be sorted per-cell on this box)
      * \param[in] geom corresponding geometry object
@@ -41,7 +44,7 @@ public:
      *            Coulomb logarithm is deduced from the plasma temperature, measured in each cell.
      * \param[in] background_density_SI background plasma density (only needed for normalized units)
      **/
-    static void doPlasmaPlasmaCoulombCollision (
+    static void doPlasmaPlasmaCoulombCollision ( int islice, int collide_every,
         int lev, const amrex::Box& bx, const amrex::Geometry& geom, PlasmaParticleContainer& species1,
         PlasmaParticleContainer& species2, bool is_same_species, amrex::Real CoulombLog,
         amrex::Real background_density_SI);
@@ -50,6 +53,7 @@ public:
      * \brief Perform Coulomb collisions of a beam with a plasma species over a push by one beam time step
      *        Particles of both species are sorted per cell, paired, and collided pairwise.
      *
+     * \param[in] islice current slice number
      * \param[in] lev MR level
      * \param[in] bx transverse box (plasma particles will be sorted per-cell on this box)
      * \param[in] geom corresponding geometry object
@@ -59,7 +63,7 @@ public:
      *            Coulomb logarithm is deduced from the plasma temperature, measured in each cell.
      * \param[in] background_density_SI background plasma density (only needed for normalized units)
      **/
-    static void doBeamPlasmaCoulombCollision (
+    static void doBeamPlasmaCoulombCollision ( int islice,
         int lev, const amrex::Box& bx, const amrex::Geometry& geom,
         BeamParticleContainer& species1, PlasmaParticleContainer& species2, amrex::Real CoulombLog,
         amrex::Real background_density_SI);

--- a/src/particles/collisions/CoulombCollision.H
+++ b/src/particles/collisions/CoulombCollision.H
@@ -63,7 +63,7 @@ public:
      *            Coulomb logarithm is deduced from the plasma temperature, measured in each cell.
      * \param[in] background_density_SI background plasma density (only needed for normalized units)
      **/
-    static void doBeamPlasmaCoulombCollision ( int islice,
+    static void doBeamPlasmaCoulombCollision ( int islice, int collide_every,
         int lev, const amrex::Box& bx, const amrex::Geometry& geom,
         BeamParticleContainer& species1, PlasmaParticleContainer& species2, amrex::Real CoulombLog,
         amrex::Real background_density_SI);

--- a/src/particles/collisions/CoulombCollision.cpp
+++ b/src/particles/collisions/CoulombCollision.cpp
@@ -65,186 +65,190 @@ CoulombCollision::doPlasmaPlasmaCoulombCollision ( int islice, int collide_every
     PlasmaParticleContainer& species2, bool is_same_species, amrex::Real CoulombLog,
     amrex::Real background_density_SI)
 {
-    if (islice%collide_every == 0){
-        HIPACE_PROFILE("CoulombCollision::doCoulombCollision()");
-        AMREX_ALWAYS_ASSERT(lev == 0);
+    if (islice%collide_every != 0) {
+        return;
+    }
+    HIPACE_PROFILE("CoulombCollision::doCoulombCollision()");
+    AMREX_ALWAYS_ASSERT(lev == 0);
 
-        if (species1.TotalNumberOfParticles(false, true) == 0 ||
-            species2.TotalNumberOfParticles(false, true) == 0) return;
+    if (species1.TotalNumberOfParticles(false, true) == 0 ||
+        species2.TotalNumberOfParticles(false, true) == 0) return;
 
-        using namespace amrex::literals;
-        const PhysConst cst = get_phys_const();
-        bool normalized_units = Hipace::m_normalized_units;
+    using namespace amrex::literals;
+    const PhysConst cst = get_phys_const();
+    bool normalized_units = Hipace::m_normalized_units;
 
-        const amrex::Real clight = cst.c;
-        constexpr amrex::Real inv_c_SI = 1.0_rt / PhysConstSI::c;
-        constexpr amrex::Real inv_c2_SI = 1.0_rt / ( PhysConstSI::c * PhysConstSI::c );
+    const amrex::Real clight = cst.c;
+    constexpr amrex::Real inv_c_SI = 1.0_rt / PhysConstSI::c;
+    constexpr amrex::Real inv_c2_SI = 1.0_rt / ( PhysConstSI::c * PhysConstSI::c );
 
-        if ( is_same_species ) // species_1 == species_2
-        {
-            // Logically particles per-cell, and return indices of particles in each cell
-            PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
-            int const n_cells = bins1.numBins();
+    if ( is_same_species ) // species_1 == species_2
+    {
+        // Logically particles per-cell, and return indices of particles in each cell
+        PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
+        int const n_cells = bins1.numBins();
 
-            // Counter to check there is only 1 box
-            int count = 0;
-            for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
+        // Counter to check there is only 1 box
+        int count = 0;
+        for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
 
-                // Get particles SoA data
-                auto& ptile1 = pti.GetParticleTile();
-                amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
-                amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
-                amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
-                const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
-                const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
-                PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
-                PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
-                amrex::Real q1 = species1.GetCharge();
-                amrex::Real m1 = species1.GetMass();
-                const bool can_ionize1 = species1.m_can_ionize;
+            // Get particles SoA data
+            auto& ptile1 = pti.GetParticleTile();
+            amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
+            amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
+            amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
+            const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
+            const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
+            PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
+            PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
+            amrex::Real q1 = species1.GetCharge();
+            amrex::Real m1 = species1.GetMass();
+            const bool can_ionize1 = species1.m_can_ionize;
 
-                // volume is used to calculate density, but weights already represent density in normalized units
-                const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
-                // static_cast<double> to avoid precision problems in FP32
-                const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
-                                                PhysConstSI::q_e*PhysConstSI::q_e /
-                                                (PhysConstSI::ep0*PhysConstSI::m_e));
-                amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
-                                                        : geom.CellSize(2)/PhysConstSI::c;
-                dt = dt * collide_every;
+            // volume is used to calculate density, but weights already represent density in normalized units
+            const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
+            // static_cast<double> to avoid precision problems in FP32
+            const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
+                                            PhysConstSI::q_e*PhysConstSI::q_e /
+                                            (PhysConstSI::ep0*PhysConstSI::m_e));
+            amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
+                                                    : geom.CellSize(2)/PhysConstSI::c;
+            dt = dt * collide_every;
 
-                amrex::ParallelForRNG(
-                    n_cells,
-                    [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
-                    {
-                        // The particles from species1 that are in the cell `i_cell` are
-                        // given by the `indices_1[cell_start_1:cell_stop_1]`
-                        PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
-                        PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
-                        PlasmaBins::index_type const cell_half1 = (cell_start1+cell_stop1)/2;
+            amrex::ParallelForRNG(
+                n_cells,
+                [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
+                {
+                    // The particles from species1 that are in the cell `i_cell` are
+                    // given by the `indices_1[cell_start_1:cell_stop_1]`
+                    PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
+                    PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
+                    PlasmaBins::index_type const cell_half1 = (cell_start1+cell_stop1)/2;
 
-                        if ( cell_stop1 - cell_start1 <= 1 ) return;
-                        // Do not collide if there is only one particle in the cell
-                        // shuffle
-                        ShuffleFisherYates(
-                            indices1, cell_start1, cell_half1, engine );
+                    if ( cell_stop1 - cell_start1 <= 1 ) return;
+                    // Do not collide if there is only one particle in the cell
+                    // shuffle
+                    ShuffleFisherYates(
+                        indices1, cell_start1, cell_half1, engine );
 
-                        // TODO: FIX DT
-                        // Call the function in order to perform collisions
-                        ElasticCollisionPerez(
-                            cell_start1, cell_half1,
-                            cell_half1, cell_stop1,
-                            indices1, indices1,
-                            ux1, uy1, psi1, ux1, uy1, psi1, w1, w1, ion_lev1, ion_lev1,
-                            q1, q1, m1, m1, -1.0_rt, -1.0_rt, can_ionize1, can_ionize1,
-                            dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
-                            normalized_units, background_density_SI, is_same_species, false, engine );
-                    }
-                    );
-                count++;
-            }
-            AMREX_ALWAYS_ASSERT(count == 1);
-
-        } else {
-
-            // Logically particles per-cell, and return indices of particles in each cell
-            PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
-            PlasmaBins bins2 = findParticlesInEachTile(bx, 1, species2, geom);
-
-            int const n_cells = bins1.numBins();
-
-            // Counter to check there is only 1 box
-            int count = 0;
-            for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
-
-                // Get particles SoA data for species 1
-                auto& ptile1 = pti.GetParticleTile();
-                amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
-                amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
-                amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
-                const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
-                const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
-                PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
-                PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
-                amrex::Real q1 = species1.GetCharge();
-                amrex::Real m1 = species1.GetMass();
-                const bool can_ionize1 = species1.m_can_ionize;
-
-                // Get particles SoA data for species 2
-                auto& ptile2 = species2.ParticlesAt(lev, pti.index(), pti.LocalTileIndex());
-                amrex::Real* const ux2 = ptile2.GetRealData(PlasmaIdx::ux_half_step).data();
-                amrex::Real* const uy2 = ptile2.GetRealData(PlasmaIdx::uy_half_step).data();
-                amrex::Real* const psi2= ptile2.GetRealData(PlasmaIdx::psi_half_step).data();
-                const amrex::Real* const w2 = ptile2.GetRealData(PlasmaIdx::w).data();
-                const int* const ion_lev2 = ptile2.GetIntData(PlasmaIdx::ion_lev).data();
-                PlasmaBins::index_type * const indices2 = bins2.permutationPtr();
-                PlasmaBins::index_type const * const offsets2 = bins2.offsetsPtr();
-                amrex::Real q2 = species2.GetCharge();
-                amrex::Real m2 = species2.GetMass();
-                const bool can_ionize2 = species2.m_can_ionize;
-
-                // volume is used to calculate density, but weights already represent density in normalized units
-                const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
-                // static_cast<double> to avoid precision problems in FP32
-                const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
-                                                PhysConstSI::q_e*PhysConstSI::q_e /
-                                                (PhysConstSI::ep0*PhysConstSI::m_e));
-                amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
-                                                        : geom.CellSize(2)/PhysConstSI::c;
-                dt = dt * collide_every;
-                // Extract particles in the tile that `mfi` points to
-                // ParticleTileType& ptile_1 = species_1->ParticlesAt(lev, mfi);
-                // ParticleTileType& ptile_2 = species_2->ParticlesAt(lev, mfi);
-                // Loop over cells, and collide the particles in each cell
-
-                // Loop over cells
-                amrex::ParallelForRNG(
-                    n_cells,
-                    [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
-                    {
-                        // The particles from species1 that are in the cell `i_cell` are
-                        // given by the `indices_1[cell_start_1:cell_stop_1]`
-                        PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
-                        PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
-                        // Same for species 2
-                        PlasmaBins::index_type const cell_start2 = offsets2[i_cell];
-                        PlasmaBins::index_type const cell_stop2  = offsets2[i_cell+1];
-
-                        // ux from species1 can be accessed like this:
-                        // ux_1[ indices_1[i] ], where i is between
-                        // cell_start_1 (inclusive) and cell_start_2 (exclusive)
-
-                        // Do not collide if one species is missing in the cell
-                        if ( cell_stop1 - cell_start1 < 1 ||
-                            cell_stop2 - cell_start2 < 1 ) return;
-                        // shuffle
-                        ShuffleFisherYates(indices1, cell_start1, cell_stop1, engine);
-                        ShuffleFisherYates(indices2, cell_start2, cell_stop2, engine);
-
-                        // TODO: FIX DT.
-                        // Call the function in order to perform collisions
-                        ElasticCollisionPerez(
-                            cell_start1, cell_stop1, cell_start2, cell_stop2,
-                            indices1, indices2,
-                            ux1, uy1, psi1, ux2, uy2, psi2, w1, w2, ion_lev1, ion_lev2,
-                            q1, q2, m1, m2, -1.0_rt, -1.0_rt, can_ionize1, can_ionize2,
-                            dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
-                            normalized_units, background_density_SI, is_same_species, false, engine );
-                    }
-                    );
-                count++;
-            }
-            AMREX_ALWAYS_ASSERT(count == 1);
+                    // TODO: FIX DT
+                    // Call the function in order to perform collisions
+                    ElasticCollisionPerez(
+                        cell_start1, cell_half1,
+                        cell_half1, cell_stop1,
+                        indices1, indices1,
+                        ux1, uy1, psi1, ux1, uy1, psi1, w1, w1, ion_lev1, ion_lev1,
+                        q1, q1, m1, m1, -1.0_rt, -1.0_rt, can_ionize1, can_ionize1,
+                        dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
+                        normalized_units, background_density_SI, is_same_species, false, engine );
+                }
+                );
+            count++;
         }
+        AMREX_ALWAYS_ASSERT(count == 1);
+
+    } else {
+
+        // Logically particles per-cell, and return indices of particles in each cell
+        PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
+        PlasmaBins bins2 = findParticlesInEachTile(bx, 1, species2, geom);
+
+        int const n_cells = bins1.numBins();
+
+        // Counter to check there is only 1 box
+        int count = 0;
+        for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
+
+            // Get particles SoA data for species 1
+            auto& ptile1 = pti.GetParticleTile();
+            amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
+            amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
+            amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
+            const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
+            const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
+            PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
+            PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
+            amrex::Real q1 = species1.GetCharge();
+            amrex::Real m1 = species1.GetMass();
+            const bool can_ionize1 = species1.m_can_ionize;
+
+            // Get particles SoA data for species 2
+            auto& ptile2 = species2.ParticlesAt(lev, pti.index(), pti.LocalTileIndex());
+            amrex::Real* const ux2 = ptile2.GetRealData(PlasmaIdx::ux_half_step).data();
+            amrex::Real* const uy2 = ptile2.GetRealData(PlasmaIdx::uy_half_step).data();
+            amrex::Real* const psi2= ptile2.GetRealData(PlasmaIdx::psi_half_step).data();
+            const amrex::Real* const w2 = ptile2.GetRealData(PlasmaIdx::w).data();
+            const int* const ion_lev2 = ptile2.GetIntData(PlasmaIdx::ion_lev).data();
+            PlasmaBins::index_type * const indices2 = bins2.permutationPtr();
+            PlasmaBins::index_type const * const offsets2 = bins2.offsetsPtr();
+            amrex::Real q2 = species2.GetCharge();
+            amrex::Real m2 = species2.GetMass();
+            const bool can_ionize2 = species2.m_can_ionize;
+
+            // volume is used to calculate density, but weights already represent density in normalized units
+            const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
+            // static_cast<double> to avoid precision problems in FP32
+            const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
+                                            PhysConstSI::q_e*PhysConstSI::q_e /
+                                            (PhysConstSI::ep0*PhysConstSI::m_e));
+            amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
+                                                    : geom.CellSize(2)/PhysConstSI::c;
+            dt = dt * collide_every;
+            // Extract particles in the tile that `mfi` points to
+            // ParticleTileType& ptile_1 = species_1->ParticlesAt(lev, mfi);
+            // ParticleTileType& ptile_2 = species_2->ParticlesAt(lev, mfi);
+            // Loop over cells, and collide the particles in each cell
+
+            // Loop over cells
+            amrex::ParallelForRNG(
+                n_cells,
+                [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
+                {
+                    // The particles from species1 that are in the cell `i_cell` are
+                    // given by the `indices_1[cell_start_1:cell_stop_1]`
+                    PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
+                    PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
+                    // Same for species 2
+                    PlasmaBins::index_type const cell_start2 = offsets2[i_cell];
+                    PlasmaBins::index_type const cell_stop2  = offsets2[i_cell+1];
+
+                    // ux from species1 can be accessed like this:
+                    // ux_1[ indices_1[i] ], where i is between
+                    // cell_start_1 (inclusive) and cell_start_2 (exclusive)
+
+                    // Do not collide if one species is missing in the cell
+                    if ( cell_stop1 - cell_start1 < 1 ||
+                        cell_stop2 - cell_start2 < 1 ) return;
+                    // shuffle
+                    ShuffleFisherYates(indices1, cell_start1, cell_stop1, engine);
+                    ShuffleFisherYates(indices2, cell_start2, cell_stop2, engine);
+
+                    // TODO: FIX DT.
+                    // Call the function in order to perform collisions
+                    ElasticCollisionPerez(
+                        cell_start1, cell_stop1, cell_start2, cell_stop2,
+                        indices1, indices2,
+                        ux1, uy1, psi1, ux2, uy2, psi2, w1, w2, ion_lev1, ion_lev2,
+                        q1, q2, m1, m2, -1.0_rt, -1.0_rt, can_ionize1, can_ionize2,
+                        dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
+                        normalized_units, background_density_SI, is_same_species, false, engine );
+                }
+                );
+            count++;
+        }
+        AMREX_ALWAYS_ASSERT(count == 1);
     }
 }
 
 void
-CoulombCollision::doBeamPlasmaCoulombCollision ( int islice,
+CoulombCollision::doBeamPlasmaCoulombCollision ( int islice, int collide_every,
     int lev, const amrex::Box& bx, const amrex::Geometry& geom,
     BeamParticleContainer& species1, PlasmaParticleContainer& species2, amrex::Real CoulombLog,
     amrex::Real background_density_SI)
 {
+    if (islice%collide_every != 0) {
+        return;
+    }
     HIPACE_PROFILE("CoulombCollision::doBeamPlasmaCoulombCollision()");
     AMREX_ALWAYS_ASSERT(lev == 0);
 

--- a/src/particles/collisions/CoulombCollision.cpp
+++ b/src/particles/collisions/CoulombCollision.cpp
@@ -25,6 +25,8 @@ CoulombCollision::ReadParameters(
 
     // default Coulomb log is -1, if < 0 (e.g. not specified), will be computed automatically
     pp.query("CoulombLog", m_CoulombLog);
+    // how often the collision operator should be applied - every m_collide_every'th slice
+    pp.query("collide_every", m_collide_every);
 
     for (int i=0; i<(int) beam_species_names.size(); i++) {
         if (beam_species_names[i] == collision_species[0]) m_nbeams += 1;
@@ -58,183 +60,187 @@ CoulombCollision::ReadParameters(
 }
 
 void
-CoulombCollision::doPlasmaPlasmaCoulombCollision (
+CoulombCollision::doPlasmaPlasmaCoulombCollision ( int islice, int collide_every,
     int lev, const amrex::Box& bx, const amrex::Geometry& geom, PlasmaParticleContainer& species1,
     PlasmaParticleContainer& species2, bool is_same_species, amrex::Real CoulombLog,
     amrex::Real background_density_SI)
 {
-    HIPACE_PROFILE("CoulombCollision::doCoulombCollision()");
-    AMREX_ALWAYS_ASSERT(lev == 0);
+    if (islice%collide_every == 0){
+        HIPACE_PROFILE("CoulombCollision::doCoulombCollision()");
+        AMREX_ALWAYS_ASSERT(lev == 0);
 
-    if (species1.TotalNumberOfParticles(false, true) == 0 ||
-        species2.TotalNumberOfParticles(false, true) == 0) return;
+        if (species1.TotalNumberOfParticles(false, true) == 0 ||
+            species2.TotalNumberOfParticles(false, true) == 0) return;
 
-    using namespace amrex::literals;
-    const PhysConst cst = get_phys_const();
-    bool normalized_units = Hipace::m_normalized_units;
+        using namespace amrex::literals;
+        const PhysConst cst = get_phys_const();
+        bool normalized_units = Hipace::m_normalized_units;
 
-    const amrex::Real clight = cst.c;
-    constexpr amrex::Real inv_c_SI = 1.0_rt / PhysConstSI::c;
-    constexpr amrex::Real inv_c2_SI = 1.0_rt / ( PhysConstSI::c * PhysConstSI::c );
+        const amrex::Real clight = cst.c;
+        constexpr amrex::Real inv_c_SI = 1.0_rt / PhysConstSI::c;
+        constexpr amrex::Real inv_c2_SI = 1.0_rt / ( PhysConstSI::c * PhysConstSI::c );
 
-    if ( is_same_species ) // species_1 == species_2
-    {
-        // Logically particles per-cell, and return indices of particles in each cell
-        PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
-        int const n_cells = bins1.numBins();
+        if ( is_same_species ) // species_1 == species_2
+        {
+            // Logically particles per-cell, and return indices of particles in each cell
+            PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
+            int const n_cells = bins1.numBins();
 
-        // Counter to check there is only 1 box
-        int count = 0;
-        for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
+            // Counter to check there is only 1 box
+            int count = 0;
+            for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
 
-            // Get particles SoA data
-            auto& ptile1 = pti.GetParticleTile();
-            amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
-            amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
-            amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
-            const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
-            const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
-            PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
-            PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
-            amrex::Real q1 = species1.GetCharge();
-            amrex::Real m1 = species1.GetMass();
-            const bool can_ionize1 = species1.m_can_ionize;
+                // Get particles SoA data
+                auto& ptile1 = pti.GetParticleTile();
+                amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
+                amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
+                amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
+                const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
+                const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
+                PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
+                PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
+                amrex::Real q1 = species1.GetCharge();
+                amrex::Real m1 = species1.GetMass();
+                const bool can_ionize1 = species1.m_can_ionize;
 
-            // volume is used to calculate density, but weights already represent density in normalized units
-            const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
-            // static_cast<double> to avoid precision problems in FP32
-            const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
-                                             PhysConstSI::q_e*PhysConstSI::q_e /
-                                             (PhysConstSI::ep0*PhysConstSI::m_e));
-            const amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
-                                                    : geom.CellSize(2)/PhysConstSI::c;
+                // volume is used to calculate density, but weights already represent density in normalized units
+                const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
+                // static_cast<double> to avoid precision problems in FP32
+                const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
+                                                PhysConstSI::q_e*PhysConstSI::q_e /
+                                                (PhysConstSI::ep0*PhysConstSI::m_e));
+                amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
+                                                        : geom.CellSize(2)/PhysConstSI::c;
+                dt = dt * collide_every;
 
-            amrex::ParallelForRNG(
-                n_cells,
-                [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
-                {
-                    // The particles from species1 that are in the cell `i_cell` are
-                    // given by the `indices_1[cell_start_1:cell_stop_1]`
-                    PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
-                    PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
-                    PlasmaBins::index_type const cell_half1 = (cell_start1+cell_stop1)/2;
+                amrex::ParallelForRNG(
+                    n_cells,
+                    [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
+                    {
+                        // The particles from species1 that are in the cell `i_cell` are
+                        // given by the `indices_1[cell_start_1:cell_stop_1]`
+                        PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
+                        PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
+                        PlasmaBins::index_type const cell_half1 = (cell_start1+cell_stop1)/2;
 
-                    if ( cell_stop1 - cell_start1 <= 1 ) return;
-                    // Do not collide if there is only one particle in the cell
-                    // shuffle
-                    ShuffleFisherYates(
-                        indices1, cell_start1, cell_half1, engine );
+                        if ( cell_stop1 - cell_start1 <= 1 ) return;
+                        // Do not collide if there is only one particle in the cell
+                        // shuffle
+                        ShuffleFisherYates(
+                            indices1, cell_start1, cell_half1, engine );
 
-                    // TODO: FIX DT
-                    // Call the function in order to perform collisions
-                    ElasticCollisionPerez(
-                        cell_start1, cell_half1,
-                        cell_half1, cell_stop1,
-                        indices1, indices1,
-                        ux1, uy1, psi1, ux1, uy1, psi1, w1, w1, ion_lev1, ion_lev1,
-                        q1, q1, m1, m1, -1.0_rt, -1.0_rt, can_ionize1, can_ionize1,
-                        dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
-                        normalized_units, background_density_SI, is_same_species, false, engine );
-                }
-                );
-            count++;
+                        // TODO: FIX DT
+                        // Call the function in order to perform collisions
+                        ElasticCollisionPerez(
+                            cell_start1, cell_half1,
+                            cell_half1, cell_stop1,
+                            indices1, indices1,
+                            ux1, uy1, psi1, ux1, uy1, psi1, w1, w1, ion_lev1, ion_lev1,
+                            q1, q1, m1, m1, -1.0_rt, -1.0_rt, can_ionize1, can_ionize1,
+                            dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
+                            normalized_units, background_density_SI, is_same_species, false, engine );
+                    }
+                    );
+                count++;
+            }
+            AMREX_ALWAYS_ASSERT(count == 1);
+
+        } else {
+
+            // Logically particles per-cell, and return indices of particles in each cell
+            PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
+            PlasmaBins bins2 = findParticlesInEachTile(bx, 1, species2, geom);
+
+            int const n_cells = bins1.numBins();
+
+            // Counter to check there is only 1 box
+            int count = 0;
+            for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
+
+                // Get particles SoA data for species 1
+                auto& ptile1 = pti.GetParticleTile();
+                amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
+                amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
+                amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
+                const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
+                const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
+                PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
+                PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
+                amrex::Real q1 = species1.GetCharge();
+                amrex::Real m1 = species1.GetMass();
+                const bool can_ionize1 = species1.m_can_ionize;
+
+                // Get particles SoA data for species 2
+                auto& ptile2 = species2.ParticlesAt(lev, pti.index(), pti.LocalTileIndex());
+                amrex::Real* const ux2 = ptile2.GetRealData(PlasmaIdx::ux_half_step).data();
+                amrex::Real* const uy2 = ptile2.GetRealData(PlasmaIdx::uy_half_step).data();
+                amrex::Real* const psi2= ptile2.GetRealData(PlasmaIdx::psi_half_step).data();
+                const amrex::Real* const w2 = ptile2.GetRealData(PlasmaIdx::w).data();
+                const int* const ion_lev2 = ptile2.GetIntData(PlasmaIdx::ion_lev).data();
+                PlasmaBins::index_type * const indices2 = bins2.permutationPtr();
+                PlasmaBins::index_type const * const offsets2 = bins2.offsetsPtr();
+                amrex::Real q2 = species2.GetCharge();
+                amrex::Real m2 = species2.GetMass();
+                const bool can_ionize2 = species2.m_can_ionize;
+
+                // volume is used to calculate density, but weights already represent density in normalized units
+                const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
+                // static_cast<double> to avoid precision problems in FP32
+                const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
+                                                PhysConstSI::q_e*PhysConstSI::q_e /
+                                                (PhysConstSI::ep0*PhysConstSI::m_e));
+                amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
+                                                        : geom.CellSize(2)/PhysConstSI::c;
+                dt = dt * collide_every;
+                // Extract particles in the tile that `mfi` points to
+                // ParticleTileType& ptile_1 = species_1->ParticlesAt(lev, mfi);
+                // ParticleTileType& ptile_2 = species_2->ParticlesAt(lev, mfi);
+                // Loop over cells, and collide the particles in each cell
+
+                // Loop over cells
+                amrex::ParallelForRNG(
+                    n_cells,
+                    [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
+                    {
+                        // The particles from species1 that are in the cell `i_cell` are
+                        // given by the `indices_1[cell_start_1:cell_stop_1]`
+                        PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
+                        PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
+                        // Same for species 2
+                        PlasmaBins::index_type const cell_start2 = offsets2[i_cell];
+                        PlasmaBins::index_type const cell_stop2  = offsets2[i_cell+1];
+
+                        // ux from species1 can be accessed like this:
+                        // ux_1[ indices_1[i] ], where i is between
+                        // cell_start_1 (inclusive) and cell_start_2 (exclusive)
+
+                        // Do not collide if one species is missing in the cell
+                        if ( cell_stop1 - cell_start1 < 1 ||
+                            cell_stop2 - cell_start2 < 1 ) return;
+                        // shuffle
+                        ShuffleFisherYates(indices1, cell_start1, cell_stop1, engine);
+                        ShuffleFisherYates(indices2, cell_start2, cell_stop2, engine);
+
+                        // TODO: FIX DT.
+                        // Call the function in order to perform collisions
+                        ElasticCollisionPerez(
+                            cell_start1, cell_stop1, cell_start2, cell_stop2,
+                            indices1, indices2,
+                            ux1, uy1, psi1, ux2, uy2, psi2, w1, w2, ion_lev1, ion_lev2,
+                            q1, q2, m1, m2, -1.0_rt, -1.0_rt, can_ionize1, can_ionize2,
+                            dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
+                            normalized_units, background_density_SI, is_same_species, false, engine );
+                    }
+                    );
+                count++;
+            }
+            AMREX_ALWAYS_ASSERT(count == 1);
         }
-        AMREX_ALWAYS_ASSERT(count == 1);
-
-    } else {
-
-        // Logically particles per-cell, and return indices of particles in each cell
-        PlasmaBins bins1 = findParticlesInEachTile(bx, 1, species1, geom);
-        PlasmaBins bins2 = findParticlesInEachTile(bx, 1, species2, geom);
-
-        int const n_cells = bins1.numBins();
-
-        // Counter to check there is only 1 box
-        int count = 0;
-        for (PlasmaParticleIterator pti(species1); pti.isValid(); ++pti) {
-
-            // Get particles SoA data for species 1
-            auto& ptile1 = pti.GetParticleTile();
-            amrex::Real* const ux1 = ptile1.GetRealData(PlasmaIdx::ux_half_step).data();
-            amrex::Real* const uy1 = ptile1.GetRealData(PlasmaIdx::uy_half_step).data();
-            amrex::Real* const psi1 = ptile1.GetRealData(PlasmaIdx::psi_half_step).data();
-            const amrex::Real* const w1 = ptile1.GetRealData(PlasmaIdx::w).data();
-            const int* const ion_lev1 = ptile1.GetIntData(PlasmaIdx::ion_lev).data();
-            PlasmaBins::index_type * const indices1 = bins1.permutationPtr();
-            PlasmaBins::index_type const * const offsets1 = bins1.offsetsPtr();
-            amrex::Real q1 = species1.GetCharge();
-            amrex::Real m1 = species1.GetMass();
-            const bool can_ionize1 = species1.m_can_ionize;
-
-            // Get particles SoA data for species 2
-            auto& ptile2 = species2.ParticlesAt(lev, pti.index(), pti.LocalTileIndex());
-            amrex::Real* const ux2 = ptile2.GetRealData(PlasmaIdx::ux_half_step).data();
-            amrex::Real* const uy2 = ptile2.GetRealData(PlasmaIdx::uy_half_step).data();
-            amrex::Real* const psi2= ptile2.GetRealData(PlasmaIdx::psi_half_step).data();
-            const amrex::Real* const w2 = ptile2.GetRealData(PlasmaIdx::w).data();
-            const int* const ion_lev2 = ptile2.GetIntData(PlasmaIdx::ion_lev).data();
-            PlasmaBins::index_type * const indices2 = bins2.permutationPtr();
-            PlasmaBins::index_type const * const offsets2 = bins2.offsetsPtr();
-            amrex::Real q2 = species2.GetCharge();
-            amrex::Real m2 = species2.GetMass();
-            const bool can_ionize2 = species2.m_can_ionize;
-
-            // volume is used to calculate density, but weights already represent density in normalized units
-            const amrex::Real inv_dV = geom.InvCellSize(0)*geom.InvCellSize(1)*geom.InvCellSize(2);
-            // static_cast<double> to avoid precision problems in FP32
-            const amrex::Real wp = std::sqrt(static_cast<double>(background_density_SI) *
-                                             PhysConstSI::q_e*PhysConstSI::q_e /
-                                             (PhysConstSI::ep0*PhysConstSI::m_e));
-            const amrex::Real dt = normalized_units ? geom.CellSize(2)/wp
-                                                    : geom.CellSize(2)/PhysConstSI::c;
-            // Extract particles in the tile that `mfi` points to
-            // ParticleTileType& ptile_1 = species_1->ParticlesAt(lev, mfi);
-            // ParticleTileType& ptile_2 = species_2->ParticlesAt(lev, mfi);
-            // Loop over cells, and collide the particles in each cell
-
-            // Loop over cells
-            amrex::ParallelForRNG(
-                n_cells,
-                [=] AMREX_GPU_DEVICE (int i_cell, amrex::RandomEngine const& engine) noexcept
-                {
-                    // The particles from species1 that are in the cell `i_cell` are
-                    // given by the `indices_1[cell_start_1:cell_stop_1]`
-                    PlasmaBins::index_type const cell_start1 = offsets1[i_cell];
-                    PlasmaBins::index_type const cell_stop1  = offsets1[i_cell+1];
-                    // Same for species 2
-                    PlasmaBins::index_type const cell_start2 = offsets2[i_cell];
-                    PlasmaBins::index_type const cell_stop2  = offsets2[i_cell+1];
-
-                    // ux from species1 can be accessed like this:
-                    // ux_1[ indices_1[i] ], where i is between
-                    // cell_start_1 (inclusive) and cell_start_2 (exclusive)
-
-                    // Do not collide if one species is missing in the cell
-                    if ( cell_stop1 - cell_start1 < 1 ||
-                         cell_stop2 - cell_start2 < 1 ) return;
-                    // shuffle
-                    ShuffleFisherYates(indices1, cell_start1, cell_stop1, engine);
-                    ShuffleFisherYates(indices2, cell_start2, cell_stop2, engine);
-
-                    // TODO: FIX DT.
-                    // Call the function in order to perform collisions
-                    ElasticCollisionPerez(
-                        cell_start1, cell_stop1, cell_start2, cell_stop2,
-                        indices1, indices2,
-                        ux1, uy1, psi1, ux2, uy2, psi2, w1, w2, ion_lev1, ion_lev2,
-                        q1, q2, m1, m2, -1.0_rt, -1.0_rt, can_ionize1, can_ionize2,
-                        dt, CoulombLog, inv_dV, clight, inv_c_SI, inv_c2_SI,
-                        normalized_units, background_density_SI, is_same_species, false, engine );
-                }
-                );
-            count++;
-        }
-        AMREX_ALWAYS_ASSERT(count == 1);
     }
 }
 
 void
-CoulombCollision::doBeamPlasmaCoulombCollision (
+CoulombCollision::doBeamPlasmaCoulombCollision ( int islice,
     int lev, const amrex::Box& bx, const amrex::Geometry& geom,
     BeamParticleContainer& species1, PlasmaParticleContainer& species2, amrex::Real CoulombLog,
     amrex::Real background_density_SI)

--- a/src/particles/deposition/TemperatureDeposition.H
+++ b/src/particles/deposition/TemperatureDeposition.H
@@ -13,7 +13,7 @@
 #include "utils/Constants.H"
 #include "Hipace.H"
 
-/** Depose current of particles in species plasma into the current 2D slice in fields
+/** Depose moments of particles in species plasma into the current 2D slice in fields
  * \param[in] plasma species of which the current is deposited
  * \param[in,out] fields the general field class, modified by this function
  * \param[in] gm Geometry of the simulation, to get the cell size etc.

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -126,7 +126,7 @@ struct PlasmaID
         from_field_ionization = 2,
         from_laser_ionization = 3,
         invalid = -1,
-        invalid_at_boundary = -2
+        invalid_at_boundary = -2,
     };
 };
 

--- a/src/particles/plasma/PlasmaParticleContainer.H
+++ b/src/particles/plasma/PlasmaParticleContainer.H
@@ -101,7 +101,7 @@ struct PlasmaIdx
         psi,                // pseudo-potential at the particle position. ATTENTION what is stored is actually normalized psi+1
         x_prev, y_prev,     // positions on the last non-temp slice
 
-        ux_half_step,       // momentum half a step behind the current slice for leapfrog pusher
+        ux_half_step,       // momentum half a step behind the current slice (t-1/2) for leapfrog pusher
         uy_half_step,       // at the same step for AB5 pusher
         psi_half_step,      // never effected by temp slice
 #ifdef HIPACE_USE_AB5_PUSH
@@ -127,6 +127,7 @@ struct PlasmaID
         from_laser_ionization = 3,
         invalid = -1,
         invalid_at_boundary = -2,
+        to_be_thermalised = -3
     };
 };
 

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -95,31 +95,30 @@ struct EnforceBC
                 invalid = true;
             }
         }
-
         return invalid;
     }
 
     /** \brief enforces Thermal boundary condition to the particle
      * at index `ip`
-     * \param[in] ptd ParticleTileData
+     * \param[inout] ptd ParticleTileData
      * \param[in] ip index of the particle
-     * \param[in] x x position of particle
-     * \param[in] y y position of particle
-     * \param[in] ux x momentum of particle
-     * \param[in] uy y momentum of particle
+     * \param[inout] x x position of particle
+     * \param[inout] y y position of particle
+     * \param[inout] ux x momentum of particle
+     * \param[inout] uy y momentum of particle
+     * \param[inout] uz z momentum of particle
+     * \param[inout] u_std momentum spread from thermal boundary velocity
+     * \param[inout] engine amrex's random number generator
      */
     template<class PTD>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (const PTD& ptd,
         const int ip, amrex::Real& x, amrex::Real& y,
-        amrex::Real& ux, amrex::Real& uy, amrex::Real& uz,
-        amrex::Real& ux_dep, amrex::Real& uy_dep, amrex::Real& uz_dep, amrex::Real u_std,
+        amrex::Real& ux, amrex::Real& uy, amrex::Real& uz, amrex::Real u_std,
         const amrex::RandomEngine& engine) const noexcept
     {
-        // if called with the engine, then we are using thermal boudnaries, and need to
-        // thermalise particles at the boundary
-
-        if (ptd.id(ip) != PlasmaID::to_be_thermalised) return;
+        // only called to reflect particle positions and provide the thermal
+        // velocities to the particles
 
         // get a random thermal velocity vector
         amrex::Real u[3] = {0.,0.,0.};
@@ -128,6 +127,7 @@ struct EnforceBC
         uy = u[1];
         uz = u[2];
 
+        // use same method for reflecting as in the ParticleBoundary::Reflecting case
         const amrex::Real len_x = m_phi[0] - m_plo[0];
         const amrex::Real len_y = m_phi[1] - m_plo[1];
 
@@ -141,7 +141,8 @@ struct EnforceBC
             if (x > m_phi[0]) {
                 x = 2*m_phi[0] - x;
             }
-        } else { // reflect particle in y
+        }
+        if (y < m_plo[1] || y > m_phi[1]) { // reflect particle in y
             if (y < m_plo[1]) uy = (uy > 0) ? uy : -uy;
             else uy = (uy < 0) ? uy : -uy;
             
@@ -152,10 +153,7 @@ struct EnforceBC
                 y = 2*m_phi[1] - y;
             }
         }
-        // plasma particle is now valid again!
-        ux_dep = ux;
-        uy_dep = uy;
-        uz_dep = uz;
+        // plasma particle is now valid again
         ptd.id(ip) = PlasmaID::valid;
     }
 };

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -19,6 +19,7 @@
 
 #include <AMReX.H>
 #include <AMReX_REAL.H>
+#include <AMReX_Random.H>
 
 #include <limits>
 
@@ -86,7 +87,93 @@ struct EnforceBC
                 if (y < 0) y += len_y;
                 y += m_plo[1];
                 invalid = false;
-            } else {
+            } else if (m_particle_boundary == ParticleBoundary::Thermal) {
+                x = std::fmod(x - m_plo[0], 2*len_x);
+                if (x < 0) x += 2*len_x;
+                x += m_plo[0];
+                if (x > m_phi[0]) {
+                    x = 2*m_phi[0] - x;
+                    ux = 0;
+                }
+                y = std::fmod(y - m_plo[1], 2*len_y);
+                if (y < 0) y += 2*len_y;
+                y += m_plo[1];
+                if (y > m_phi[1]) {
+                    y = 2*m_phi[1] - y;
+                    uy = 0;
+                }
+                ptd.id(ip) = PlasmaID::invalid_at_boundary;
+
+            } else {                       // ParticleBoundary::Absorbing
+                ptd.id(ip) = PlasmaID::invalid_at_boundary;
+                invalid = true;
+            }
+        }
+
+        return invalid;
+    }
+
+    /** \brief enforces the boundary condition to the particle
+     * at index `ip` and returns if the particle is invalid
+     * \param[in] ptd ParticleTileData
+     * \param[in] ip index of the particle
+     * \param[in] x x position of particle
+     * \param[in] y y position of particle
+     * \param[in] ux x momentum of particle
+     * \param[in] uy y momentum of particle
+     */
+    template<class PTD>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool operator() (const PTD& ptd,
+        const int ip, amrex::Real& x, amrex::Real& y,
+        amrex::Real& ux, amrex::Real& uy, amrex::Random& engine) const noexcept
+    {
+        bool invalid = false;
+        if (x < m_plo[0] || y < m_plo[1] || x > m_phi[0] || y > m_phi[1]) {
+            const amrex::Real len_x = m_phi[0] - m_plo[0];
+            const amrex::Real len_y = m_phi[1] - m_plo[1];
+            if (m_particle_boundary == ParticleBoundary::Reflecting) {
+                x = std::fmod(x - m_plo[0], 2*len_x);
+                if (x < 0) x += 2*len_x;
+                x += m_plo[0];
+                if (x > m_phi[0]) {
+                    x = 2*m_phi[0] - x;
+                    ux = -ux;
+                }
+                y = std::fmod(y - m_plo[1], 2*len_y);
+                if (y < 0) y += 2*len_y;
+                y += m_plo[1];
+                if (y > m_phi[1]) {
+                    y = 2*m_phi[1] - y;
+                    uy = -uy;
+                }
+                invalid = false;
+            } else if (m_particle_boundary == ParticleBoundary::Periodic) {
+                x = std::fmod(x - m_plo[0], len_x);
+                if (x < 0) x += len_x;
+                x += m_plo[0];
+                y = std::fmod(y - m_plo[1], len_y);
+                if (y < 0) y += len_y;
+                y += m_plo[1];
+                invalid = false;
+            } else if (m_particle_boundary == ParticleBoundary::Thermal) {
+                x = std::fmod(x - m_plo[0], 2*len_x);
+                if (x < 0) x += 2*len_x;
+                x += m_plo[0];
+                if (x > m_phi[0]) {
+                    x = 2*m_phi[0] - x;
+                    ux = 0;
+                }
+                y = std::fmod(y - m_plo[1], 2*len_y);
+                if (y < 0) y += 2*len_y;
+                y += m_plo[1];
+                if (y > m_phi[1]) {
+                    y = 2*m_phi[1] - y;
+                    uy = 0;
+                }
+                ptd.id(ip) = PlasmaID::invalid_at_boundary;
+
+            } else {                       // ParticleBoundary::Absorbing
                 ptd.id(ip) = PlasmaID::invalid_at_boundary;
                 invalid = true;
             }

--- a/src/particles/pusher/GetAndSetPosition.H
+++ b/src/particles/pusher/GetAndSetPosition.H
@@ -16,6 +16,7 @@
 #define HIPACE_GETANDSETPOSITION_H_
 
 #include "Hipace.H"
+#include "particles/particles_utils/ParticleUtil.H"
 
 #include <AMReX.H>
 #include <AMReX_REAL.H>
@@ -88,22 +89,7 @@ struct EnforceBC
                 y += m_plo[1];
                 invalid = false;
             } else if (m_particle_boundary == ParticleBoundary::Thermal) {
-                x = std::fmod(x - m_plo[0], 2*len_x);
-                if (x < 0) x += 2*len_x;
-                x += m_plo[0];
-                if (x > m_phi[0]) {
-                    x = 2*m_phi[0] - x;
-                    ux = 0;
-                }
-                y = std::fmod(y - m_plo[1], 2*len_y);
-                if (y < 0) y += 2*len_y;
-                y += m_plo[1];
-                if (y > m_phi[1]) {
-                    y = 2*m_phi[1] - y;
-                    uy = 0;
-                }
-                ptd.id(ip) = PlasmaID::invalid_at_boundary;
-
+                ptd.id(ip) = PlasmaID::to_be_thermalised;
             } else {                       // ParticleBoundary::Absorbing
                 ptd.id(ip) = PlasmaID::invalid_at_boundary;
                 invalid = true;
@@ -113,8 +99,8 @@ struct EnforceBC
         return invalid;
     }
 
-    /** \brief enforces the boundary condition to the particle
-     * at index `ip` and returns if the particle is invalid
+    /** \brief enforces Thermal boundary condition to the particle
+     * at index `ip`
      * \param[in] ptd ParticleTileData
      * \param[in] ip index of the particle
      * \param[in] x x position of particle
@@ -124,62 +110,53 @@ struct EnforceBC
      */
     template<class PTD>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator() (const PTD& ptd,
+    void operator() (const PTD& ptd,
         const int ip, amrex::Real& x, amrex::Real& y,
-        amrex::Real& ux, amrex::Real& uy, amrex::Random& engine) const noexcept
+        amrex::Real& ux, amrex::Real& uy, amrex::Real& uz,
+        amrex::Real& ux_dep, amrex::Real& uy_dep, amrex::Real& uz_dep, amrex::Real u_std,
+        const amrex::RandomEngine& engine) const noexcept
     {
-        bool invalid = false;
-        if (x < m_plo[0] || y < m_plo[1] || x > m_phi[0] || y > m_phi[1]) {
-            const amrex::Real len_x = m_phi[0] - m_plo[0];
-            const amrex::Real len_y = m_phi[1] - m_plo[1];
-            if (m_particle_boundary == ParticleBoundary::Reflecting) {
-                x = std::fmod(x - m_plo[0], 2*len_x);
-                if (x < 0) x += 2*len_x;
-                x += m_plo[0];
-                if (x > m_phi[0]) {
-                    x = 2*m_phi[0] - x;
-                    ux = -ux;
-                }
-                y = std::fmod(y - m_plo[1], 2*len_y);
-                if (y < 0) y += 2*len_y;
-                y += m_plo[1];
-                if (y > m_phi[1]) {
-                    y = 2*m_phi[1] - y;
-                    uy = -uy;
-                }
-                invalid = false;
-            } else if (m_particle_boundary == ParticleBoundary::Periodic) {
-                x = std::fmod(x - m_plo[0], len_x);
-                if (x < 0) x += len_x;
-                x += m_plo[0];
-                y = std::fmod(y - m_plo[1], len_y);
-                if (y < 0) y += len_y;
-                y += m_plo[1];
-                invalid = false;
-            } else if (m_particle_boundary == ParticleBoundary::Thermal) {
-                x = std::fmod(x - m_plo[0], 2*len_x);
-                if (x < 0) x += 2*len_x;
-                x += m_plo[0];
-                if (x > m_phi[0]) {
-                    x = 2*m_phi[0] - x;
-                    ux = 0;
-                }
-                y = std::fmod(y - m_plo[1], 2*len_y);
-                if (y < 0) y += 2*len_y;
-                y += m_plo[1];
-                if (y > m_phi[1]) {
-                    y = 2*m_phi[1] - y;
-                    uy = 0;
-                }
-                ptd.id(ip) = PlasmaID::invalid_at_boundary;
+        // if called with the engine, then we are using thermal boudnaries, and need to
+        // thermalise particles at the boundary
 
-            } else {                       // ParticleBoundary::Absorbing
-                ptd.id(ip) = PlasmaID::invalid_at_boundary;
-                invalid = true;
+        if (ptd.id(ip) != PlasmaID::to_be_thermalised) return;
+
+        // get a random thermal velocity vector
+        amrex::Real u[3] = {0.,0.,0.};
+        ParticleUtil::get_gaussian_random_momentum(u, {0., 0., 0.}, {u_std, u_std, u_std}, engine);
+        ux = u[0];
+        uy = u[1];
+        uz = u[2];
+
+        const amrex::Real len_x = m_phi[0] - m_plo[0];
+        const amrex::Real len_y = m_phi[1] - m_plo[1];
+
+        if (x < m_plo[0] || x > m_phi[0]) { // reflect particle in x
+            if (x < m_plo[0]) ux = (ux > 0) ? ux : -ux;
+            else ux = (ux < 0) ? ux : -ux;
+
+            x = std::fmod(x - m_plo[0], 2*len_x);
+            if (x < 0) x += 2*len_x;
+            x += m_plo[0];
+            if (x > m_phi[0]) {
+                x = 2*m_phi[0] - x;
+            }
+        } else { // reflect particle in y
+            if (y < m_plo[1]) uy = (uy > 0) ? uy : -uy;
+            else uy = (uy < 0) ? uy : -uy;
+            
+            y = std::fmod(y - m_plo[1], 2*len_y);
+            if (y < 0) y += 2*len_y;
+            y += m_plo[1];
+            if (y > m_phi[1]) {
+                y = 2*m_phi[1] - y;
             }
         }
-
-        return invalid;
+        // plasma particle is now valid again!
+        ux_dep = ux;
+        uy_dep = uy;
+        uz_dep = uz;
+        ptd.id(ip) = PlasmaID::valid;
     }
 };
 

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -311,7 +311,6 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                         ptd.rdata(PlasmaIdx::y_prev)[ip] = yp;
                     }
 
-                    // do/don't include thermalised plasma particles in this iteration's current deposition (maybe change)
                     ptd.rdata(PlasmaIdx::ux)[ip] = ux;
                     ptd.rdata(PlasmaIdx::uy)[ip] = uy;
                     ptd.rdata(PlasmaIdx::psi)[ip] = psi;

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -14,6 +14,7 @@
 #include "utils/Constants.H"
 #include "Hipace.H"
 #include "GetAndSetPosition.H"
+#include "RethermaliseMomentum.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/GPUUtil.H"
 #include "utils/OMPUtil.H"
@@ -273,6 +274,26 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
 #endif
                 } // loop over subcycles
             });
+
+        // Rethermalise particles at the boundary here.
+        
+        amrex::ParallelForRNG(int(pti.numParticles()),
+            [=] AMREX_GPU_DEVICE (int ip, const amrex::RandomEngine& engine) {
+
+                if (ptd.id(ip) != PlasmaID::invalid_at_boundary) return;
+
+                amrex::Real xp = ptd.pos(0, ip);
+                amrex::Real yp = ptd.pos(1, ip);
+                amrex::Real ux = ptd.rdata(PlasmaIdx::ux)[ip]
+                amrex::Real uy = ptd.rdata(PlasmaIdx::uy)[ip]
+                amrex::Real psi = ptd.rdata(PlasmaIdx::psi)[ip]
+
+
+                RethermaliseMomentum(ptd, ip, xp, yp, ux, uy);
+                amrex::Real u[3] = {0.,0.,0.};
+                ParticleUtil::get_gaussian_random_momentum(u, 0., m_boundary_temperature, engine);
+
+        });
     }
 
 #ifdef HIPACE_USE_AB5_PUSH

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -14,12 +14,10 @@
 #include "utils/Constants.H"
 #include "Hipace.H"
 #include "GetAndSetPosition.H"
-#include "RethermaliseMomentum.H"
 #include "utils/HipaceProfilerWrapper.H"
 #include "utils/GPUUtil.H"
 #include "utils/OMPUtil.H"
 #include "utils/DualNumbers.H"
-#include "particles/particles_utils/ParticleUtil.H"
 
 #include <string>
 
@@ -276,24 +274,57 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
             });
 
         // Rethermalise particles at the boundary here.
-        
-        amrex::ParallelForRNG(int(pti.numParticles()),
-            [=] AMREX_GPU_DEVICE (int ip, const amrex::RandomEngine& engine) {
+        if (Hipace::m_boundary_particles == ParticleBoundary::Thermal) {
 
-                if (ptd.id(ip) != PlasmaID::invalid_at_boundary) return;
+            const PhysConst phys_const_SI = make_constants_SI();
 
-                amrex::Real xp = ptd.pos(0, ip);
-                amrex::Real yp = ptd.pos(1, ip);
-                amrex::Real ux = ptd.rdata(PlasmaIdx::ux)[ip]
-                amrex::Real uy = ptd.rdata(PlasmaIdx::uy)[ip]
-                amrex::Real psi = ptd.rdata(PlasmaIdx::psi)[ip]
+            amrex::Real u_std = std::sqrt(Hipace::m_boundary_temperature * phys_const_SI.q_e / 
+                                (plasma.m_mass * (phys_const_SI.m_e / phys_const.m_e) *
+                                (phys_const_SI.c * phys_const_SI.c) ) );
 
 
-                RethermaliseMomentum(ptd, ip, xp, yp, ux, uy);
-                amrex::Real u[3] = {0.,0.,0.};
-                ParticleUtil::get_gaussian_random_momentum(u, 0., m_boundary_temperature, engine);
+            amrex::ParallelForRNG(int(pti.numParticles()),
+                [=] AMREX_GPU_DEVICE (int ip, const amrex::RandomEngine& engine) {
 
-        });
+                    // Use positions at t+1 to reflect and velocities at t
+                    amrex::Real xp = ptd.pos(0, ip);
+                    amrex::Real yp = ptd.pos(1, ip);
+                    amrex::Real ux = ptd.rdata(PlasmaIdx::ux_half_step)[ip];
+                    amrex::Real uy = ptd.rdata(PlasmaIdx::uy_half_step)[ip];
+                    amrex::Real psi = ptd.rdata(PlasmaIdx::psi_half_step)[ip];
+
+                    amrex::Real ux_dep = ptd.rdata(PlasmaIdx::ux)[ip];
+                    amrex::Real uy_dep = ptd.rdata(PlasmaIdx::uy)[ip];
+                    amrex::Real psi_dep = ptd.rdata(PlasmaIdx::psi)[ip];
+
+                    amrex::Real gamma = plasma_gamma(ux, uy, psi, 1/psi, 0);
+                    amrex::Real uz = plasma_uz(gamma, psi);
+
+                    amrex::Real gamma_dep = plasma_gamma(ux_dep, uy_dep, psi_dep, 1/psi_dep, 0);
+                    amrex::Real uz_dep = plasma_uz(gamma_dep, psi_dep);
+
+                    
+                    enforceBC(ptd, ip, xp, yp, ux, uy, uz, ux_dep, uy_dep, uz_dep, u_std, engine);
+
+                    ptd.pos(0, ip) = xp;
+                    ptd.pos(1, ip) = yp;
+
+                    // set values which will be used for the next push
+                    if (!temp_slice) {
+                        ptd.rdata(PlasmaIdx::ux_half_step)[ip] = ux;
+                        ptd.rdata(PlasmaIdx::uy_half_step)[ip] = uy;
+                        ptd.rdata(PlasmaIdx::psi_half_step)[ip] = plasma_psi(ux, uy, uz, 0._rt);
+                        ptd.rdata(PlasmaIdx::x_prev)[ip] = xp;
+                        ptd.rdata(PlasmaIdx::y_prev)[ip] = yp;
+                    }
+
+                    // don't include thermalised plasma particles in this iteration's current deposition
+                    ptd.rdata(PlasmaIdx::ux)[ip] = ux_dep;
+                    ptd.rdata(PlasmaIdx::uy)[ip] = uy_dep;
+                    ptd.rdata(PlasmaIdx::psi)[ip] = plasma_psi(ux_dep, uy_dep, uz_dep, 0._rt);
+
+            });
+        }
     }
 
 #ifdef HIPACE_USE_AB5_PUSH

--- a/src/particles/pusher/PlasmaParticleAdvance.cpp
+++ b/src/particles/pusher/PlasmaParticleAdvance.cpp
@@ -273,7 +273,7 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                 } // loop over subcycles
             });
 
-        // Rethermalise particles at the boundary here.
+        // to rethermalise particles at the boundary here.
         if (Hipace::m_boundary_particles == ParticleBoundary::Thermal) {
 
             const PhysConst phys_const_SI = make_constants_SI();
@@ -282,47 +282,39 @@ AdvancePlasmaParticles (PlasmaParticleContainer& plasma, const Fields & fields,
                                 (plasma.m_mass * (phys_const_SI.m_e / phys_const.m_e) *
                                 (phys_const_SI.c * phys_const_SI.c) ) );
 
-
             amrex::ParallelForRNG(int(pti.numParticles()),
                 [=] AMREX_GPU_DEVICE (int ip, const amrex::RandomEngine& engine) {
 
-                    // Use positions at t+1 to reflect and velocities at t
+                    // return if particle not at boundary
+                    if (ptd.id(ip) != PlasmaID::to_be_thermalised) return;
+
+                    // use positions at t+1 and velocities at t+1/2
                     amrex::Real xp = ptd.pos(0, ip);
                     amrex::Real yp = ptd.pos(1, ip);
-                    amrex::Real ux = ptd.rdata(PlasmaIdx::ux_half_step)[ip];
-                    amrex::Real uy = ptd.rdata(PlasmaIdx::uy_half_step)[ip];
-                    amrex::Real psi = ptd.rdata(PlasmaIdx::psi_half_step)[ip];
+                    amrex::Real ux = 0._rt;
+                    amrex::Real uy = 0._rt;
+                    amrex::Real uz = 0._rt;
 
-                    amrex::Real ux_dep = ptd.rdata(PlasmaIdx::ux)[ip];
-                    amrex::Real uy_dep = ptd.rdata(PlasmaIdx::uy)[ip];
-                    amrex::Real psi_dep = ptd.rdata(PlasmaIdx::psi)[ip];
-
-                    amrex::Real gamma = plasma_gamma(ux, uy, psi, 1/psi, 0);
-                    amrex::Real uz = plasma_uz(gamma, psi);
-
-                    amrex::Real gamma_dep = plasma_gamma(ux_dep, uy_dep, psi_dep, 1/psi_dep, 0);
-                    amrex::Real uz_dep = plasma_uz(gamma_dep, psi_dep);
-
-                    
-                    enforceBC(ptd, ip, xp, yp, ux, uy, uz, ux_dep, uy_dep, uz_dep, u_std, engine);
+                    // reflect positions and get thermal velocities with overloaded boundary enforcing functor
+                    enforceBC(ptd, ip, xp, yp, ux, uy, uz, u_std, engine);
 
                     ptd.pos(0, ip) = xp;
                     ptd.pos(1, ip) = yp;
+                    amrex::Real psi = plasma_psi(ux, uy, uz, 0._rt);
 
                     // set values which will be used for the next push
                     if (!temp_slice) {
                         ptd.rdata(PlasmaIdx::ux_half_step)[ip] = ux;
                         ptd.rdata(PlasmaIdx::uy_half_step)[ip] = uy;
-                        ptd.rdata(PlasmaIdx::psi_half_step)[ip] = plasma_psi(ux, uy, uz, 0._rt);
+                        ptd.rdata(PlasmaIdx::psi_half_step)[ip] = psi;
                         ptd.rdata(PlasmaIdx::x_prev)[ip] = xp;
                         ptd.rdata(PlasmaIdx::y_prev)[ip] = yp;
                     }
 
-                    // don't include thermalised plasma particles in this iteration's current deposition
-                    ptd.rdata(PlasmaIdx::ux)[ip] = ux_dep;
-                    ptd.rdata(PlasmaIdx::uy)[ip] = uy_dep;
-                    ptd.rdata(PlasmaIdx::psi)[ip] = plasma_psi(ux_dep, uy_dep, uz_dep, 0._rt);
-
+                    // do/don't include thermalised plasma particles in this iteration's current deposition (maybe change)
+                    ptd.rdata(PlasmaIdx::ux)[ip] = ux;
+                    ptd.rdata(PlasmaIdx::uy)[ip] = uy;
+                    ptd.rdata(PlasmaIdx::psi)[ip] = psi;
             });
         }
     }


### PR DESCRIPTION
Added an option for Thermal particle boundaries, as well as some features for convenience, with usages described below.

- Thermal boundaries: Specify boundary.particle = Thermal, and boundary.temperature = x (where x is your temperature in eV)
- Added an interval for elastic collisions (both beam and plasma collisions): Specify <collision_name>.collide_every = x (where x is number of xi slices)
- Added an option to track progress in a single timestep simulation: Specify hipace.print_slice_interval = x (where x is number of xi slices)

Implementation: Simply added a flag (PlasmaID::to_be_thermalised) for particles which need to be thermalised. A separate amrex::ParallelForRNG loop goes over all particles, and if the flag is activated, reflects the particle velocity and provides a velocity from a Normal distribution with variance kT/Mc2.

Potential issue: In one test, after many iterations > 100k, the simulation got 'stuck' somewhere and had to be aborted.