### PR TITLE
Fix issue with environment on Maxwell Jupyter

### DIFF
--- a/docs/source/building/platforms/maxwell_desy.rst
+++ b/docs/source/building/platforms/maxwell_desy.rst
@@ -15,6 +15,8 @@ HiPACE++:
    module load maxwell gcc/12.2 cuda/13.0 openmpi/4.1.8-cuda13.0 hdf5/1.12.1
    # optimize CUDA compilation for A100
    export CUDAARCHS=80 # use 70 for V100, 80 for A100 or 90 for H200
+   # Fix issue with the Python 3.13 jhub environment
+   export PATH="/usr/bin:$PATH"
 
 Install HiPACE++ (the first time, and whenever you want the latest version):
 
@@ -24,7 +26,7 @@ Install HiPACE++ (the first time, and whenever you want the latest version):
    git clone https://github.com/Hi-PACE/hipace.git $HOME/src/hipace # only the first time
    cd $HOME/src/hipace
    rm -rf build
-   cmake -S . -B build -DHiPACE_COMPUTE=CUDA -DopenPMD_USE_MPI=OFF
+   cmake -S . -B build -DHiPACE_COMPUTE=CUDA
    cmake --build build -j 16
 
 You can get familiar with the HiPACE++ input file format in our :doc:`../../run/get_started`


### PR DESCRIPTION
With the Python 3.13 environment, `/usr/bin` is not in PATH which caused cmake to fail to find MPI even though the MPI module was loaded.

Additionally, now that we use a version of MPI that works with parallel HDF5, the `-DopenPMD_USE_MPI=OFF` flag should be removed.