### PR TITLE
Replace AMREX_CUDA_ARCH with CUDAARCHS and update Maxwell modules

### DIFF
--- a/docs/source/building/platforms/booster_jsc.rst
+++ b/docs/source/building/platforms/booster_jsc.rst
@@ -23,7 +23,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    module load HDF5
    module load ccache # optional, accelerates recompilation
    # optimize CUDA compilation for A100
-   export AMREX_CUDA_ARCH=8.0 # 8.0 for A100, 7.0 for V100
+   export CUDAARCHS=80 # 80 for A100, 70 for V100
 
 Install HiPACE++ (the first time, and whenever you want the latest version):
 

--- a/docs/source/building/platforms/jupiter_jsc.rst
+++ b/docs/source/building/platforms/jupiter_jsc.rst
@@ -24,7 +24,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    module load HDF5
    module load ccache # optional, accelerates recompilation
    # optimize CUDA compilation for GH200
-   export AMREX_CUDA_ARCH=9.0
+   export CUDAARCHS=90
 
 Install HiPACE++ (the first time, and whenever you want the latest version):
 

--- a/docs/source/building/platforms/maxwell_desy.rst
+++ b/docs/source/building/platforms/maxwell_desy.rst
@@ -12,9 +12,9 @@ HiPACE++:
 
    #!/usr/bin/env zsh # Shell is assumed to be zsh
    module purge
-   module load maxwell gcc/12 cuda/12.8 openmpi/4 hdf5/1.10.6
+   module load maxwell gcc/12.2 cuda/13.0 openmpi/4.1.8-cuda13.0 hdf5/1.12.1
    # optimize CUDA compilation for A100
-   export AMREX_CUDA_ARCH=8.0 # use 7.0 for V100, 8.0 for A100 or 9.0 for H200
+   export CUDAARCHS=80 # use 70 for V100, 80 for A100 or 90 for H200
 
 Install HiPACE++ (the first time, and whenever you want the latest version):
 

--- a/docs/source/building/platforms/perlmutter_nersc.rst
+++ b/docs/source/building/platforms/perlmutter_nersc.rst
@@ -24,7 +24,7 @@ Create a file ``profile.hipace`` and ``source`` it whenever you log in and want 
    export CRAY_ACCEL_TARGET=nvidia80
 
    # optimize CUDA compilation for A100
-   export AMREX_CUDA_ARCH=8.0
+   export CUDAARCHS=80
 
    # compiler environment hints
    export CC=cc


### PR DESCRIPTION
Updates now that https://github.com/AMReX-Codes/amrex/pull/4773 was merged. Also use cuda13 with fitting MPI module on DESY Maxwell. 