### PR TITLE
Add phase diagnostics to laser in_situ diagnostics

### DIFF
--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1348,9 +1348,9 @@ For the field in-situ diagnostics, the following quantities are calculated per s
 These quantities can be used to calculate the energy stored in the fields.
 
 For the laser in-situ diagnostics, the following quantities are calculated per slice and stored:
-``max(|a|^2), [|a|^2], [|a|^2*x], [|a|^2*x*x], [|a|^2*y], [|a|^2*y*y], axis(a), [chi*d_z|a|^2],[|a|^2*d_x(phi)],[|a|^2*d_y(phi)],[|a|^2*d_zeta(phi)],[|D_t(a)|^2],laser_energy``.
+``max(|a|^2), [|a|^2], [|a|^2*x], [|a|^2*x*x], [|a|^2*y], [|a|^2*y*y], axis(a), [chi*d_z|a|^2], [|a|^2*d_x(phi)], [|a|^2*d_y(phi)], [|a|^2*d_zeta(phi)],[|D_t(a)|^2]``.
 Thereby, ``max(|a|^2)`` is the highest value of ``|a|^2`` in the current slice
-and ``axis(a)`` gives the complex value of the laser envelope, in the center of every slice.
+and ``axis(a)`` gives the complex value of the laser envelope, in the center of every slice.  ``laser_energy`` is stored per time step.
 
 Additionally, some metadata is also available:
 ``time, step, n_slices, charge, mass, z_lo, z_hi, normalized_density_factor``.

--- a/docs/source/run/parameters.rst
+++ b/docs/source/run/parameters.rst
@@ -1348,7 +1348,7 @@ For the field in-situ diagnostics, the following quantities are calculated per s
 These quantities can be used to calculate the energy stored in the fields.
 
 For the laser in-situ diagnostics, the following quantities are calculated per slice and stored:
-``max(|a|^2), [|a|^2], [|a|^2*x], [|a|^2*x*x], [|a|^2*y], [|a|^2*y*y], axis(a), [chi*d_z|a|^2]``.
+``max(|a|^2), [|a|^2], [|a|^2*x], [|a|^2*x*x], [|a|^2*y], [|a|^2*y*y], axis(a), [chi*d_z|a|^2],[|a|^2*d_x(phi)],[|a|^2*d_y(phi)],[|a|^2*d_zeta(phi)],[|D_t(a)|^2],laser_energy``.
 Thereby, ``max(|a|^2)`` is the highest value of ``|a|^2`` in the current slice
 and ``axis(a)`` gives the complex value of the laser envelope, in the center of every slice.
 

--- a/src/Hipace.cpp
+++ b/src/Hipace.cpp
@@ -819,7 +819,7 @@ Hipace::SolveOneSlice (int islice, int step, bool is_first_step, bool is_last_st
     m_fields.InSituComputeDiags(step, islice, m_3D_geom[0], m_physical_time, is_last_step);
 
     // get laser insitu diagnostics
-    m_multi_laser.InSituComputeDiags(step, islice, m_physical_time, is_last_step);
+    m_multi_laser.InSituComputeDiags(step, islice, m_physical_time, is_last_step, m_dt);
 
     // copy fields, laser, plasma and beam to diagnostic array
     m_diags.FillDiagnostics(

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -149,7 +149,7 @@ public:
      * \param[in] time physical time of the current step
      * \param[in] is_last_step if this is the last time step of the simulation
      */
-    void InSituComputeDiags (int step, int islice, amrex::Real time, bool is_last_step);
+    void InSituComputeDiags (int step, int islice, amrex::Real time, bool is_last_step, const amrex::Real dt);
 
     /** Dump in-situ reduced diagnostics to file.
      * \param[in] step current time step

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -148,6 +148,7 @@ public:
      * \param[in] islice current slice, on which diags are computed.
      * \param[in] time physical time of the current step
      * \param[in] is_last_step if this is the last time step of the simulation
+     * \param[in] dt time step of the simulation
      */
     void InSituComputeDiags (int step, int islice, amrex::Real time, bool is_last_step, const amrex::Real dt);
 
@@ -155,7 +156,6 @@ public:
      * \param[in] step current time step
      * \param[in] time physical time
      * \param[in] is_last_step if this is the last time step of the simulation
-     * \param[in] dt time step of the simulation
      */
     void InSituWriteToFile (int step, amrex::Real time, bool is_last_step);
 

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -155,6 +155,7 @@ public:
      * \param[in] step current time step
      * \param[in] time physical time
      * \param[in] is_last_step if this is the last time step of the simulation
+     * \param[in] dt time step of the simulation
      */
     void InSituWriteToFile (int step, amrex::Real time, bool is_last_step);
 

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -239,7 +239,7 @@ private:
 
     // Data for in-situ diagnostics:
     /** Number of real laser properties for in-situ per-slice reduced diagnostics. */
-    static constexpr int m_insitu_nrp = 7;
+    static constexpr int m_insitu_nrp = 10;
     /** Number of real complex properties for in-situ per-slice reduced diagnostics. */
     static constexpr int m_insitu_ncp = 1;
     /** How often the insitu laser diagnostics should be computed and written

--- a/src/laser/MultiLaser.H
+++ b/src/laser/MultiLaser.H
@@ -239,7 +239,7 @@ private:
 
     // Data for in-situ diagnostics:
     /** Number of real laser properties for in-situ per-slice reduced diagnostics. */
-    static constexpr int m_insitu_nrp = 10;
+    static constexpr int m_insitu_nrp = 11;
     /** Number of real complex properties for in-situ per-slice reduced diagnostics. */
     static constexpr int m_insitu_ncp = 1;
     /** How often the insitu laser diagnostics should be computed and written

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1096,10 +1096,6 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
     const int iy_lo = m_laser_geom_3D.Domain().smallEnd(1);
     const int iy_hi = m_laser_geom_3D.Domain().bigEnd(1);
 
-    const bool has_zeta_neighbors =
-        islice > m_laser_geom_3D.Domain().smallEnd(2) &&
-        islice < m_laser_geom_3D.Domain().bigEnd(2);
-    
     const int xmid_lo = m_laser_geom_3D.Domain().smallEnd(0) + (m_laser_geom_3D.Domain().length(0) - 1) / 2;
     const int xmid_hi = m_laser_geom_3D.Domain().smallEnd(0) + (m_laser_geom_3D.Domain().length(0)) / 2;
     const int ymid_lo = m_laser_geom_3D.Domain().smallEnd(1) + (m_laser_geom_3D.Domain().length(1) - 1) / 2;
@@ -1107,6 +1103,9 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
     const amrex::Real mid_factor = (xmid_lo == xmid_hi ? 1._rt : 0.5_rt)
                                  * (ymid_lo == ymid_hi ? 1._rt : 0.5_rt);
 
+                                 const PhysConst phc = get_phys_const();
+    const amrex::Real clight = phc.c;
+    const amrex::Real omega0 = 2. * MathConst::pi * clight / m_lambda0;
     amrex::TypeMultiplier<amrex::ReduceOps, amrex::ReduceOpMax, amrex::ReduceOpSum[m_insitu_nrp-1+m_insitu_ncp]> reduce_op;
     amrex::TypeMultiplier<amrex::ReduceData, amrex::Real[m_insitu_nrp], Complex[m_insitu_ncp]> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -1122,8 +1121,8 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                 const amrex::Real aimag = arr(i,j, n00j00_i);
                 const amrex::Real aabssq = abssq(areal, aimag);
                 // Im(conj(a) * d_q(a)) = |a|^2 * d_q(phi)
-
                 amrex::Real a2dphidx = 0._rt;
+
                 if (i > ix_lo && i < ix_hi) {
                     const amrex::Real darealdx =
                         (arr(i+1,j,n00j00_r) - arr(i-1,j,n00j00_r)) * dx2i;
@@ -1143,17 +1142,20 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     a2dphidy = areal * daimagdy - aimag * darealdy;
                 }
 
+                amrex::Real darealdzeta = 0._rt;
+                amrex::Real daimagdzeta = 0._rt;
                 amrex::Real a2dphidzeta = 0._rt;
-                if (has_zeta_neighbors) {
+                if (islice > m_laser_geom_3D.Domain().smallEnd(2) && 
+                    islice < m_laser_geom_3D.Domain().bigEnd(2)){
                     // Here n00jp1 is j+1 and n00jp2 contains j-1.
-                    const amrex::Real darealdzeta =
-                        (arr(i,j,n00jp1_r) - arr(i,j,n00jp2_r)) * dz2i;
-                    const amrex::Real daimagdzeta =
-                        (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
-
-                    a2dphidzeta =
-                        areal * daimagdzeta - aimag * darealdzeta;
-}
+                    darealdzeta = (arr(i,j,n00jp1_r) - arr(i,j,n00jp2_r))
+                                * dz2i;
+                    daimagdzeta = (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
+                    a2dphidzeta = areal * daimagdzeta - aimag * darealdzeta;
+                }   
+                const amrex::Real dt_a_real =  -clight * darealdzeta -omega0 * aimag;
+                const amrex::Real dt_a_imag =  -clight * daimagdzeta + omega0 * areal;
+                const amrex::Real dt_a_abssq =  abssq(dt_a_real, dt_a_imag);
                 // At this point, n00jp2 actually contains the data of n00jm1
                 const amrex::Real chidzabssq = arr(i,j, chi) * (
                      - abssq(arr(i,j, n00jp2_r), arr(i,j, n00jp2_i))
@@ -1161,7 +1163,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     ) * dz2i;
                 const amrex::Real x = i * dx + poff_x;
                 const amrex::Real y = j * dy + poff_y;
-                
+
                 const bool is_on_axis = (i==xmid_lo || i==xmid_hi) && (j==ymid_lo || j==ymid_hi);
                 const Complex aaxis{is_on_axis ? areal : 0._rt, is_on_axis ? aimag : 0._rt};
 
@@ -1176,6 +1178,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     a2dphidx,       // 7  [|a|^2*d_x(phi)]
                     a2dphidy,       // 8  [|a|^2*d_y(phi)]
                     a2dphidzeta,    // 9  [|a|^2*d_zeta(phi)]
+                    dt_a_abssq,     // 11 |(-c*d_zeta+i*omega0)a|^2
                     aaxis           // 10    axis(a)
                 };
             });
@@ -1242,19 +1245,18 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
 
     // Physical pulse energy for an SI-units simulation.
     const PhysConst phc = get_phys_const();
-    const amrex::Real omega0 =
-        2. * MathConst::pi * phc.c / m_lambda0;
 
-    const amrex::Real polarization_factor =
-        m_linear_polarization ? 1. : 2.;
+    const amrex::Real polarization_factor = m_linear_polarization ? 1. : 2.;
 
-    const amrex::Real efield_per_a =
-        phc.m_e * phc.c * omega0 / phc.q_e;
+    const amrex::Real vector_potential_per_a = phc.m_e * phc.c / phc.q_e;
 
     const amrex::Real laser_energy =
-        0.5 * polarization_factor * phc.ep0
-        * efield_per_a * efield_per_a
-        * a2_integral;
+        0.5
+        * polarization_factor
+        * phc.ep0
+        * vector_potential_per_a
+        * vector_potential_per_a
+        * m_insitu_sum_rdata[10];       
     // specify the structure of the data later available in python
     // avoid pointers to temporary objects as second argument, stack variables are ok
     const amrex::Vector<insitu_utils::DataNode> all_data{
@@ -1278,7 +1280,8 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
             &m_insitu_rdata[8*nslices], nslices},
         {"[|a|^2*d_zeta(phi)]",
             &m_insitu_rdata[9*nslices], nslices},
-
+        {"[|D_t(a)|^2]",
+            &m_insitu_rdata[10*nslices], nslices},
         {"average", {
             {"d_x(phi)",    &avg_dphidx},
             {"d_y(phi)",    &avg_dphidy},
@@ -1294,6 +1297,7 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
             {"[|a|^2*d_x(phi)]", &m_insitu_sum_rdata[7]},
             {"[|a|^2*d_y(phi)]", &m_insitu_sum_rdata[8]},
             {"[|a|^2*d_zeta(phi)]", &m_insitu_sum_rdata[9]},
+            {"[|D_t(a)|^2]", &m_insitu_sum_rdata[10]},
             {"laser_energy", &laser_energy},
             {"[chi*d_z|a|^2]" , &m_insitu_sum_rdata[6]}
         }}

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1242,6 +1242,33 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
     const amrex::Real avg_dphidzeta =
         m_insitu_sum_rdata[9] * inv_a2_integral;
 
+    const amrex::Real avg_x =
+    m_insitu_sum_rdata[2] * inv_a2_integral;
+
+    const amrex::Real avg_x2 =
+        m_insitu_sum_rdata[3] * inv_a2_integral;
+
+    const amrex::Real avg_y =
+        m_insitu_sum_rdata[4] * inv_a2_integral;
+
+    const amrex::Real avg_y2 =
+        m_insitu_sum_rdata[5] * inv_a2_integral;
+
+    const amrex::Real sigma_x =
+        std::sqrt(std::max(
+            0.,
+            avg_x2 - avg_x * avg_x
+        ));
+
+    const amrex::Real sigma_y =
+        std::sqrt(std::max(
+            0.,
+            avg_y2 - avg_y * avg_y
+        ));
+    
+    const amrex::Real waist_x = 2. * sigma_x;
+    const amrex::Real waist_y = 2. * sigma_y;
+
     // Physical pulse energy for an SI-units simulation.
     const PhysConst phc = get_phys_const();
 
@@ -1282,9 +1309,13 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
         {"[|D_t(a)|^2]",
             &m_insitu_rdata[10*nslices], nslices},
         {"average", {
-            {"d_x(phi)",    &avg_dphidx},
-            {"d_y(phi)",    &avg_dphidy},
-            {"d_zeta(phi)", &avg_dphidzeta}
+            {"x_mean",       &avg_x},
+            {"y_mean",       &avg_y},
+            {"waist_x",      &waist_x},
+            {"waist_y",      &waist_y},
+            {"d_x(phi)",     &avg_dphidx},
+            {"d_y(phi)",     &avg_dphidy},
+            {"d_zeta(phi)",  &avg_dphidzeta}
         }},
         {"integrated", {
             {"max(|a|^2)"     , &m_insitu_sum_rdata[0]},

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1268,7 +1268,7 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
         * vector_potential_per_a
         * vector_potential_per_a
         * m_insitu_sum_rdata[10];
-        
+
     const amrex::Vector<insitu_utils::DataNode> all_data{
         {"time"     , &time},
         {"step"     , &step},

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1067,7 +1067,7 @@ MultiLaser::InitLaserSlice (const int islice, const int comp)
 }
 
 void
-MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_last_step)
+MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_last_step, const amrex::Real dt)
 {
     if (!UseLaser(islice)) return;
     if (!m_insitu_period.doDiagnostics(step, time, is_last_step)) return;
@@ -1152,8 +1152,25 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     daimagdzeta = (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
                     a2dphidzeta = areal * daimagdzeta - aimag * darealdzeta;
                 }
-                const amrex::Real dt_a_real =  -clight * darealdzeta +omega0 * aimag;
-                const amrex::Real dt_a_imag =  -clight * daimagdzeta - omega0 * areal;
+                const amrex::Real dt2i = 1._rt / (2._rt * dt);
+
+                amrex::Real dtaudreal;
+                amrex::Real dtaudimag;
+
+                if (time == 0) {
+                    dtaudreal = 0;
+                    dtaudimag = 0;
+                } 
+                else{
+                    dtaudreal =
+                        (arr(i,j,n00j00_r) - arr(i,j,nm1j00_r)) * dt2i * 2;
+
+                    dtaudimag =
+                        (arr(i,j,n00j00_i) - arr(i,j,nm1j00_i)) * dt2i * 2;
+                }
+                
+                const amrex::Real dt_a_real =  -clight * darealdzeta +omega0 * aimag + dtaudreal;
+                const amrex::Real dt_a_imag =  -clight * daimagdzeta -omega0 * areal + dtaudimag;
                 const amrex::Real dt_a_abssq =  abssq(dt_a_real, dt_a_imag);
                 // At this point, n00jp2 actually contains the data of n00jm1
                 const amrex::Real chidzabssq = arr(i,j, chi) * (

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1086,9 +1086,20 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
     const amrex::Real dx = m_laser_geom_3D.CellSize(0);
     const amrex::Real dy = m_laser_geom_3D.CellSize(1);
     const amrex::Real dz = m_laser_geom_3D.CellSize(2);
+    const amrex::Real dx2i = 1. / (2. * dx);
+    const amrex::Real dy2i = 1. / (2. * dy);
     const amrex::Real dz2i = 1./(2. * dz);
     const amrex::Real dxdydz = dx * dy * dz;
 
+    const int ix_lo = m_laser_geom_3D.Domain().smallEnd(0);
+    const int ix_hi = m_laser_geom_3D.Domain().bigEnd(0);
+    const int iy_lo = m_laser_geom_3D.Domain().smallEnd(1);
+    const int iy_hi = m_laser_geom_3D.Domain().bigEnd(1);
+
+    const bool has_zeta_neighbors =
+        islice > m_laser_geom_3D.Domain().smallEnd(2) &&
+        islice < m_laser_geom_3D.Domain().bigEnd(2);
+    
     const int xmid_lo = m_laser_geom_3D.Domain().smallEnd(0) + (m_laser_geom_3D.Domain().length(0) - 1) / 2;
     const int xmid_hi = m_laser_geom_3D.Domain().smallEnd(0) + (m_laser_geom_3D.Domain().length(0)) / 2;
     const int ymid_lo = m_laser_geom_3D.Domain().smallEnd(1) + (m_laser_geom_3D.Domain().length(1) - 1) / 2;
@@ -1110,6 +1121,39 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                 const amrex::Real areal = arr(i,j, n00j00_r);
                 const amrex::Real aimag = arr(i,j, n00j00_i);
                 const amrex::Real aabssq = abssq(areal, aimag);
+                // Im(conj(a) * d_q(a)) = |a|^2 * d_q(phi)
+
+                amrex::Real a2dphidx = 0._rt;
+                if (i > ix_lo && i < ix_hi) {
+                    const amrex::Real darealdx =
+                        (arr(i+1,j,n00j00_r) - arr(i-1,j,n00j00_r)) * dx2i;
+                    const amrex::Real daimagdx =
+                        (arr(i+1,j,n00j00_i) - arr(i-1,j,n00j00_i)) * dx2i;
+
+                    a2dphidx = areal * daimagdx - aimag * darealdx;
+                }
+
+                amrex::Real a2dphidy = 0._rt;
+                if (j > iy_lo && j < iy_hi) {
+                    const amrex::Real darealdy =
+                        (arr(i,j+1,n00j00_r) - arr(i,j-1,n00j00_r)) * dy2i;
+                    const amrex::Real daimagdy =
+                        (arr(i,j+1,n00j00_i) - arr(i,j-1,n00j00_i)) * dy2i;
+
+                    a2dphidy = areal * daimagdy - aimag * darealdy;
+                }
+
+                amrex::Real a2dphidzeta = 0._rt;
+                if (has_zeta_neighbors) {
+                    // Here n00jp1 is j+1 and n00jp2 contains j-1.
+                    const amrex::Real darealdzeta =
+                        (arr(i,j,n00jp1_r) - arr(i,j,n00jp2_r)) * dz2i;
+                    const amrex::Real daimagdzeta =
+                        (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
+
+                    a2dphidzeta =
+                        areal * daimagdzeta - aimag * darealdzeta;
+}
                 // At this point, n00jp2 actually contains the data of n00jm1
                 const amrex::Real chidzabssq = arr(i,j, chi) * (
                      - abssq(arr(i,j, n00jp2_r), arr(i,j, n00jp2_i))
@@ -1117,7 +1161,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     ) * dz2i;
                 const amrex::Real x = i * dx + poff_x;
                 const amrex::Real y = j * dy + poff_y;
-
+                
                 const bool is_on_axis = (i==xmid_lo || i==xmid_hi) && (j==ymid_lo || j==ymid_hi);
                 const Complex aaxis{is_on_axis ? areal : 0._rt, is_on_axis ? aimag : 0._rt};
 
@@ -1129,7 +1173,10 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     aabssq*y,       // 4    [|a|^2*y]
                     aabssq*y*y,     // 5    [|a|^2*y*y]
                     chidzabssq,     // 6    [chi*d_z|a|^2]
-                    aaxis           // 7    axis(a)
+                    a2dphidx,       // 7  [|a|^2*d_x(phi)]
+                    a2dphidy,       // 8  [|a|^2*d_y(phi)]
+                    a2dphidzeta,    // 9  [|a|^2*d_zeta(phi)]
+                    aaxis           // 10    axis(a)
                 };
             });
     }
@@ -1179,7 +1226,35 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
     const int nslices_int = m_laser_geom_3D.Domain().length(2);
     const std::size_t nslices = static_cast<std::size_t>(nslices_int);
     const int is_normalized_units = Hipace::m_normalized_units;
+    
+    const amrex::Real a2_integral = m_insitu_sum_rdata[1];
+    const amrex::Real inv_a2_integral =
+        a2_integral > 0. ? 1. / a2_integral : 0.;
 
+    const amrex::Real avg_dphidx =
+        m_insitu_sum_rdata[7] * inv_a2_integral;
+
+    const amrex::Real avg_dphidy =
+        m_insitu_sum_rdata[8] * inv_a2_integral;
+
+    const amrex::Real avg_dphidzeta =
+        m_insitu_sum_rdata[9] * inv_a2_integral;
+
+    // Physical pulse energy for an SI-units simulation.
+    const PhysConst phc = get_phys_const();
+    const amrex::Real omega0 =
+        2. * MathConst::pi * phc.c / m_lambda0;
+
+    const amrex::Real polarization_factor =
+        m_linear_polarization ? 1. : 2.;
+
+    const amrex::Real efield_per_a =
+        phc.m_e * phc.c * omega0 / phc.q_e;
+
+    const amrex::Real laser_energy =
+        0.5 * polarization_factor * phc.ep0
+        * efield_per_a * efield_per_a
+        * a2_integral;
     // specify the structure of the data later available in python
     // avoid pointers to temporary objects as second argument, stack variables are ok
     const amrex::Vector<insitu_utils::DataNode> all_data{
@@ -1197,6 +1272,18 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
         {"[|a|^2*y*y]"    , &m_insitu_rdata[5*nslices], nslices},
         {"[chi*d_z|a|^2]" , &m_insitu_rdata[6*nslices], nslices},
         {"axis(a)"        , &m_insitu_cdata[0], nslices},
+        {"[|a|^2*d_x(phi)]",
+            &m_insitu_rdata[7*nslices], nslices},
+        {"[|a|^2*d_y(phi)]",
+            &m_insitu_rdata[8*nslices], nslices},
+        {"[|a|^2*d_zeta(phi)]",
+            &m_insitu_rdata[9*nslices], nslices},
+
+        {"average", {
+            {"d_x(phi)",    &avg_dphidx},
+            {"d_y(phi)",    &avg_dphidy},
+            {"d_zeta(phi)", &avg_dphidzeta}
+        }},
         {"integrated", {
             {"max(|a|^2)"     , &m_insitu_sum_rdata[0]},
             {"[|a|^2]"        , &m_insitu_sum_rdata[1]},
@@ -1204,6 +1291,10 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
             {"[|a|^2*x*x]"    , &m_insitu_sum_rdata[3]},
             {"[|a|^2*y]"      , &m_insitu_sum_rdata[4]},
             {"[|a|^2*y*y]"    , &m_insitu_sum_rdata[5]},
+            {"[|a|^2*d_x(phi)]", &m_insitu_sum_rdata[7]},
+            {"[|a|^2*d_y(phi)]", &m_insitu_sum_rdata[8]},
+            {"[|a|^2*d_zeta(phi)]", &m_insitu_sum_rdata[9]},
+            {"laser_energy", &laser_energy},
             {"[chi*d_z|a|^2]" , &m_insitu_sum_rdata[6]}
         }}
     };

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1265,7 +1265,7 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
             0.,
             avg_y2 - avg_y * avg_y
         ));
-    
+
     const amrex::Real waist_x = 2. * sigma_x;
     const amrex::Real waist_y = 2. * sigma_y;
 

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1103,7 +1103,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
     const amrex::Real mid_factor = (xmid_lo == xmid_hi ? 1._rt : 0.5_rt)
                                  * (ymid_lo == ymid_hi ? 1._rt : 0.5_rt);
 
-                                 const PhysConst phc = get_phys_const();
+    const PhysConst phc = get_phys_const();
     const amrex::Real clight = phc.c;
     const amrex::Real omega0 = 2. * MathConst::pi * clight / m_lambda0;
     amrex::TypeMultiplier<amrex::ReduceOps, amrex::ReduceOpMax, amrex::ReduceOpSum[m_insitu_nrp-1+m_insitu_ncp]> reduce_op;
@@ -1256,7 +1256,7 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
         * phc.ep0
         * vector_potential_per_a
         * vector_potential_per_a
-        * m_insitu_sum_rdata[10];       
+        * m_insitu_sum_rdata[10];
     // specify the structure of the data later available in python
     // avoid pointers to temporary objects as second argument, stack variables are ok
     const amrex::Vector<insitu_utils::DataNode> all_data{

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1145,14 +1145,14 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                 amrex::Real darealdzeta = 0._rt;
                 amrex::Real daimagdzeta = 0._rt;
                 amrex::Real a2dphidzeta = 0._rt;
-                if (islice > m_laser_geom_3D.Domain().smallEnd(2) && 
+                if (islice > m_laser_geom_3D.Domain().smallEnd(2) &&
                     islice < m_laser_geom_3D.Domain().bigEnd(2)){
                     // Here n00jp1 is j+1 and n00jp2 contains j-1.
                     darealdzeta = (arr(i,j,n00jp1_r) - arr(i,j,n00jp2_r))
                                 * dz2i;
                     daimagdzeta = (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
                     a2dphidzeta = areal * daimagdzeta - aimag * darealdzeta;
-                }   
+                }
                 const amrex::Real dt_a_real =  -clight * darealdzeta -omega0 * aimag;
                 const amrex::Real dt_a_imag =  -clight * daimagdzeta + omega0 * areal;
                 const amrex::Real dt_a_abssq =  abssq(dt_a_real, dt_a_imag);
@@ -1229,7 +1229,7 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
     const int nslices_int = m_laser_geom_3D.Domain().length(2);
     const std::size_t nslices = static_cast<std::size_t>(nslices_int);
     const int is_normalized_units = Hipace::m_normalized_units;
-    
+
     const amrex::Real a2_integral = m_insitu_sum_rdata[1];
     const amrex::Real inv_a2_integral =
         a2_integral > 0. ? 1. / a2_integral : 0.;

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1147,7 +1147,6 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                 amrex::Real a2dphidzeta = 0._rt;
                 if (islice > m_laser_geom_3D.Domain().smallEnd(2) &&
                     islice < m_laser_geom_3D.Domain().bigEnd(2)){
-                    // Here n00jp1 is j+1 and n00jp2 contains j-1.
                     darealdzeta = (arr(i,j,n00jp1_r) - arr(i,j,n00jp2_r))
                                 * dz2i;
                     daimagdzeta = (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
@@ -1178,8 +1177,8 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     a2dphidx,       // 7  [|a|^2*d_x(phi)]
                     a2dphidy,       // 8  [|a|^2*d_y(phi)]
                     a2dphidzeta,    // 9  [|a|^2*d_zeta(phi)]
-                    dt_a_abssq,     // 11 |(-c*d_zeta+i*omega0)a|^2
-                    aaxis           // 10    axis(a)
+                    dt_a_abssq,     // 10 |(-c*d_zeta+i*omega0)a|^2
+                    aaxis           // 11    axis(a)
                 };
             });
     }

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1160,7 +1160,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                 if (time == 0) {
                     dtaudreal = 0;
                     dtaudimag = 0;
-                } 
+                }
                 else{
                     dtaudreal =
                         (arr(i,j,n00j00_r) - arr(i,j,nm1j00_r)) * dt2i * 2;

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1152,8 +1152,8 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     daimagdzeta = (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
                     a2dphidzeta = areal * daimagdzeta - aimag * darealdzeta;
                 }
-                const amrex::Real dt_a_real =  -clight * darealdzeta -omega0 * aimag;
-                const amrex::Real dt_a_imag =  -clight * daimagdzeta + omega0 * areal;
+                const amrex::Real dt_a_real =  -clight * darealdzeta +omega0 * aimag;
+                const amrex::Real dt_a_imag =  -clight * daimagdzeta - omega0 * areal;
                 const amrex::Real dt_a_abssq =  abssq(dt_a_real, dt_a_imag);
                 // At this point, n00jp2 actually contains the data of n00jm1
                 const amrex::Real chidzabssq = arr(i,j, chi) * (
@@ -1245,14 +1245,8 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
     const amrex::Real avg_x =
     m_insitu_sum_rdata[2] * inv_a2_integral;
 
-    const amrex::Real avg_x2 =
-        m_insitu_sum_rdata[3] * inv_a2_integral;
-
     const amrex::Real avg_y =
         m_insitu_sum_rdata[4] * inv_a2_integral;
-
-    const amrex::Real avg_y2 =
-        m_insitu_sum_rdata[5] * inv_a2_integral;
 
     // Physical pulse energy for an SI-units simulation.
     const PhysConst phc = get_phys_const();

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1168,7 +1168,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                     dtaudimag =
                         (arr(i,j,n00j00_i) - arr(i,j,nm1j00_i)) * dt2i * 2;
                 }
-                
+
                 const amrex::Real dt_a_real =  -clight * darealdzeta +omega0 * aimag + dtaudreal;
                 const amrex::Real dt_a_imag =  -clight * daimagdzeta -omega0 * areal + dtaudimag;
                 const amrex::Real dt_a_abssq =  abssq(dt_a_real, dt_a_imag);

--- a/src/laser/MultiLaser.cpp
+++ b/src/laser/MultiLaser.cpp
@@ -1109,6 +1109,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
     amrex::TypeMultiplier<amrex::ReduceOps, amrex::ReduceOpMax, amrex::ReduceOpSum[m_insitu_nrp-1+m_insitu_ncp]> reduce_op;
     amrex::TypeMultiplier<amrex::ReduceData, amrex::Real[m_insitu_nrp], Complex[m_insitu_ncp]> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
+    const bool has_zeta_neighbors = islice > m_laser_geom_3D.Domain().smallEnd(2) && islice < m_laser_geom_3D.Domain().bigEnd(2);
 
     for ( amrex::MFIter mfi(m_slices, DfltMfi); mfi.isValid(); ++mfi ) {
         Array3<amrex::Real const> const arr = m_slices.const_array(mfi);
@@ -1145,8 +1146,7 @@ MultiLaser::InSituComputeDiags (int step, int islice, amrex::Real time, bool is_
                 amrex::Real darealdzeta = 0._rt;
                 amrex::Real daimagdzeta = 0._rt;
                 amrex::Real a2dphidzeta = 0._rt;
-                if (islice > m_laser_geom_3D.Domain().smallEnd(2) &&
-                    islice < m_laser_geom_3D.Domain().bigEnd(2)){
+                if (has_zeta_neighbors){
                     darealdzeta = (arr(i,j,n00jp1_r) - arr(i,j,n00jp2_r))
                                 * dz2i;
                     daimagdzeta = (arr(i,j,n00jp1_i) - arr(i,j,n00jp2_i)) * dz2i;
@@ -1254,21 +1254,6 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
     const amrex::Real avg_y2 =
         m_insitu_sum_rdata[5] * inv_a2_integral;
 
-    const amrex::Real sigma_x =
-        std::sqrt(std::max(
-            0.,
-            avg_x2 - avg_x * avg_x
-        ));
-
-    const amrex::Real sigma_y =
-        std::sqrt(std::max(
-            0.,
-            avg_y2 - avg_y * avg_y
-        ));
-
-    const amrex::Real waist_x = 2. * sigma_x;
-    const amrex::Real waist_y = 2. * sigma_y;
-
     // Physical pulse energy for an SI-units simulation.
     const PhysConst phc = get_phys_const();
 
@@ -1283,8 +1268,7 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
         * vector_potential_per_a
         * vector_potential_per_a
         * m_insitu_sum_rdata[10];
-    // specify the structure of the data later available in python
-    // avoid pointers to temporary objects as second argument, stack variables are ok
+        
     const amrex::Vector<insitu_utils::DataNode> all_data{
         {"time"     , &time},
         {"step"     , &step},
@@ -1311,8 +1295,6 @@ MultiLaser::InSituWriteToFile (int step, amrex::Real time, bool is_last_step)
         {"average", {
             {"x_mean",       &avg_x},
             {"y_mean",       &avg_y},
-            {"waist_x",      &waist_x},
-            {"waist_y",      &waist_y},
             {"d_x(phi)",     &avg_dphidx},
             {"d_y(phi)",     &avg_dphidy},
             {"d_zeta(phi)",  &avg_dphidzeta}


### PR DESCRIPTION
This PR extends the laser in-situ diagnostics to track phase evolution, transverse position, and pulse energy without requiring full field output.

The changes include:

* Per-slice and integrated phase-gradient diagnostics, computed using `Im(conj(a) * ∂q(a)) = |a|² ∂q(φ)` for `q = x, y, ζ`, avoiding explicit phase unwrapping.
* An `average` group containing the `|a|²`-weighted phase gradients and transverse centroids (`x_mean`, `y_mean`).
* Per-slice and integrated `|D_t(a)|²`, where `D_t(a) = ∂τa − c∂ζa − iω₀a`, including both envelope evolution and the carrier contribution.
* An integrated `laser_energy` diagnostic with the appropriate polarization factor, giving the pulse energy in joules for SI-unit simulations.
* Updated documentation listing the new quantities and clarifying that `laser_energy` is stored per diagnostic time step.
<img width="742" height="615" alt="截屏2026-09-08 17 42 19" src="https://github.com/user-attachments/assets/3151a6b1-f854-4b94-925c-6c10f2954329" />

